### PR TITLE
Update error_span to make required fields required

### DIFF
--- a/Semgrep_output_v0.atd
+++ b/Semgrep_output_v0.atd
@@ -380,18 +380,25 @@ type cli_error = {
 
 (* TODO: get rid of rule_lang.Span *)
 type error_span = {
-    (* TODO: use a variant, so don't have to put all those '?' and nullable *)
-    inherit legacy_span;
-
     (* for InvalidRuleSchemaError *)
     (* LATER: could inherit location; but file: vs path: *)
-    (* TODO: all those fields are actually mandatory when the error_span            
-     * is not a legact_span *)
-    ?file: string option;
-    ?start: position_bis option;
-    ?end <ocaml name="end_">: position_bis option;
+    (* TODO: source hash should probably also be mandatory? *)
+    file: string;
+    start: position_bis;
+    end <ocaml name="end_">: position_bis;
     ?source_hash: string option;
-    (* those are really optional *)
+
+    (*  The path to the pattern in the yaml rule
+     *  and an adjusted start/end within just the pattern
+     *  Used to report playground parse errors in the simple editor
+     *
+     *  TODO: remove this or add back simple editor error highlighting
+     *)
+    ?config_start: position_bis nullable option;
+    ?config_end: position_bis nullable option;
+    ?config_path: string list nullable option;
+    
+    (* LATER: what is this for? *)
     ?context_start: position_bis nullable option;
     ?context_end: position_bis nullable option;
   }
@@ -409,15 +416,7 @@ type position_bis = {
  *  and an adjusted start/end within just the pattern
  *  Used to report playground parse errors in the simpler editor"
  *)
-type legacy_span = {
-  (* for Pattern parse error *)
-  config_start: position_bis nullable;
-  config_end: position_bis nullable;
-  (* LATER: what is that?? e.g. ["rule"; "1"; "pattern"] means? 
-   * see also yaml_path in core_error
-  *)
-  config_path: string list nullable;
-}
+
     
 (*****************************************************************************)
 (* Match result (called RuleMatch in rule_matches.py) *)

--- a/Semgrep_output_v0_j.ml
+++ b/Semgrep_output_v0_j.ml
@@ -80,12 +80,6 @@ type location = Semgrep_output_v0_t.location = {
   end_ (*atd end *): position
 }
 
-type legacy_span = Semgrep_output_v0_t.legacy_span = {
-  config_start: position_bis option;
-  config_end: position_bis option;
-  config_path: string list option
-}
-
 type fix_regex = Semgrep_output_v0_t.fix_regex = {
   regex: string;
   replacement: string;
@@ -110,13 +104,13 @@ type finding = Semgrep_output_v0_t.finding = {
 }
 
 type error_span = Semgrep_output_v0_t.error_span = {
-  config_start: position_bis option;
-  config_end: position_bis option;
-  config_path: string list option;
-  file: string option;
-  start: position_bis option;
-  end_ (*atd end *): position_bis option;
+  file: string;
+  start: position_bis;
+  end_ (*atd end *): position_bis;
   source_hash: string option;
+  config_start: position_bis option option;
+  config_end: position_bis option option;
+  config_path: string list option option;
   context_start: position_bis option option;
   context_end: position_bis option option
 }
@@ -2983,256 +2977,6 @@ let read_location = (
 )
 let location_of_string s =
   read_location (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__7 = (
-  Atdgen_runtime.Oj_run.write_list (
-    Yojson.Safe.write_string
-  )
-)
-let string_of__7 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__7 ob x;
-  Bi_outbuf.contents ob
-let read__7 = (
-  Atdgen_runtime.Oj_run.read_list (
-    Atdgen_runtime.Oj_run.read_string
-  )
-)
-let _7_of_string s =
-  read__7 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__23 = (
-  Atdgen_runtime.Oj_run.write_nullable (
-    write__7
-  )
-)
-let string_of__23 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__23 ob x;
-  Bi_outbuf.contents ob
-let read__23 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    (if Yojson.Safe.read_null_if_possible p lb then None
-    else Some ((
-      read__7
-    ) p lb) : _ option)
-)
-let _23_of_string s =
-  read__23 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__22 = (
-  Atdgen_runtime.Oj_run.write_nullable (
-    write_position_bis
-  )
-)
-let string_of__22 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__22 ob x;
-  Bi_outbuf.contents ob
-let read__22 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    (if Yojson.Safe.read_null_if_possible p lb then None
-    else Some ((
-      read_position_bis
-    ) p lb) : _ option)
-)
-let _22_of_string s =
-  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write_legacy_span : _ -> legacy_span -> _ = (
-  fun ob (x : legacy_span) ->
-    Bi_outbuf.add_char ob '{';
-    let is_first = ref true in
-    if !is_first then
-      is_first := false
-    else
-      Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"config_start\":";
-    (
-      write__22
-    )
-      ob x.config_start;
-    if !is_first then
-      is_first := false
-    else
-      Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"config_end\":";
-    (
-      write__22
-    )
-      ob x.config_end;
-    if !is_first then
-      is_first := false
-    else
-      Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"config_path\":";
-    (
-      write__23
-    )
-      ob x.config_path;
-    Bi_outbuf.add_char ob '}';
-)
-let string_of_legacy_span ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write_legacy_span ob x;
-  Bi_outbuf.contents ob
-let read_legacy_span = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    Yojson.Safe.read_lcurl p lb;
-    let field_config_start = ref (None) in
-    let field_config_end = ref (None) in
-    let field_config_path = ref (None) in
-    try
-      Yojson.Safe.read_space p lb;
-      Yojson.Safe.read_object_end lb;
-      Yojson.Safe.read_space p lb;
-      let f =
-        fun s pos len ->
-          if pos < 0 || len < 0 || pos + len > String.length s then
-            invalid_arg "out-of-bounds substring position or length";
-          match len with
-            | 10 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 'n' && String.unsafe_get s (pos+9) = 'd' then (
-                  1
-                )
-                else (
-                  -1
-                )
-              )
-            | 11 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'p' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' then (
-                  2
-                )
-                else (
-                  -1
-                )
-              )
-            | 12 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 's' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 't' then (
-                  0
-                )
-                else (
-                  -1
-                )
-              )
-            | _ -> (
-                -1
-              )
-      in
-      let i = Yojson.Safe.map_ident p f lb in
-      Atdgen_runtime.Oj_run.read_until_field_value p lb;
-      (
-        match i with
-          | 0 ->
-            field_config_start := (
-              Some (
-                (
-                  read__22
-                ) p lb
-              )
-            );
-          | 1 ->
-            field_config_end := (
-              Some (
-                (
-                  read__22
-                ) p lb
-              )
-            );
-          | 2 ->
-            field_config_path := (
-              Some (
-                (
-                  read__23
-                ) p lb
-              )
-            );
-          | _ -> (
-              Yojson.Safe.skip_json p lb
-            )
-      );
-      while true do
-        Yojson.Safe.read_space p lb;
-        Yojson.Safe.read_object_sep p lb;
-        Yojson.Safe.read_space p lb;
-        let f =
-          fun s pos len ->
-            if pos < 0 || len < 0 || pos + len > String.length s then
-              invalid_arg "out-of-bounds substring position or length";
-            match len with
-              | 10 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 'n' && String.unsafe_get s (pos+9) = 'd' then (
-                    1
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 11 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'p' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' then (
-                    2
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 12 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 's' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 't' then (
-                    0
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | _ -> (
-                  -1
-                )
-        in
-        let i = Yojson.Safe.map_ident p f lb in
-        Atdgen_runtime.Oj_run.read_until_field_value p lb;
-        (
-          match i with
-            | 0 ->
-              field_config_start := (
-                Some (
-                  (
-                    read__22
-                  ) p lb
-                )
-              );
-            | 1 ->
-              field_config_end := (
-                Some (
-                  (
-                    read__22
-                  ) p lb
-                )
-              );
-            | 2 ->
-              field_config_path := (
-                Some (
-                  (
-                    read__23
-                  ) p lb
-                )
-              );
-            | _ -> (
-                Yojson.Safe.skip_json p lb
-              )
-        );
-      done;
-      assert false;
-    with Yojson.End_of_object -> (
-        (
-          {
-            config_start = (match !field_config_start with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "config_start");
-            config_end = (match !field_config_end with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "config_end");
-            config_path = (match !field_config_path with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "config_path");
-          }
-         : legacy_span)
-      )
-)
-let legacy_span_of_string s =
-  read_legacy_span (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_fix_regex : _ -> fix_regex -> _ = (
   fun ob (x : fix_regex) ->
     Bi_outbuf.add_char ob '{';
@@ -3447,6 +3191,22 @@ let read_fix_regex = (
 )
 let fix_regex_of_string s =
   read_fix_regex (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__7 = (
+  Atdgen_runtime.Oj_run.write_list (
+    Yojson.Safe.write_string
+  )
+)
+let string_of__7 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__7 ob x;
+  Bi_outbuf.contents ob
+let read__7 = (
+  Atdgen_runtime.Oj_run.read_list (
+    Atdgen_runtime.Oj_run.read_string
+  )
+)
+let _7_of_string s =
+  read__7 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__8 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write__7
@@ -4215,9 +3975,28 @@ let read_finding = (
 )
 let finding_of_string s =
   read_finding (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__24 = (
+  Atdgen_runtime.Oj_run.write_nullable (
+    write__7
+  )
+)
+let string_of__24 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__24 ob x;
+  Bi_outbuf.contents ob
+let read__24 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    (if Yojson.Safe.read_null_if_possible p lb then None
+    else Some ((
+      read__7
+    ) p lb) : _ option)
+)
+let _24_of_string s =
+  read__24 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__25 = (
   Atdgen_runtime.Oj_run.write_std_option (
-    write__22
+    write__24
   )
 )
 let string_of__25 ?(len = 1024) x =
@@ -4237,7 +4016,7 @@ let read__25 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__22
+                  read__24
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -4260,7 +4039,7 @@ let read__25 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__22
+                  read__24
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -4272,16 +4051,35 @@ let read__25 = (
 )
 let _25_of_string s =
   read__25 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__24 = (
-  Atdgen_runtime.Oj_run.write_std_option (
+let write__22 = (
+  Atdgen_runtime.Oj_run.write_nullable (
     write_position_bis
   )
 )
-let string_of__24 ?(len = 1024) x =
+let string_of__22 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__24 ob x;
+  write__22 ob x;
   Bi_outbuf.contents ob
-let read__24 = (
+let read__22 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    (if Yojson.Safe.read_null_if_possible p lb then None
+    else Some ((
+      read_position_bis
+    ) p lb) : _ option)
+)
+let _22_of_string s =
+  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__23 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__22
+  )
+)
+let string_of__23 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__23 ob x;
+  Bi_outbuf.contents ob
+let read__23 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -4294,7 +4092,7 @@ let read__24 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read_position_bis
+                  read__22
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -4317,7 +4115,7 @@ let read__24 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read_position_bis
+                  read__22
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -4327,8 +4125,8 @@ let read__24 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _24_of_string s =
-  read__24 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _23_of_string s =
+  read__23 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_error_span : _ -> error_span -> _ = (
   fun ob (x : error_span) ->
     Bi_outbuf.add_char ob '{';
@@ -4337,62 +4135,29 @@ let write_error_span : _ -> error_span -> _ = (
       is_first := false
     else
       Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"config_start\":";
+    Bi_outbuf.add_string ob "\"file\":";
     (
-      write__22
+      Yojson.Safe.write_string
     )
-      ob x.config_start;
+      ob x.file;
     if !is_first then
       is_first := false
     else
       Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"config_end\":";
+    Bi_outbuf.add_string ob "\"start\":";
     (
-      write__22
+      write_position_bis
     )
-      ob x.config_end;
+      ob x.start;
     if !is_first then
       is_first := false
     else
       Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"config_path\":";
+    Bi_outbuf.add_string ob "\"end\":";
     (
-      write__23
+      write_position_bis
     )
-      ob x.config_path;
-    (match x.file with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Bi_outbuf.add_char ob ',';
-      Bi_outbuf.add_string ob "\"file\":";
-      (
-        Yojson.Safe.write_string
-      )
-        ob x;
-    );
-    (match x.start with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Bi_outbuf.add_char ob ',';
-      Bi_outbuf.add_string ob "\"start\":";
-      (
-        write_position_bis
-      )
-        ob x;
-    );
-    (match x.end_ with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Bi_outbuf.add_char ob ',';
-      Bi_outbuf.add_string ob "\"end\":";
-      (
-        write_position_bis
-      )
-        ob x;
-    );
+      ob x.end_;
     (match x.source_hash with None -> () | Some x ->
       if !is_first then
         is_first := false
@@ -4401,6 +4166,39 @@ let write_error_span : _ -> error_span -> _ = (
       Bi_outbuf.add_string ob "\"source_hash\":";
       (
         Yojson.Safe.write_string
+      )
+        ob x;
+    );
+    (match x.config_start with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"config_start\":";
+      (
+        write__22
+      )
+        ob x;
+    );
+    (match x.config_end with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"config_end\":";
+      (
+        write__22
+      )
+        ob x;
+    );
+    (match x.config_path with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"config_path\":";
+      (
+        write__24
       )
         ob x;
     );
@@ -4436,13 +4234,13 @@ let read_error_span = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
-    let field_config_start = ref (None) in
-    let field_config_end = ref (None) in
-    let field_config_path = ref (None) in
     let field_file = ref (None) in
     let field_start = ref (None) in
     let field_end_ = ref (None) in
     let field_source_hash = ref (None) in
+    let field_config_start = ref (None) in
+    let field_config_end = ref (None) in
+    let field_config_path = ref (None) in
     let field_context_start = ref (None) in
     let field_context_end = ref (None) in
     try
@@ -4456,7 +4254,7 @@ let read_error_span = (
           match len with
             | 3 -> (
                 if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 'd' then (
-                  5
+                  2
                 )
                 else (
                   -1
@@ -4464,7 +4262,7 @@ let read_error_span = (
               )
             | 4 -> (
                 if String.unsafe_get s pos = 'f' && String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' then (
-                  3
+                  0
                 )
                 else (
                   -1
@@ -4472,7 +4270,7 @@ let read_error_span = (
               )
             | 5 -> (
                 if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 't' && String.unsafe_get s (pos+2) = 'a' && String.unsafe_get s (pos+3) = 'r' && String.unsafe_get s (pos+4) = 't' then (
-                  4
+                  1
                 )
                 else (
                   -1
@@ -4480,7 +4278,7 @@ let read_error_span = (
               )
             | 10 -> (
                 if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 'n' && String.unsafe_get s (pos+9) = 'd' then (
-                  1
+                  5
                 )
                 else (
                   -1
@@ -4493,7 +4291,7 @@ let read_error_span = (
                         match String.unsafe_get s (pos+3) with
                           | 'f' -> (
                               if String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'p' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' then (
-                                2
+                                6
                               )
                               else (
                                 -1
@@ -4517,7 +4315,7 @@ let read_error_span = (
                     )
                   | 's' -> (
                       if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'u' && String.unsafe_get s (pos+3) = 'r' && String.unsafe_get s (pos+4) = 'c' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'h' then (
-                        6
+                        3
                       )
                       else (
                         -1
@@ -4529,7 +4327,7 @@ let read_error_span = (
               )
             | 12 -> (
                 if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 's' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 't' then (
-                  0
+                  4
                 )
                 else (
                   -1
@@ -4552,32 +4350,32 @@ let read_error_span = (
       (
         match i with
           | 0 ->
-            field_config_start := (
+            field_file := (
               Some (
                 (
-                  read__22
+                  Atdgen_runtime.Oj_run.read_string
                 ) p lb
               )
             );
           | 1 ->
-            field_config_end := (
+            field_start := (
               Some (
                 (
-                  read__22
+                  read_position_bis
                 ) p lb
               )
             );
           | 2 ->
-            field_config_path := (
+            field_end_ := (
               Some (
                 (
-                  read__23
+                  read_position_bis
                 ) p lb
               )
             );
           | 3 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_file := (
+              field_source_hash := (
                 Some (
                   (
                     Atdgen_runtime.Oj_run.read_string
@@ -4587,30 +4385,30 @@ let read_error_span = (
             )
           | 4 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_start := (
+              field_config_start := (
                 Some (
                   (
-                    read_position_bis
+                    read__22
                   ) p lb
                 )
               );
             )
           | 5 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_end_ := (
+              field_config_end := (
                 Some (
                   (
-                    read_position_bis
+                    read__22
                   ) p lb
                 )
               );
             )
           | 6 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_source_hash := (
+              field_config_path := (
                 Some (
                   (
-                    Atdgen_runtime.Oj_run.read_string
+                    read__24
                   ) p lb
                 )
               );
@@ -4650,7 +4448,7 @@ let read_error_span = (
             match len with
               | 3 -> (
                   if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 'd' then (
-                    5
+                    2
                   )
                   else (
                     -1
@@ -4658,7 +4456,7 @@ let read_error_span = (
                 )
               | 4 -> (
                   if String.unsafe_get s pos = 'f' && String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' then (
-                    3
+                    0
                   )
                   else (
                     -1
@@ -4666,7 +4464,7 @@ let read_error_span = (
                 )
               | 5 -> (
                   if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 't' && String.unsafe_get s (pos+2) = 'a' && String.unsafe_get s (pos+3) = 'r' && String.unsafe_get s (pos+4) = 't' then (
-                    4
+                    1
                   )
                   else (
                     -1
@@ -4674,7 +4472,7 @@ let read_error_span = (
                 )
               | 10 -> (
                   if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 'n' && String.unsafe_get s (pos+9) = 'd' then (
-                    1
+                    5
                   )
                   else (
                     -1
@@ -4687,7 +4485,7 @@ let read_error_span = (
                           match String.unsafe_get s (pos+3) with
                             | 'f' -> (
                                 if String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'p' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' then (
-                                  2
+                                  6
                                 )
                                 else (
                                   -1
@@ -4711,7 +4509,7 @@ let read_error_span = (
                       )
                     | 's' -> (
                         if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'u' && String.unsafe_get s (pos+3) = 'r' && String.unsafe_get s (pos+4) = 'c' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'h' then (
-                          6
+                          3
                         )
                         else (
                           -1
@@ -4723,7 +4521,7 @@ let read_error_span = (
                 )
               | 12 -> (
                   if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'f' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 's' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 't' then (
-                    0
+                    4
                   )
                   else (
                     -1
@@ -4746,32 +4544,32 @@ let read_error_span = (
         (
           match i with
             | 0 ->
-              field_config_start := (
+              field_file := (
                 Some (
                   (
-                    read__22
+                    Atdgen_runtime.Oj_run.read_string
                   ) p lb
                 )
               );
             | 1 ->
-              field_config_end := (
+              field_start := (
                 Some (
                   (
-                    read__22
+                    read_position_bis
                   ) p lb
                 )
               );
             | 2 ->
-              field_config_path := (
+              field_end_ := (
                 Some (
                   (
-                    read__23
+                    read_position_bis
                   ) p lb
                 )
               );
             | 3 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_file := (
+                field_source_hash := (
                   Some (
                     (
                       Atdgen_runtime.Oj_run.read_string
@@ -4781,30 +4579,30 @@ let read_error_span = (
               )
             | 4 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_start := (
+                field_config_start := (
                   Some (
                     (
-                      read_position_bis
+                      read__22
                     ) p lb
                   )
                 );
               )
             | 5 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_end_ := (
+                field_config_end := (
                   Some (
                     (
-                      read_position_bis
+                      read__22
                     ) p lb
                   )
                 );
               )
             | 6 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_source_hash := (
+                field_config_path := (
                   Some (
                     (
-                      Atdgen_runtime.Oj_run.read_string
+                      read__24
                     ) p lb
                   )
                 );
@@ -4838,13 +4636,13 @@ let read_error_span = (
     with Yojson.End_of_object -> (
         (
           {
-            config_start = (match !field_config_start with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "config_start");
-            config_end = (match !field_config_end with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "config_end");
-            config_path = (match !field_config_path with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "config_path");
-            file = !field_file;
-            start = !field_start;
-            end_ = !field_end_;
+            file = (match !field_file with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "file");
+            start = (match !field_start with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "start");
+            end_ = (match !field_end_ with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "end_");
             source_hash = !field_source_hash;
+            config_start = !field_config_start;
+            config_end = !field_config_end;
+            config_path = !field_config_path;
             context_start = !field_context_start;
             context_end = !field_context_end;
           }

--- a/Semgrep_output_v0_j.mli
+++ b/Semgrep_output_v0_j.mli
@@ -80,12 +80,6 @@ type location = Semgrep_output_v0_t.location = {
   end_ (*atd end *): position
 }
 
-type legacy_span = Semgrep_output_v0_t.legacy_span = {
-  config_start: position_bis option;
-  config_end: position_bis option;
-  config_path: string list option
-}
-
 type fix_regex = Semgrep_output_v0_t.fix_regex = {
   regex: string;
   replacement: string;
@@ -110,13 +104,13 @@ type finding = Semgrep_output_v0_t.finding = {
 }
 
 type error_span = Semgrep_output_v0_t.error_span = {
-  config_start: position_bis option;
-  config_end: position_bis option;
-  config_path: string list option;
-  file: string option;
-  start: position_bis option;
-  end_ (*atd end *): position_bis option;
+  file: string;
+  start: position_bis;
+  end_ (*atd end *): position_bis;
   source_hash: string option;
+  config_start: position_bis option option;
+  config_end: position_bis option option;
+  config_path: string list option option;
   context_start: position_bis option option;
   context_end: position_bis option option
 }
@@ -602,26 +596,6 @@ val read_location :
 val location_of_string :
   string -> location
   (** Deserialize JSON data of type {!location}. *)
-
-val write_legacy_span :
-  Bi_outbuf.t -> legacy_span -> unit
-  (** Output a JSON value of type {!legacy_span}. *)
-
-val string_of_legacy_span :
-  ?len:int -> legacy_span -> string
-  (** Serialize a value of type {!legacy_span}
-      into a JSON string.
-      @param len specifies the initial length
-                 of the buffer used internally.
-                 Default: 1024. *)
-
-val read_legacy_span :
-  Yojson.Safe.lexer_state -> Lexing.lexbuf -> legacy_span
-  (** Input JSON data of type {!legacy_span}. *)
-
-val legacy_span_of_string :
-  string -> legacy_span
-  (** Deserialize JSON data of type {!legacy_span}. *)
 
 val write_fix_regex :
   Bi_outbuf.t -> fix_regex -> unit

--- a/semgrep_output_v0.jsonschema
+++ b/semgrep_output_v0.jsonschema
@@ -254,18 +254,18 @@
     },
     "error_span": {
       "type": "object",
-      "required": [ "config_start", "config_end", "config_path" ],
+      "required": [ "file", "start", "end" ],
       "properties": {
+        "file": { "type": "string" },
+        "start": { "$ref": "#/definitions/position_bis" },
+        "end": { "$ref": "#/definitions/position_bis" },
+        "source_hash": { "type": "string" },
         "config_start": { "$ref": "#/definitions/position_bis" },
         "config_end": { "$ref": "#/definitions/position_bis" },
         "config_path": {
           "type": [ "array", "null" ],
           "items": { "type": "string" }
         },
-        "file": { "type": "string" },
-        "start": { "$ref": "#/definitions/position_bis" },
-        "end": { "$ref": "#/definitions/position_bis" },
-        "source_hash": { "type": "string" },
         "context_start": { "$ref": "#/definitions/position_bis" },
         "context_end": { "$ref": "#/definitions/position_bis" }
       }
@@ -276,18 +276,6 @@
       "properties": {
         "line": { "type": "integer" },
         "col": { "type": "integer" }
-      }
-    },
-    "legacy_span": {
-      "type": "object",
-      "required": [ "config_start", "config_end", "config_path" ],
-      "properties": {
-        "config_start": { "$ref": "#/definitions/position_bis" },
-        "config_end": { "$ref": "#/definitions/position_bis" },
-        "config_path": {
-          "type": [ "array", "null" ],
-          "items": { "type": "string" }
-        }
       }
     },
     "cli_match": {

--- a/semgrep_output_v0.py
+++ b/semgrep_output_v0.py
@@ -1050,11 +1050,11 @@ class ErrorSpan:
     start: PositionBis
     end: PositionBis
     source_hash: Optional[str] = None
-    config_start: Optional[PositionBis] = None
-    config_end: Optional[PositionBis] = None
-    config_path: Optional[List[str]] = None
-    context_start: Optional[PositionBis] = None
-    context_end: Optional[PositionBis] = None
+    config_start: Optional[Optional[PositionBis]] = None
+    config_end: Optional[Optional[PositionBis]] = None
+    config_path: Optional[Optional[List[str]]] = None
+    context_start: Optional[Optional[PositionBis]] = None
+    context_end: Optional[Optional[PositionBis]] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'ErrorSpan':
@@ -2118,8 +2118,8 @@ class ApiScansFindings:
     """Original type: api_scans_findings = { ... }"""
 
     findings: List[Finding]
-    token: str
-    gitlab_token: str
+    token: Optional[str]
+    gitlab_token: Optional[str]
     searched_paths: List[str]
     rule_ids: List[str]
     cai_ids: List[str]

--- a/semgrep_output_v0.py
+++ b/semgrep_output_v0.py
@@ -940,40 +940,6 @@ class Location:
 
 
 @dataclass
-class LegacySpan:
-    """Original type: legacy_span = { ... }"""
-
-    config_start: Optional[PositionBis]
-    config_end: Optional[PositionBis]
-    config_path: Optional[List[str]]
-
-    @classmethod
-    def from_json(cls, x: Any) -> 'LegacySpan':
-        if isinstance(x, dict):
-            return cls(
-                config_start=_atd_read_nullable(PositionBis.from_json)(x['config_start']) if 'config_start' in x else _atd_missing_json_field('LegacySpan', 'config_start'),
-                config_end=_atd_read_nullable(PositionBis.from_json)(x['config_end']) if 'config_end' in x else _atd_missing_json_field('LegacySpan', 'config_end'),
-                config_path=_atd_read_nullable(_atd_read_list(_atd_read_string))(x['config_path']) if 'config_path' in x else _atd_missing_json_field('LegacySpan', 'config_path'),
-            )
-        else:
-            _atd_bad_json('LegacySpan', x)
-
-    def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        res['config_start'] = _atd_write_nullable((lambda x: x.to_json()))(self.config_start)
-        res['config_end'] = _atd_write_nullable((lambda x: x.to_json()))(self.config_end)
-        res['config_path'] = _atd_write_nullable(_atd_write_list(_atd_write_string))(self.config_path)
-        return res
-
-    @classmethod
-    def from_json_string(cls, x: str) -> 'LegacySpan':
-        return cls.from_json(json.loads(x))
-
-    def to_json_string(self, **kw: Any) -> str:
-        return json.dumps(self.to_json(), **kw)
-
-
-@dataclass
 class FixRegex:
     """Original type: fix_regex = { ... }"""
 
@@ -1080,27 +1046,27 @@ class Finding:
 class ErrorSpan:
     """Original type: error_span = { ... }"""
 
-    config_start: Optional[PositionBis]
-    config_end: Optional[PositionBis]
-    config_path: Optional[List[str]]
-    file: Optional[str] = None
-    start: Optional[PositionBis] = None
-    end: Optional[PositionBis] = None
+    file: str
+    start: PositionBis
+    end: PositionBis
     source_hash: Optional[str] = None
-    context_start: Optional[Optional[PositionBis]] = None
-    context_end: Optional[Optional[PositionBis]] = None
+    config_start: Optional[PositionBis] = None
+    config_end: Optional[PositionBis] = None
+    config_path: Optional[List[str]] = None
+    context_start: Optional[PositionBis] = None
+    context_end: Optional[PositionBis] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'ErrorSpan':
         if isinstance(x, dict):
             return cls(
-                config_start=_atd_read_nullable(PositionBis.from_json)(x['config_start']) if 'config_start' in x else _atd_missing_json_field('ErrorSpan', 'config_start'),
-                config_end=_atd_read_nullable(PositionBis.from_json)(x['config_end']) if 'config_end' in x else _atd_missing_json_field('ErrorSpan', 'config_end'),
-                config_path=_atd_read_nullable(_atd_read_list(_atd_read_string))(x['config_path']) if 'config_path' in x else _atd_missing_json_field('ErrorSpan', 'config_path'),
-                file=_atd_read_string(x['file']) if 'file' in x else None,
-                start=PositionBis.from_json(x['start']) if 'start' in x else None,
-                end=PositionBis.from_json(x['end']) if 'end' in x else None,
+                file=_atd_read_string(x['file']) if 'file' in x else _atd_missing_json_field('ErrorSpan', 'file'),
+                start=PositionBis.from_json(x['start']) if 'start' in x else _atd_missing_json_field('ErrorSpan', 'start'),
+                end=PositionBis.from_json(x['end']) if 'end' in x else _atd_missing_json_field('ErrorSpan', 'end'),
                 source_hash=_atd_read_string(x['source_hash']) if 'source_hash' in x else None,
+                config_start=_atd_read_nullable(PositionBis.from_json)(x['config_start']) if 'config_start' in x else None,
+                config_end=_atd_read_nullable(PositionBis.from_json)(x['config_end']) if 'config_end' in x else None,
+                config_path=_atd_read_nullable(_atd_read_list(_atd_read_string))(x['config_path']) if 'config_path' in x else None,
                 context_start=_atd_read_nullable(PositionBis.from_json)(x['context_start']) if 'context_start' in x else None,
                 context_end=_atd_read_nullable(PositionBis.from_json)(x['context_end']) if 'context_end' in x else None,
             )
@@ -1109,17 +1075,17 @@ class ErrorSpan:
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
-        res['config_start'] = _atd_write_nullable((lambda x: x.to_json()))(self.config_start)
-        res['config_end'] = _atd_write_nullable((lambda x: x.to_json()))(self.config_end)
-        res['config_path'] = _atd_write_nullable(_atd_write_list(_atd_write_string))(self.config_path)
-        if self.file is not None:
-            res['file'] = _atd_write_string(self.file)
-        if self.start is not None:
-            res['start'] = (lambda x: x.to_json())(self.start)
-        if self.end is not None:
-            res['end'] = (lambda x: x.to_json())(self.end)
+        res['file'] = _atd_write_string(self.file)
+        res['start'] = (lambda x: x.to_json())(self.start)
+        res['end'] = (lambda x: x.to_json())(self.end)
         if self.source_hash is not None:
             res['source_hash'] = _atd_write_string(self.source_hash)
+        if self.config_start is not None:
+            res['config_start'] = _atd_write_nullable((lambda x: x.to_json()))(self.config_start)
+        if self.config_end is not None:
+            res['config_end'] = _atd_write_nullable((lambda x: x.to_json()))(self.config_end)
+        if self.config_path is not None:
+            res['config_path'] = _atd_write_nullable(_atd_write_list(_atd_write_string))(self.config_path)
         if self.context_start is not None:
             res['context_start'] = _atd_write_nullable((lambda x: x.to_json()))(self.context_start)
         if self.context_end is not None:
@@ -2152,8 +2118,8 @@ class ApiScansFindings:
     """Original type: api_scans_findings = { ... }"""
 
     findings: List[Finding]
-    token: Optional[str]
-    gitlab_token: Optional[str]
+    token: str
+    gitlab_token: str
     searched_paths: List[str]
     rule_ids: List[str]
     cai_ids: List[str]

--- a/semgrep_output_v0.ts
+++ b/semgrep_output_v0.ts
@@ -168,13 +168,13 @@ export type CliError = {
 }
 
 export type ErrorSpan = {
-  config_start: (PositionBis | null);
-  config_end: (PositionBis | null);
-  config_path: (string[] | null);
-  file?: string;
-  start?: PositionBis;
-  end?: PositionBis;
+  file: string;
+  start: PositionBis;
+  end: PositionBis;
   source_hash?: string;
+  config_start?: (PositionBis | null);
+  config_end?: (PositionBis | null);
+  config_path?: (string[] | null);
   context_start?: (PositionBis | null);
   context_end?: (PositionBis | null);
 }
@@ -182,12 +182,6 @@ export type ErrorSpan = {
 export type PositionBis = {
   line: Int;
   col: Int;
-}
-
-export type LegacySpan = {
-  config_start: (PositionBis | null);
-  config_end: (PositionBis | null);
-  config_path: (string[] | null);
 }
 
 export type CliMatch = {
@@ -781,13 +775,13 @@ export function readCliError(x: any, context: any = x): CliError {
 
 export function writeErrorSpan(x: ErrorSpan, context: any = x): any {
   return {
-    'config_start': _atd_write_required_field('ErrorSpan', 'config_start', writePositionBis, x.config_start, x),
-    'config_end': _atd_write_required_field('ErrorSpan', 'config_end', writePositionBis, x.config_end, x),
-    'config_path': _atd_write_required_field('ErrorSpan', 'config_path', _atd_write_array(_atd_write_string), x.config_path, x),
-    'file': _atd_write_optional_field(_atd_write_string, x.file, x),
-    'start': _atd_write_optional_field(writePositionBis, x.start, x),
-    'end': _atd_write_optional_field(writePositionBis, x.end, x),
+    'file': _atd_write_required_field('ErrorSpan', 'file', _atd_write_string, x.file, x),
+    'start': _atd_write_required_field('ErrorSpan', 'start', writePositionBis, x.start, x),
+    'end': _atd_write_required_field('ErrorSpan', 'end', writePositionBis, x.end, x),
     'source_hash': _atd_write_optional_field(_atd_write_string, x.source_hash, x),
+    'config_start': _atd_write_optional_field(writePositionBis, x.config_start, x),
+    'config_end': _atd_write_optional_field(writePositionBis, x.config_end, x),
+    'config_path': _atd_write_optional_field(_atd_write_array(_atd_write_string), x.config_path, x),
     'context_start': _atd_write_optional_field(writePositionBis, x.context_start, x),
     'context_end': _atd_write_optional_field(writePositionBis, x.context_end, x),
   };
@@ -795,13 +789,13 @@ export function writeErrorSpan(x: ErrorSpan, context: any = x): any {
 
 export function readErrorSpan(x: any, context: any = x): ErrorSpan {
   return {
-    config_start: _atd_read_required_field('ErrorSpan', 'config_start', _atd_read_nullable(readPositionBis), x['config_start'], x),
-    config_end: _atd_read_required_field('ErrorSpan', 'config_end', _atd_read_nullable(readPositionBis), x['config_end'], x),
-    config_path: _atd_read_required_field('ErrorSpan', 'config_path', _atd_read_nullable(_atd_read_array(_atd_read_string)), x['config_path'], x),
-    file: _atd_read_optional_field(_atd_read_string, x['file'], x),
-    start: _atd_read_optional_field(readPositionBis, x['start'], x),
-    end: _atd_read_optional_field(readPositionBis, x['end'], x),
+    file: _atd_read_required_field('ErrorSpan', 'file', _atd_read_string, x['file'], x),
+    start: _atd_read_required_field('ErrorSpan', 'start', readPositionBis, x['start'], x),
+    end: _atd_read_required_field('ErrorSpan', 'end', readPositionBis, x['end'], x),
     source_hash: _atd_read_optional_field(_atd_read_string, x['source_hash'], x),
+    config_start: _atd_read_optional_field(_atd_read_nullable(readPositionBis), x['config_start'], x),
+    config_end: _atd_read_optional_field(_atd_read_nullable(readPositionBis), x['config_end'], x),
+    config_path: _atd_read_optional_field(_atd_read_nullable(_atd_read_array(_atd_read_string)), x['config_path'], x),
     context_start: _atd_read_optional_field(_atd_read_nullable(readPositionBis), x['context_start'], x),
     context_end: _atd_read_optional_field(_atd_read_nullable(readPositionBis), x['context_end'], x),
   };
@@ -818,22 +812,6 @@ export function readPositionBis(x: any, context: any = x): PositionBis {
   return {
     line: _atd_read_required_field('PositionBis', 'line', _atd_read_int, x['line'], x),
     col: _atd_read_required_field('PositionBis', 'col', _atd_read_int, x['col'], x),
-  };
-}
-
-export function writeLegacySpan(x: LegacySpan, context: any = x): any {
-  return {
-    'config_start': _atd_write_required_field('LegacySpan', 'config_start', writePositionBis, x.config_start, x),
-    'config_end': _atd_write_required_field('LegacySpan', 'config_end', writePositionBis, x.config_end, x),
-    'config_path': _atd_write_required_field('LegacySpan', 'config_path', _atd_write_array(_atd_write_string), x.config_path, x),
-  };
-}
-
-export function readLegacySpan(x: any, context: any = x): LegacySpan {
-  return {
-    config_start: _atd_read_required_field('LegacySpan', 'config_start', _atd_read_nullable(readPositionBis), x['config_start'], x),
-    config_end: _atd_read_required_field('LegacySpan', 'config_end', _atd_read_nullable(readPositionBis), x['config_end'], x),
-    config_path: _atd_read_required_field('LegacySpan', 'config_path', _atd_read_nullable(_atd_read_array(_atd_read_string)), x['config_path'], x),
   };
 }
 


### PR DESCRIPTION
File, start, and end were marked as optional for error_span, but in reality
they are required by the playground code. This is now reflected in the
interface