### PR TITLE
Add taint traces to semgrep output

### DIFF
--- a/semgrep_output_v0.atd
+++ b/semgrep_output_v0.atd
@@ -108,6 +108,24 @@ type core_match_extra
   <python decorator="dataclass(frozen=True)"> = {
   ?message: string option; (* rule.message (?) *)
   metavars: metavars;
+  ?dataflow_trace: dataflow_trace option;
+}
+
+(* Provides information about dataflow that leads to a finding. For now, just
+ * provides taint traces (i.e. information about the taint source and how the
+ * source reaches the sink). In the future, we may want to include more dataflow
+ * information. For example, we may want to explain how constant propagation
+ * leads to a finding. *)
+type dataflow_trace
+  <ocaml attr="deriving show">
+  <python decorator="dataclass(frozen=True)"> = {
+  ?taint_source: location list option;
+  (* Intermediate variables which are involved in the dataflow. For taint, this
+   * explains how the taint flows from the source to the sink. *)
+  ?intermediate_vars: location list option;
+  (* For now, omitting the taint sink, since it's redundant data except for
+   * certain cases that only appear with DeepSemgrep. We can add it in later
+   * without breaking consumers. *)
 }
 
 (* Name/value map of the matched metavariables.
@@ -477,6 +495,10 @@ type cli_match_extra <ocaml attr="deriving show"> = {
    * and seems to be used only when sending findings to the App.
    *)
   ?fixed_lines: string list option;
+
+  (* For now, present only for taint findings. May be extended to others later
+   * on. *)
+  ?dataflow_trace: dataflow_trace option;
 }
 
 type fix_regex <ocaml attr="deriving show"> = {

--- a/semgrep_output_v0.jsonschema
+++ b/semgrep_output_v0.jsonschema
@@ -53,7 +53,22 @@
       "required": [ "metavars" ],
       "properties": {
         "message": { "type": "string" },
-        "metavars": { "$ref": "#/definitions/metavars" }
+        "metavars": { "$ref": "#/definitions/metavars" },
+        "dataflow_trace": { "$ref": "#/definitions/dataflow_trace" }
+      }
+    },
+    "dataflow_trace": {
+      "type": "object",
+      "required": [],
+      "properties": {
+        "taint_source": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/location" }
+        },
+        "intermediate_vars": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/location" }
+        }
       }
     },
     "metavars": {
@@ -326,7 +341,8 @@
         "is_ignored": { "type": "boolean" },
         "dependency_match_only": { "type": "boolean" },
         "dependency_matches": { "$ref": "#/definitions/raw_json" },
-        "fixed_lines": { "type": "array", "items": { "type": "string" } }
+        "fixed_lines": { "type": "array", "items": { "type": "string" } },
+        "dataflow_trace": { "$ref": "#/definitions/dataflow_trace" }
       }
     },
     "fix_regex": {

--- a/semgrep_output_v0.py
+++ b/semgrep_output_v0.py
@@ -1127,6 +1127,39 @@ class ErrorSpan:
 
 
 @dataclass(frozen=True)
+class DataflowTrace:
+    """Original type: dataflow_trace = { ... }"""
+
+    taint_source: Optional[List[Location]] = None
+    intermediate_vars: Optional[List[Location]] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'DataflowTrace':
+        if isinstance(x, dict):
+            return cls(
+                taint_source=_atd_read_list(Location.from_json)(x['taint_source']) if 'taint_source' in x else None,
+                intermediate_vars=_atd_read_list(Location.from_json)(x['intermediate_vars']) if 'intermediate_vars' in x else None,
+            )
+        else:
+            _atd_bad_json('DataflowTrace', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self.taint_source is not None:
+            res['taint_source'] = _atd_write_list((lambda x: x.to_json()))(self.taint_source)
+        if self.intermediate_vars is not None:
+            res['intermediate_vars'] = _atd_write_list((lambda x: x.to_json()))(self.intermediate_vars)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'DataflowTrace':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass(frozen=True)
 class CveResult:
     """Original type: cve_result = { ... }"""
 
@@ -1319,6 +1352,7 @@ class CoreMatchExtra:
 
     metavars: Metavars
     message: Optional[str] = None
+    dataflow_trace: Optional[DataflowTrace] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CoreMatchExtra':
@@ -1326,6 +1360,7 @@ class CoreMatchExtra:
             return cls(
                 metavars=Metavars.from_json(x['metavars']) if 'metavars' in x else _atd_missing_json_field('CoreMatchExtra', 'metavars'),
                 message=_atd_read_string(x['message']) if 'message' in x else None,
+                dataflow_trace=DataflowTrace.from_json(x['dataflow_trace']) if 'dataflow_trace' in x else None,
             )
         else:
             _atd_bad_json('CoreMatchExtra', x)
@@ -1335,6 +1370,8 @@ class CoreMatchExtra:
         res['metavars'] = (lambda x: x.to_json())(self.metavars)
         if self.message is not None:
             res['message'] = _atd_write_string(self.message)
+        if self.dataflow_trace is not None:
+            res['dataflow_trace'] = (lambda x: x.to_json())(self.dataflow_trace)
         return res
 
     @classmethod
@@ -1963,6 +2000,7 @@ class CliMatchExtra:
     dependency_match_only: Optional[bool] = None
     dependency_matches: Optional[RawJson] = None
     fixed_lines: Optional[List[str]] = None
+    dataflow_trace: Optional[DataflowTrace] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliMatchExtra':
@@ -1980,6 +2018,7 @@ class CliMatchExtra:
                 dependency_match_only=_atd_read_bool(x['dependency_match_only']) if 'dependency_match_only' in x else None,
                 dependency_matches=RawJson.from_json(x['dependency_matches']) if 'dependency_matches' in x else None,
                 fixed_lines=_atd_read_list(_atd_read_string)(x['fixed_lines']) if 'fixed_lines' in x else None,
+                dataflow_trace=DataflowTrace.from_json(x['dataflow_trace']) if 'dataflow_trace' in x else None,
             )
         else:
             _atd_bad_json('CliMatchExtra', x)
@@ -2005,6 +2044,8 @@ class CliMatchExtra:
             res['dependency_matches'] = (lambda x: x.to_json())(self.dependency_matches)
         if self.fixed_lines is not None:
             res['fixed_lines'] = _atd_write_list(_atd_write_string)(self.fixed_lines)
+        if self.dataflow_trace is not None:
+            res['dataflow_trace'] = (lambda x: x.to_json())(self.dataflow_trace)
         return res
 
     @classmethod

--- a/semgrep_output_v0.ts
+++ b/semgrep_output_v0.ts
@@ -35,6 +35,12 @@ export type CoreMatch = {
 export type CoreMatchExtra = {
   message?: string;
   metavars: Metavars;
+  dataflow_trace?: DataflowTrace;
+}
+
+export type DataflowTrace = {
+  taint_source?: Location[];
+  intermediate_vars?: Location[];
 }
 
 export type Metavars = [string, MetavarValue][]
@@ -205,6 +211,7 @@ export type CliMatchExtra = {
   dependency_match_only?: boolean;
   dependency_matches?: RawJson;
   fixed_lines?: string[];
+  dataflow_trace?: DataflowTrace;
 }
 
 export type FixRegex = {
@@ -366,6 +373,7 @@ export function writeCoreMatchExtra(x: CoreMatchExtra, context: any = x): any {
   return {
     'message': _atd_write_optional_field(_atd_write_string, x.message, x),
     'metavars': _atd_write_required_field('CoreMatchExtra', 'metavars', writeMetavars, x.metavars, x),
+    'dataflow_trace': _atd_write_optional_field(writeDataflowTrace, x.dataflow_trace, x),
   };
 }
 
@@ -373,6 +381,21 @@ export function readCoreMatchExtra(x: any, context: any = x): CoreMatchExtra {
   return {
     message: _atd_read_optional_field(_atd_read_string, x['message'], x),
     metavars: _atd_read_required_field('CoreMatchExtra', 'metavars', readMetavars, x['metavars'], x),
+    dataflow_trace: _atd_read_optional_field(readDataflowTrace, x['dataflow_trace'], x),
+  };
+}
+
+export function writeDataflowTrace(x: DataflowTrace, context: any = x): any {
+  return {
+    'taint_source': _atd_write_optional_field(_atd_write_array(writeLocation), x.taint_source, x),
+    'intermediate_vars': _atd_write_optional_field(_atd_write_array(writeLocation), x.intermediate_vars, x),
+  };
+}
+
+export function readDataflowTrace(x: any, context: any = x): DataflowTrace {
+  return {
+    taint_source: _atd_read_optional_field(_atd_read_array(readLocation), x['taint_source'], x),
+    intermediate_vars: _atd_read_optional_field(_atd_read_array(readLocation), x['intermediate_vars'], x),
   };
 }
 
@@ -868,6 +891,7 @@ export function writeCliMatchExtra(x: CliMatchExtra, context: any = x): any {
     'dependency_match_only': _atd_write_optional_field(_atd_write_bool, x.dependency_match_only, x),
     'dependency_matches': _atd_write_optional_field(writeRawJson, x.dependency_matches, x),
     'fixed_lines': _atd_write_optional_field(_atd_write_array(_atd_write_string), x.fixed_lines, x),
+    'dataflow_trace': _atd_write_optional_field(writeDataflowTrace, x.dataflow_trace, x),
   };
 }
 
@@ -885,6 +909,7 @@ export function readCliMatchExtra(x: any, context: any = x): CliMatchExtra {
     dependency_match_only: _atd_read_optional_field(_atd_read_bool, x['dependency_match_only'], x),
     dependency_matches: _atd_read_optional_field(readRawJson, x['dependency_matches'], x),
     fixed_lines: _atd_read_optional_field(_atd_read_array(_atd_read_string), x['fixed_lines'], x),
+    dataflow_trace: _atd_read_optional_field(readDataflowTrace, x['dataflow_trace'], x),
   };
 }
 

--- a/semgrep_output_v0_j.ml
+++ b/semgrep_output_v0_j.ml
@@ -138,6 +138,12 @@ type error_span = Semgrep_output_v0_t.error_span = {
 }
   [@@deriving show]
 
+type dataflow_trace = Semgrep_output_v0_t.dataflow_trace = {
+  taint_source: location list option;
+  intermediate_vars: location list option
+}
+  [@@deriving show]
+
 type cve_result = Semgrep_output_v0_t.cve_result = {
   url: string;
   filename: string;
@@ -165,7 +171,8 @@ type core_severity = Semgrep_output_v0_t.core_severity =  Error | Warning
 
 type core_match_extra = Semgrep_output_v0_t.core_match_extra = {
   message: string option;
-  metavars: metavars
+  metavars: metavars;
+  dataflow_trace: dataflow_trace option
 }
   [@@deriving show]
 
@@ -263,7 +270,8 @@ type cli_match_extra = Semgrep_output_v0_t.cli_match_extra = {
   is_ignored: bool option;
   dependency_match_only: bool option;
   dependency_matches: raw_json option;
-  fixed_lines: string list option
+  fixed_lines: string list option;
+  dataflow_trace: dataflow_trace option
 }
   [@@deriving show]
 
@@ -353,16 +361,16 @@ let read_unique_id_type = (
 )
 let unique_id_type_of_string s =
   read_unique_id_type (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__5 = (
+let write__8 = (
   Atdgen_runtime.Oj_run.write_std_option (
     Yojson.Safe.write_int
   )
 )
-let string_of__5 ?(len = 1024) x =
+let string_of__8 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__5 ob x;
+  write__8 ob x;
   Bi_outbuf.contents ob
-let read__5 = (
+let read__8 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -408,8 +416,8 @@ let read__5 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _5_of_string s =
-  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _8_of_string s =
+  read__8 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__1 = (
   Atdgen_runtime.Oj_run.write_std_option (
     Yojson.Safe.write_string
@@ -895,22 +903,22 @@ let read_rule_times = (
 )
 let rule_times_of_string s =
   read_rule_times (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__12 = (
+let write__14 = (
   Atdgen_runtime.Oj_run.write_list (
     write_rule_times
   )
 )
-let string_of__12 ?(len = 1024) x =
+let string_of__14 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__12 ob x;
+  write__14 ob x;
   Bi_outbuf.contents ob
-let read__12 = (
+let read__14 = (
   Atdgen_runtime.Oj_run.read_list (
     read_rule_times
   )
 )
-let _12_of_string s =
-  read__12 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _14_of_string s =
+  read__14 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_target_time : _ -> target_time -> _ = (
   fun ob (x : target_time) ->
     Bi_outbuf.add_char ob '{';
@@ -930,7 +938,7 @@ let write_target_time : _ -> target_time -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"rule_times\":";
     (
-      write__12
+      write__14
     )
       ob x.rule_times;
     if !is_first then
@@ -1008,7 +1016,7 @@ let read_target_time = (
             field_rule_times := (
               Some (
                 (
-                  read__12
+                  read__14
                 ) p lb
               )
             );
@@ -1077,7 +1085,7 @@ let read_target_time = (
               field_rule_times := (
                 Some (
                   (
-                    read__12
+                    read__14
                   ) p lb
                 )
               );
@@ -1303,16 +1311,16 @@ let read_position = (
 )
 let position_of_string s =
   read_position (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__4 = (
+let write__7 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_position
   )
 )
-let string_of__4 ?(len = 1024) x =
+let string_of__7 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__4 ob x;
+  write__7 ob x;
   Bi_outbuf.contents ob
-let read__4 = (
+let read__7 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -1358,8 +1366,8 @@ let read__4 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _4_of_string s =
-  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _7_of_string s =
+  read__7 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_svalue_value : _ -> svalue_value -> _ = (
   fun ob (x : svalue_value) ->
     Bi_outbuf.add_char ob '{';
@@ -1647,16 +1655,16 @@ let read_skip_reason = (
 )
 let skip_reason_of_string s =
   read_skip_reason (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__6 = (
+let write__9 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_rule_id
   )
 )
-let string_of__6 ?(len = 1024) x =
+let string_of__9 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__6 ob x;
+  write__9 ob x;
   Bi_outbuf.contents ob
-let read__6 = (
+let read__9 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -1702,8 +1710,8 @@ let read__6 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _6_of_string s =
-  read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _9_of_string s =
+  read__9 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_skipped_target : _ -> skipped_target -> _ = (
   fun ob (x : skipped_target) ->
     Bi_outbuf.add_char ob '{';
@@ -2597,16 +2605,16 @@ let read_position_bis = (
 )
 let position_bis_of_string s =
   read_position_bis (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__3 = (
+let write__6 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_svalue_value
   )
 )
-let string_of__3 ?(len = 1024) x =
+let string_of__6 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__3 ob x;
+  write__6 ob x;
   Bi_outbuf.contents ob
-let read__3 = (
+let read__6 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -2652,8 +2660,8 @@ let read__3 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _3_of_string s =
-  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _6_of_string s =
+  read__6 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_metavar_value : _ -> metavar_value -> _ = (
   fun ob (x : metavar_value) ->
     Bi_outbuf.add_char ob '{';
@@ -2954,35 +2962,35 @@ let read_metavar_value = (
 )
 let metavar_value_of_string s =
   read_metavar_value (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__2 = (
+let write__5 = (
   Atdgen_runtime.Oj_run.write_assoc_list (
     Yojson.Safe.write_string
   ) (
     write_metavar_value
   )
 )
-let string_of__2 ?(len = 1024) x =
+let string_of__5 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__2 ob x;
+  write__5 ob x;
   Bi_outbuf.contents ob
-let read__2 = (
+let read__5 = (
   Atdgen_runtime.Oj_run.read_assoc_list (
     Atdgen_runtime.Oj_run.read_string
   ) (
     read_metavar_value
   )
 )
-let _2_of_string s =
-  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _5_of_string s =
+  read__5 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_metavars = (
-  write__2
+  write__5
 )
 let string_of_metavars ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write_metavars ob x;
   Bi_outbuf.contents ob
 let read_metavars = (
-  read__2
+  read__5
 )
 let metavars_of_string s =
   read_metavars (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -3396,32 +3404,16 @@ let read_fix_regex = (
 )
 let fix_regex_of_string s =
   read_fix_regex (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__7 = (
-  Atdgen_runtime.Oj_run.write_list (
-    Yojson.Safe.write_string
-  )
-)
-let string_of__7 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__7 ob x;
-  Bi_outbuf.contents ob
-let read__7 = (
-  Atdgen_runtime.Oj_run.read_list (
-    Atdgen_runtime.Oj_run.read_string
-  )
-)
-let _7_of_string s =
-  read__7 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__43 = (
+let write__45 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_sca_info
   )
 )
-let string_of__43 ?(len = 1024) x =
+let string_of__45 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__43 ob x;
+  write__45 ob x;
   Bi_outbuf.contents ob
-let read__43 = (
+let read__45 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -3467,18 +3459,34 @@ let read__43 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _43_of_string s =
-  read__43 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__30 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write__7
+let _45_of_string s =
+  read__45 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__10 = (
+  Atdgen_runtime.Oj_run.write_list (
+    Yojson.Safe.write_string
   )
 )
-let string_of__30 ?(len = 1024) x =
+let string_of__10 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__30 ob x;
+  write__10 ob x;
   Bi_outbuf.contents ob
-let read__30 = (
+let read__10 = (
+  Atdgen_runtime.Oj_run.read_list (
+    Atdgen_runtime.Oj_run.read_string
+  )
+)
+let _10_of_string s =
+  read__10 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__32 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__10
+  )
+)
+let string_of__32 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__32 ob x;
+  Bi_outbuf.contents ob
+let read__32 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -3491,7 +3499,7 @@ let read__30 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__7
+                  read__10
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -3514,7 +3522,7 @@ let read__30 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__7
+                  read__10
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -3524,8 +3532,8 @@ let read__30 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _30_of_string s =
-  read__30 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _32_of_string s =
+  read__32 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_finding : _ -> finding -> _ = (
   fun ob (x : finding) ->
     Bi_outbuf.add_char ob '{';
@@ -3665,7 +3673,7 @@ let write_finding : _ -> finding -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"fixed_lines\":";
       (
-        write__7
+        write__10
       )
         ob x;
     );
@@ -3994,7 +4002,7 @@ let read_finding = (
               field_fixed_lines := (
                 Some (
                   (
-                    read__7
+                    read__10
                   ) p lb
                 )
               );
@@ -4301,7 +4309,7 @@ let read_finding = (
                 field_fixed_lines := (
                   Some (
                     (
-                      read__7
+                      read__10
                     ) p lb
                   )
                 );
@@ -4347,9 +4355,85 @@ let read_finding = (
 )
 let finding_of_string s =
   read_finding (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__26 = (
+  Atdgen_runtime.Oj_run.write_nullable (
+    write__10
+  )
+)
+let string_of__26 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__26 ob x;
+  Bi_outbuf.contents ob
+let read__26 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    (if Yojson.Safe.read_null_if_possible p lb then None
+    else Some ((
+      read__10
+    ) p lb) : _ option)
+)
+let _26_of_string s =
+  read__26 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__27 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__26
+  )
+)
+let string_of__27 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__27 ob x;
+  Bi_outbuf.contents ob
+let read__27 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__26
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__26
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _27_of_string s =
+  read__27 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__24 = (
   Atdgen_runtime.Oj_run.write_nullable (
-    write__7
+    write_position_bis
   )
 )
 let string_of__24 ?(len = 1024) x =
@@ -4361,7 +4445,7 @@ let read__24 = (
     Yojson.Safe.read_space p lb;
     (if Yojson.Safe.read_null_if_possible p lb then None
     else Some ((
-      read__7
+      read_position_bis
     ) p lb) : _ option)
 )
 let _24_of_string s =
@@ -4423,82 +4507,6 @@ let read__25 = (
 )
 let _25_of_string s =
   read__25 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__22 = (
-  Atdgen_runtime.Oj_run.write_nullable (
-    write_position_bis
-  )
-)
-let string_of__22 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__22 ob x;
-  Bi_outbuf.contents ob
-let read__22 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    (if Yojson.Safe.read_null_if_possible p lb then None
-    else Some ((
-      read_position_bis
-    ) p lb) : _ option)
-)
-let _22_of_string s =
-  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__23 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write__22
-  )
-)
-let string_of__23 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__23 ob x;
-  Bi_outbuf.contents ob
-let read__23 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read__22
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read__22
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _23_of_string s =
-  read__23 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_error_span : _ -> error_span -> _ = (
   fun ob (x : error_span) ->
     Bi_outbuf.add_char ob '{';
@@ -4548,7 +4556,7 @@ let write_error_span : _ -> error_span -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"config_start\":";
       (
-        write__22
+        write__24
       )
         ob x;
     );
@@ -4559,7 +4567,7 @@ let write_error_span : _ -> error_span -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"config_end\":";
       (
-        write__22
+        write__24
       )
         ob x;
     );
@@ -4570,7 +4578,7 @@ let write_error_span : _ -> error_span -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"config_path\":";
       (
-        write__24
+        write__26
       )
         ob x;
     );
@@ -4581,7 +4589,7 @@ let write_error_span : _ -> error_span -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"context_start\":";
       (
-        write__22
+        write__24
       )
         ob x;
     );
@@ -4592,7 +4600,7 @@ let write_error_span : _ -> error_span -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"context_end\":";
       (
-        write__22
+        write__24
       )
         ob x;
     );
@@ -4760,7 +4768,7 @@ let read_error_span = (
               field_config_start := (
                 Some (
                   (
-                    read__22
+                    read__24
                   ) p lb
                 )
               );
@@ -4770,7 +4778,7 @@ let read_error_span = (
               field_config_end := (
                 Some (
                   (
-                    read__22
+                    read__24
                   ) p lb
                 )
               );
@@ -4780,7 +4788,7 @@ let read_error_span = (
               field_config_path := (
                 Some (
                   (
-                    read__24
+                    read__26
                   ) p lb
                 )
               );
@@ -4790,7 +4798,7 @@ let read_error_span = (
               field_context_start := (
                 Some (
                   (
-                    read__22
+                    read__24
                   ) p lb
                 )
               );
@@ -4800,7 +4808,7 @@ let read_error_span = (
               field_context_end := (
                 Some (
                   (
-                    read__22
+                    read__24
                   ) p lb
                 )
               );
@@ -4954,7 +4962,7 @@ let read_error_span = (
                 field_config_start := (
                   Some (
                     (
-                      read__22
+                      read__24
                     ) p lb
                   )
                 );
@@ -4964,7 +4972,7 @@ let read_error_span = (
                 field_config_end := (
                   Some (
                     (
-                      read__22
+                      read__24
                     ) p lb
                   )
                 );
@@ -4974,7 +4982,7 @@ let read_error_span = (
                 field_config_path := (
                   Some (
                     (
-                      read__24
+                      read__26
                     ) p lb
                   )
                 );
@@ -4984,7 +4992,7 @@ let read_error_span = (
                 field_context_start := (
                   Some (
                     (
-                      read__22
+                      read__24
                     ) p lb
                   )
                 );
@@ -4994,7 +5002,7 @@ let read_error_span = (
                 field_context_end := (
                   Some (
                     (
-                      read__22
+                      read__24
                     ) p lb
                   )
                 );
@@ -5023,6 +5031,244 @@ let read_error_span = (
 )
 let error_span_of_string s =
   read_error_span (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__3 = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_location
+  )
+)
+let string_of__3 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__3 ob x;
+  Bi_outbuf.contents ob
+let read__3 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_location
+  )
+)
+let _3_of_string s =
+  read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__4 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__3
+  )
+)
+let string_of__4 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__4 ob x;
+  Bi_outbuf.contents ob
+let read__4 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__3
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__3
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _4_of_string s =
+  read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_dataflow_trace : _ -> dataflow_trace -> _ = (
+  fun ob (x : dataflow_trace) ->
+    Bi_outbuf.add_char ob '{';
+    let is_first = ref true in
+    (match x.taint_source with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"taint_source\":";
+      (
+        write__3
+      )
+        ob x;
+    );
+    (match x.intermediate_vars with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"intermediate_vars\":";
+      (
+        write__3
+      )
+        ob x;
+    );
+    Bi_outbuf.add_char ob '}';
+)
+let string_of_dataflow_trace ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_dataflow_trace ob x;
+  Bi_outbuf.contents ob
+let read_dataflow_trace = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_taint_source = ref (None) in
+    let field_intermediate_vars = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg "out-of-bounds substring position or length";
+          match len with
+            | 12 -> (
+                if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'n' && String.unsafe_get s (pos+4) = 't' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 's' && String.unsafe_get s (pos+7) = 'o' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 'r' && String.unsafe_get s (pos+10) = 'c' && String.unsafe_get s (pos+11) = 'e' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | 17 -> (
+                if String.unsafe_get s pos = 'i' && String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'm' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'd' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 't' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = '_' && String.unsafe_get s (pos+13) = 'v' && String.unsafe_get s (pos+14) = 'a' && String.unsafe_get s (pos+15) = 'r' && String.unsafe_get s (pos+16) = 's' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_taint_source := (
+                Some (
+                  (
+                    read__3
+                  ) p lb
+                )
+              );
+            )
+          | 1 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_intermediate_vars := (
+                Some (
+                  (
+                    read__3
+                  ) p lb
+                )
+              );
+            )
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg "out-of-bounds substring position or length";
+            match len with
+              | 12 -> (
+                  if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'n' && String.unsafe_get s (pos+4) = 't' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 's' && String.unsafe_get s (pos+7) = 'o' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 'r' && String.unsafe_get s (pos+10) = 'c' && String.unsafe_get s (pos+11) = 'e' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 17 -> (
+                  if String.unsafe_get s pos = 'i' && String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'm' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'd' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 't' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = '_' && String.unsafe_get s (pos+13) = 'v' && String.unsafe_get s (pos+14) = 'a' && String.unsafe_get s (pos+15) = 'r' && String.unsafe_get s (pos+16) = 's' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_taint_source := (
+                  Some (
+                    (
+                      read__3
+                    ) p lb
+                  )
+                );
+              )
+            | 1 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_intermediate_vars := (
+                  Some (
+                    (
+                      read__3
+                    ) p lb
+                  )
+                );
+              )
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            taint_source = !field_taint_source;
+            intermediate_vars = !field_intermediate_vars;
+          }
+         : dataflow_trace)
+      )
+)
+let dataflow_trace_of_string s =
+  read_dataflow_trace (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cve_result : _ -> cve_result -> _ = (
   fun ob (x : cve_result) ->
     Bi_outbuf.add_char ob '{';
@@ -5051,7 +5297,7 @@ let write_cve_result : _ -> cve_result -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"funcnames\":";
     (
-      write__7
+      write__10
     )
       ob x.funcnames;
     Bi_outbuf.add_char ob '}';
@@ -5128,7 +5374,7 @@ let read_cve_result = (
             field_funcnames := (
               Some (
                 (
-                  read__7
+                  read__10
                 ) p lb
               )
             );
@@ -5197,7 +5443,7 @@ let read_cve_result = (
               field_funcnames := (
                 Some (
                   (
-                    read__7
+                    read__10
                   ) p lb
                 )
               );
@@ -5219,9 +5465,37 @@ let read_cve_result = (
 )
 let cve_result_of_string s =
   read_cve_result (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__13 = (
+let write__15 = (
   Atdgen_runtime.Oj_run.write_list (
     write_cve_result
+  )
+)
+let string_of__15 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__15 ob x;
+  Bi_outbuf.contents ob
+let read__15 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_cve_result
+  )
+)
+let _15_of_string s =
+  read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_cve_results = (
+  write__15
+)
+let string_of_cve_results ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_cve_results ob x;
+  Bi_outbuf.contents ob
+let read_cve_results = (
+  read__15
+)
+let cve_results_of_string s =
+  read_cve_results (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__13 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    Yojson.Safe.write_std_float
   )
 )
 let string_of__13 ?(len = 1024) x =
@@ -5229,50 +5503,6 @@ let string_of__13 ?(len = 1024) x =
   write__13 ob x;
   Bi_outbuf.contents ob
 let read__13 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_cve_result
-  )
-)
-let _13_of_string s =
-  read__13 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write_cve_results = (
-  write__13
-)
-let string_of_cve_results ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write_cve_results ob x;
-  Bi_outbuf.contents ob
-let read_cve_results = (
-  read__13
-)
-let cve_results_of_string s =
-  read_cve_results (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__9 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_target_time
-  )
-)
-let string_of__9 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__9 ob x;
-  Bi_outbuf.contents ob
-let read__9 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_target_time
-  )
-)
-let _9_of_string s =
-  read__9 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__11 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    Yojson.Safe.write_std_float
-  )
-)
-let string_of__11 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__11 ob x;
-  Bi_outbuf.contents ob
-let read__11 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -5318,24 +5548,40 @@ let read__11 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _11_of_string s =
-  read__11 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__10 = (
+let _13_of_string s =
+  read__13 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__12 = (
   Atdgen_runtime.Oj_run.write_list (
     write_rule_id
   )
 )
-let string_of__10 ?(len = 1024) x =
+let string_of__12 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__10 ob x;
+  write__12 ob x;
   Bi_outbuf.contents ob
-let read__10 = (
+let read__12 = (
   Atdgen_runtime.Oj_run.read_list (
     read_rule_id
   )
 )
-let _10_of_string s =
-  read__10 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _12_of_string s =
+  read__12 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__11 = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_target_time
+  )
+)
+let string_of__11 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__11 ob x;
+  Bi_outbuf.contents ob
+let read__11 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_target_time
+  )
+)
+let _11_of_string s =
+  read__11 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_timing : _ -> core_timing -> _ = (
   fun ob (x : core_timing) ->
     Bi_outbuf.add_char ob '{';
@@ -5346,7 +5592,7 @@ let write_core_timing : _ -> core_timing -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"targets\":";
     (
-      write__9
+      write__11
     )
       ob x.targets;
     if !is_first then
@@ -5355,7 +5601,7 @@ let write_core_timing : _ -> core_timing -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"rules\":";
     (
-      write__10
+      write__12
     )
       ob x.rules;
     (match x.rules_parse_time with None -> () | Some x ->
@@ -5427,7 +5673,7 @@ let read_core_timing = (
             field_targets := (
               Some (
                 (
-                  read__9
+                  read__11
                 ) p lb
               )
             );
@@ -5435,7 +5681,7 @@ let read_core_timing = (
             field_rules := (
               Some (
                 (
-                  read__10
+                  read__12
                 ) p lb
               )
             );
@@ -5498,7 +5744,7 @@ let read_core_timing = (
               field_targets := (
                 Some (
                   (
-                    read__9
+                    read__11
                   ) p lb
                 )
               );
@@ -5506,7 +5752,7 @@ let read_core_timing = (
               field_rules := (
                 Some (
                   (
-                    read__10
+                    read__12
                   ) p lb
                 )
               );
@@ -5735,6 +5981,63 @@ let read_core_severity = (
 )
 let core_severity_of_string s =
   read_core_severity (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__2 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_dataflow_trace
+  )
+)
+let string_of__2 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__2 ob x;
+  Bi_outbuf.contents ob
+let read__2 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read_dataflow_trace
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read_dataflow_trace
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _2_of_string s =
+  read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_match_extra : _ -> core_match_extra -> _ = (
   fun ob (x : core_match_extra) ->
     Bi_outbuf.add_char ob '{';
@@ -5759,6 +6062,17 @@ let write_core_match_extra : _ -> core_match_extra -> _ = (
       write_metavars
     )
       ob x.metavars;
+    (match x.dataflow_trace with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"dataflow_trace\":";
+      (
+        write_dataflow_trace
+      )
+        ob x;
+    );
     Bi_outbuf.add_char ob '}';
 )
 let string_of_core_match_extra ?(len = 1024) x =
@@ -5771,6 +6085,7 @@ let read_core_match_extra = (
     Yojson.Safe.read_lcurl p lb;
     let field_message = ref (None) in
     let field_metavars = ref (None) in
+    let field_dataflow_trace = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -5791,6 +6106,14 @@ let read_core_match_extra = (
             | 8 -> (
                 if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'v' && String.unsafe_get s (pos+5) = 'a' && String.unsafe_get s (pos+6) = 'r' && String.unsafe_get s (pos+7) = 's' then (
                   1
+                )
+                else (
+                  -1
+                )
+              )
+            | 14 -> (
+                if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'f' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'w' && String.unsafe_get s (pos+8) = '_' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 'a' && String.unsafe_get s (pos+12) = 'c' && String.unsafe_get s (pos+13) = 'e' then (
+                  2
                 )
                 else (
                   -1
@@ -5822,6 +6145,16 @@ let read_core_match_extra = (
                 ) p lb
               )
             );
+          | 2 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_dataflow_trace := (
+                Some (
+                  (
+                    read_dataflow_trace
+                  ) p lb
+                )
+              );
+            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -5846,6 +6179,14 @@ let read_core_match_extra = (
               | 8 -> (
                   if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'v' && String.unsafe_get s (pos+5) = 'a' && String.unsafe_get s (pos+6) = 'r' && String.unsafe_get s (pos+7) = 's' then (
                     1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 14 -> (
+                  if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'f' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'w' && String.unsafe_get s (pos+8) = '_' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 'a' && String.unsafe_get s (pos+12) = 'c' && String.unsafe_get s (pos+13) = 'e' then (
+                    2
                   )
                   else (
                     -1
@@ -5877,6 +6218,16 @@ let read_core_match_extra = (
                   ) p lb
                 )
               );
+            | 2 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_dataflow_trace := (
+                  Some (
+                    (
+                      read_dataflow_trace
+                    ) p lb
+                  )
+                );
+              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -5888,6 +6239,7 @@ let read_core_match_extra = (
           {
             message = !field_message;
             metavars = (match !field_metavars with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "metavars");
+            dataflow_trace = !field_dataflow_trace;
           }
          : core_match_extra)
       )
@@ -6090,22 +6442,6 @@ let read_core_match = (
 )
 let core_match_of_string s =
   read_core_match (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__8 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_location
-  )
-)
-let string_of__8 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__8 ob x;
-  Bi_outbuf.contents ob
-let read__8 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_location
-  )
-)
-let _8_of_string s =
-  read__8 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_error_kind : _ -> core_error_kind -> _ = (
   fun ob x ->
     match x with
@@ -6117,7 +6453,7 @@ let write_core_error_kind : _ -> core_error_kind -> _ = (
       | PatternParseError x ->
         Bi_outbuf.add_string ob "[\"Pattern parse error\",";
         (
-          write__7
+          write__10
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | InvalidYaml -> Bi_outbuf.add_string ob "\"Invalid YAML\""
@@ -6130,7 +6466,7 @@ let write_core_error_kind : _ -> core_error_kind -> _ = (
       | PartialParsing x ->
         Bi_outbuf.add_string ob "[\"PartialParsing\",";
         (
-          write__8
+          write__3
         ) ob x;
         Bi_outbuf.add_char ob ']'
 )
@@ -6167,7 +6503,7 @@ let read_core_error_kind = (
             | "Pattern parse error" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__7
+                  read__10
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -6204,7 +6540,7 @@ let read_core_error_kind = (
             | "PartialParsing" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__8
+                  read__3
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -6249,7 +6585,7 @@ let read_core_error_kind = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__7
+                  read__10
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -6260,7 +6596,7 @@ let read_core_error_kind = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__8
+                  read__3
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -6633,16 +6969,16 @@ let read_core_error = (
 )
 let core_error_of_string s =
   read_core_error (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__19 = (
+let write__21 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_core_timing
   )
 )
-let string_of__19 ?(len = 1024) x =
+let string_of__21 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__19 ob x;
+  write__21 ob x;
   Bi_outbuf.contents ob
-let read__19 = (
+let read__21 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -6688,11 +7024,100 @@ let read__19 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _19_of_string s =
-  read__19 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__17 = (
+let _21_of_string s =
+  read__21 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__19 = (
   Atdgen_runtime.Oj_run.write_list (
     write_skipped_rule
+  )
+)
+let string_of__19 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__19 ob x;
+  Bi_outbuf.contents ob
+let read__19 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_skipped_rule
+  )
+)
+let _19_of_string s =
+  read__19 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__20 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__19
+  )
+)
+let string_of__20 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__20 ob x;
+  Bi_outbuf.contents ob
+let read__20 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__19
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__19
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _20_of_string s =
+  read__20 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__18 = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_skipped_target
+  )
+)
+let string_of__18 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__18 ob x;
+  Bi_outbuf.contents ob
+let read__18 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_skipped_target
+  )
+)
+let _18_of_string s =
+  read__18 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__17 = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_core_error
   )
 )
 let string_of__17 ?(len = 1024) x =
@@ -6701,71 +7126,14 @@ let string_of__17 ?(len = 1024) x =
   Bi_outbuf.contents ob
 let read__17 = (
   Atdgen_runtime.Oj_run.read_list (
-    read_skipped_rule
+    read_core_error
   )
 )
 let _17_of_string s =
   read__17 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__18 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write__17
-  )
-)
-let string_of__18 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__18 ob x;
-  Bi_outbuf.contents ob
-let read__18 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read__17
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read__17
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _18_of_string s =
-  read__18 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__16 = (
   Atdgen_runtime.Oj_run.write_list (
-    write_skipped_target
+    write_core_match
   )
 )
 let string_of__16 ?(len = 1024) x =
@@ -6774,43 +7142,11 @@ let string_of__16 ?(len = 1024) x =
   Bi_outbuf.contents ob
 let read__16 = (
   Atdgen_runtime.Oj_run.read_list (
-    read_skipped_target
+    read_core_match
   )
 )
 let _16_of_string s =
   read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__15 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_core_error
-  )
-)
-let string_of__15 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__15 ob x;
-  Bi_outbuf.contents ob
-let read__15 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_core_error
-  )
-)
-let _15_of_string s =
-  read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__14 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_core_match
-  )
-)
-let string_of__14 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__14 ob x;
-  Bi_outbuf.contents ob
-let read__14 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_core_match
-  )
-)
-let _14_of_string s =
-  read__14 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_match_results : _ -> core_match_results -> _ = (
   fun ob (x : core_match_results) ->
     Bi_outbuf.add_char ob '{';
@@ -6821,7 +7157,7 @@ let write_core_match_results : _ -> core_match_results -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"matches\":";
     (
-      write__14
+      write__16
     )
       ob x.matches;
     if !is_first then
@@ -6830,7 +7166,7 @@ let write_core_match_results : _ -> core_match_results -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"errors\":";
     (
-      write__15
+      write__17
     )
       ob x.errors;
     if !is_first then
@@ -6839,7 +7175,7 @@ let write_core_match_results : _ -> core_match_results -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"skipped\":";
     (
-      write__16
+      write__18
     )
       ob x.skipped_targets;
     (match x.skipped_rules with None -> () | Some x ->
@@ -6849,7 +7185,7 @@ let write_core_match_results : _ -> core_match_results -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"skipped_rules\":";
       (
-        write__17
+        write__19
       )
         ob x;
     );
@@ -6964,7 +7300,7 @@ let read_core_match_results = (
             field_matches := (
               Some (
                 (
-                  read__14
+                  read__16
                 ) p lb
               )
             );
@@ -6972,7 +7308,7 @@ let read_core_match_results = (
             field_errors := (
               Some (
                 (
-                  read__15
+                  read__17
                 ) p lb
               )
             );
@@ -6980,7 +7316,7 @@ let read_core_match_results = (
             field_skipped_targets := (
               Some (
                 (
-                  read__16
+                  read__18
                 ) p lb
               )
             );
@@ -6989,7 +7325,7 @@ let read_core_match_results = (
               field_skipped_rules := (
                 Some (
                   (
-                    read__17
+                    read__19
                   ) p lb
                 )
               );
@@ -7091,7 +7427,7 @@ let read_core_match_results = (
               field_matches := (
                 Some (
                   (
-                    read__14
+                    read__16
                   ) p lb
                 )
               );
@@ -7099,7 +7435,7 @@ let read_core_match_results = (
               field_errors := (
                 Some (
                   (
-                    read__15
+                    read__17
                   ) p lb
                 )
               );
@@ -7107,7 +7443,7 @@ let read_core_match_results = (
               field_skipped_targets := (
                 Some (
                   (
-                    read__16
+                    read__18
                   ) p lb
                 )
               );
@@ -7116,7 +7452,7 @@ let read_core_match_results = (
                 field_skipped_rules := (
                   Some (
                     (
-                      read__17
+                      read__19
                     ) p lb
                   )
                 );
@@ -7160,22 +7496,22 @@ let read_core_match_results = (
 )
 let core_match_results_of_string s =
   read_core_match_results (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__40 = (
+let write__42 = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_std_float
   )
 )
-let string_of__40 ?(len = 1024) x =
+let string_of__42 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__40 ob x;
+  write__42 ob x;
   Bi_outbuf.contents ob
-let read__40 = (
+let read__42 = (
   Atdgen_runtime.Oj_run.read_list (
     Atdgen_runtime.Oj_run.read_number
   )
 )
-let _40_of_string s =
-  read__40 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _42_of_string s =
+  read__42 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_target_times : _ -> cli_target_times -> _ = (
   fun ob (x : cli_target_times) ->
     Bi_outbuf.add_char ob '{';
@@ -7204,7 +7540,7 @@ let write_cli_target_times : _ -> cli_target_times -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"match_times\":";
     (
-      write__40
+      write__42
     )
       ob x.match_times;
     if !is_first then
@@ -7213,7 +7549,7 @@ let write_cli_target_times : _ -> cli_target_times -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"parse_times\":";
     (
-      write__40
+      write__42
     )
       ob x.parse_times;
     if !is_first then
@@ -7323,7 +7659,7 @@ let read_cli_target_times = (
             field_match_times := (
               Some (
                 (
-                  read__40
+                  read__42
                 ) p lb
               )
             );
@@ -7331,7 +7667,7 @@ let read_cli_target_times = (
             field_parse_times := (
               Some (
                 (
-                  read__40
+                  read__42
                 ) p lb
               )
             );
@@ -7430,7 +7766,7 @@ let read_cli_target_times = (
               field_match_times := (
                 Some (
                   (
-                    read__40
+                    read__42
                   ) p lb
                 )
               );
@@ -7438,7 +7774,7 @@ let read_cli_target_times = (
               field_parse_times := (
                 Some (
                   (
-                    read__40
+                    read__42
                   ) p lb
                 )
               );
@@ -7470,9 +7806,45 @@ let read_cli_target_times = (
 )
 let cli_target_times_of_string s =
   read_cli_target_times (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__39 = (
+let write__41 = (
   Atdgen_runtime.Oj_run.write_list (
     write_cli_target_times
+  )
+)
+let string_of__41 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__41 ob x;
+  Bi_outbuf.contents ob
+let read__41 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_cli_target_times
+  )
+)
+let _41_of_string s =
+  read__41 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__40 = (
+  Atdgen_runtime.Oj_run.write_assoc_list (
+    Yojson.Safe.write_string
+  ) (
+    Yojson.Safe.write_std_float
+  )
+)
+let string_of__40 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__40 ob x;
+  Bi_outbuf.contents ob
+let read__40 = (
+  Atdgen_runtime.Oj_run.read_assoc_list (
+    Atdgen_runtime.Oj_run.read_string
+  ) (
+    Atdgen_runtime.Oj_run.read_number
+  )
+)
+let _40_of_string s =
+  read__40 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__39 = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_rule_id_dict
   )
 )
 let string_of__39 ?(len = 1024) x =
@@ -7481,47 +7853,11 @@ let string_of__39 ?(len = 1024) x =
   Bi_outbuf.contents ob
 let read__39 = (
   Atdgen_runtime.Oj_run.read_list (
-    read_cli_target_times
+    read_rule_id_dict
   )
 )
 let _39_of_string s =
   read__39 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__38 = (
-  Atdgen_runtime.Oj_run.write_assoc_list (
-    Yojson.Safe.write_string
-  ) (
-    Yojson.Safe.write_std_float
-  )
-)
-let string_of__38 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__38 ob x;
-  Bi_outbuf.contents ob
-let read__38 = (
-  Atdgen_runtime.Oj_run.read_assoc_list (
-    Atdgen_runtime.Oj_run.read_string
-  ) (
-    Atdgen_runtime.Oj_run.read_number
-  )
-)
-let _38_of_string s =
-  read__38 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__37 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_rule_id_dict
-  )
-)
-let string_of__37 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__37 ob x;
-  Bi_outbuf.contents ob
-let read__37 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_rule_id_dict
-  )
-)
-let _37_of_string s =
-  read__37 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_timing : _ -> cli_timing -> _ = (
   fun ob (x : cli_timing) ->
     Bi_outbuf.add_char ob '{';
@@ -7532,7 +7868,7 @@ let write_cli_timing : _ -> cli_timing -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"rules\":";
     (
-      write__37
+      write__39
     )
       ob x.rules;
     if !is_first then
@@ -7550,7 +7886,7 @@ let write_cli_timing : _ -> cli_timing -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"profiling_times\":";
     (
-      write__38
+      write__40
     )
       ob x.profiling_times;
     if !is_first then
@@ -7559,7 +7895,7 @@ let write_cli_timing : _ -> cli_timing -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"targets\":";
     (
-      write__39
+      write__41
     )
       ob x.targets;
     if !is_first then
@@ -7647,7 +7983,7 @@ let read_cli_timing = (
             field_rules := (
               Some (
                 (
-                  read__37
+                  read__39
                 ) p lb
               )
             );
@@ -7663,7 +7999,7 @@ let read_cli_timing = (
             field_profiling_times := (
               Some (
                 (
-                  read__38
+                  read__40
                 ) p lb
               )
             );
@@ -7671,7 +8007,7 @@ let read_cli_timing = (
             field_targets := (
               Some (
                 (
-                  read__39
+                  read__41
                 ) p lb
               )
             );
@@ -7748,7 +8084,7 @@ let read_cli_timing = (
               field_rules := (
                 Some (
                   (
-                    read__37
+                    read__39
                   ) p lb
                 )
               );
@@ -7764,7 +8100,7 @@ let read_cli_timing = (
               field_profiling_times := (
                 Some (
                   (
-                    read__38
+                    read__40
                   ) p lb
                 )
               );
@@ -7772,7 +8108,7 @@ let read_cli_timing = (
               field_targets := (
                 Some (
                   (
-                    read__39
+                    read__41
                   ) p lb
                 )
               );
@@ -7957,32 +8293,32 @@ let read_cli_skipped_target = (
 )
 let cli_skipped_target_of_string s =
   read_cli_skipped_target (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__35 = (
+let write__37 = (
   Atdgen_runtime.Oj_run.write_list (
     write_cli_skipped_target
   )
 )
-let string_of__35 ?(len = 1024) x =
+let string_of__37 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__35 ob x;
+  write__37 ob x;
   Bi_outbuf.contents ob
-let read__35 = (
+let read__37 = (
   Atdgen_runtime.Oj_run.read_list (
     read_cli_skipped_target
   )
 )
-let _35_of_string s =
-  read__35 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__36 = (
+let _37_of_string s =
+  read__37 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__38 = (
   Atdgen_runtime.Oj_run.write_std_option (
-    write__35
+    write__37
   )
 )
-let string_of__36 ?(len = 1024) x =
+let string_of__38 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__36 ob x;
+  write__38 ob x;
   Bi_outbuf.contents ob
-let read__36 = (
+let read__38 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -7995,7 +8331,7 @@ let read__36 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__35
+                  read__37
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -8018,7 +8354,7 @@ let read__36 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__35
+                  read__37
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -8028,8 +8364,8 @@ let read__36 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _36_of_string s =
-  read__36 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _38_of_string s =
+  read__38 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_paths : _ -> cli_paths -> _ = (
   fun ob (x : cli_paths) ->
     Bi_outbuf.add_char ob '{';
@@ -8040,7 +8376,7 @@ let write_cli_paths : _ -> cli_paths -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"scanned\":";
     (
-      write__7
+      write__10
     )
       ob x.scanned;
     (match x._comment with None -> () | Some x ->
@@ -8061,7 +8397,7 @@ let write_cli_paths : _ -> cli_paths -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"skipped\":";
       (
-        write__35
+        write__37
       )
         ob x;
     );
@@ -8134,7 +8470,7 @@ let read_cli_paths = (
             field_scanned := (
               Some (
                 (
-                  read__7
+                  read__10
                 ) p lb
               )
             );
@@ -8153,7 +8489,7 @@ let read_cli_paths = (
               field_skipped := (
                 Some (
                   (
-                    read__35
+                    read__37
                   ) p lb
                 )
               );
@@ -8218,7 +8554,7 @@ let read_cli_paths = (
               field_scanned := (
                 Some (
                   (
-                    read__7
+                    read__10
                   ) p lb
                 )
               );
@@ -8237,7 +8573,7 @@ let read_cli_paths = (
                 field_skipped := (
                   Some (
                     (
-                      read__35
+                      read__37
                     ) p lb
                   )
                 );
@@ -8260,16 +8596,16 @@ let read_cli_paths = (
 )
 let cli_paths_of_string s =
   read_cli_paths (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__34 = (
+let write__36 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_cli_timing
   )
 )
-let string_of__34 ?(len = 1024) x =
+let string_of__36 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__34 ob x;
+  write__36 ob x;
   Bi_outbuf.contents ob
-let read__34 = (
+let read__36 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -8315,8 +8651,8 @@ let read__34 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _34_of_string s =
-  read__34 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _36_of_string s =
+  read__36 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_output_extra : _ -> cli_output_extra -> _ = (
   fun ob (x : cli_output_extra) ->
     Bi_outbuf.add_char ob '{';
@@ -8476,9 +8812,123 @@ let read_cli_output_extra = (
 )
 let cli_output_extra_of_string s =
   read_cli_output_extra (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__29 = (
+let write__31 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_raw_json
+  )
+)
+let string_of__31 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__31 ob x;
+  Bi_outbuf.contents ob
+let read__31 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read_raw_json
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read_raw_json
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _31_of_string s =
+  read__31 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__30 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    Yojson.Safe.write_bool
+  )
+)
+let string_of__30 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__30 ob x;
+  Bi_outbuf.contents ob
+let read__30 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  Atdgen_runtime.Oj_run.read_bool
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _30_of_string s =
+  read__30 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__29 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_fix_regex
   )
 )
 let string_of__29 ?(len = 1024) x =
@@ -8498,7 +8948,7 @@ let read__29 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read_raw_json
+                  read_fix_regex
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -8521,7 +8971,7 @@ let read__29 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read_raw_json
+                  read_fix_regex
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -8535,7 +8985,7 @@ let _29_of_string s =
   read__29 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__28 = (
   Atdgen_runtime.Oj_run.write_std_option (
-    Yojson.Safe.write_bool
+    write_metavars
   )
 )
 let string_of__28 ?(len = 1024) x =
@@ -8555,7 +9005,7 @@ let read__28 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  Atdgen_runtime.Oj_run.read_bool
+                  read_metavars
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -8578,7 +9028,7 @@ let read__28 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  Atdgen_runtime.Oj_run.read_bool
+                  read_metavars
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -8590,120 +9040,6 @@ let read__28 = (
 )
 let _28_of_string s =
   read__28 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__27 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_fix_regex
-  )
-)
-let string_of__27 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__27 ob x;
-  Bi_outbuf.contents ob
-let read__27 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read_fix_regex
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read_fix_regex
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _27_of_string s =
-  read__27 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__26 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_metavars
-  )
-)
-let string_of__26 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__26 ob x;
-  Bi_outbuf.contents ob
-let read__26 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    match Yojson.Safe.start_any_variant p lb with
-      | `Edgy_bracket -> (
-          match Yojson.Safe.read_ident p lb with
-            | "None" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (None : _ option)
-            | "Some" ->
-              Atdgen_runtime.Oj_run.read_until_field_value p lb;
-              let x = (
-                  read_metavars
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_gt p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Double_quote -> (
-          match Yojson.Safe.finish_string p lb with
-            | "None" ->
-              (None : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-      | `Square_bracket -> (
-          match Atdgen_runtime.Oj_run.read_string p lb with
-            | "Some" ->
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_comma p lb;
-              Yojson.Safe.read_space p lb;
-              let x = (
-                  read_metavars
-                ) p lb
-              in
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_rbr p lb;
-              (Some x : _ option)
-            | x ->
-              Atdgen_runtime.Oj_run.invalid_variant_tag p x
-        )
-)
-let _26_of_string s =
-  read__26 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_match_extra : _ -> cli_match_extra -> _ = (
   fun ob (x : cli_match_extra) ->
     Bi_outbuf.add_char ob '{';
@@ -8826,7 +9162,18 @@ let write_cli_match_extra : _ -> cli_match_extra -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"fixed_lines\":";
       (
-        write__7
+        write__10
+      )
+        ob x;
+    );
+    (match x.dataflow_trace with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"dataflow_trace\":";
+      (
+        write_dataflow_trace
       )
         ob x;
     );
@@ -8852,6 +9199,7 @@ let read_cli_match_extra = (
     let field_dependency_match_only = ref (None) in
     let field_dependency_matches = ref (None) in
     let field_fixed_lines = ref (None) in
+    let field_dataflow_trace = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -8964,6 +9312,14 @@ let read_cli_match_extra = (
                     | _ -> (
                         -1
                       )
+                )
+                else (
+                  -1
+                )
+              )
+            | 14 -> (
+                if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'f' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'w' && String.unsafe_get s (pos+8) = '_' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 'a' && String.unsafe_get s (pos+12) = 'c' && String.unsafe_get s (pos+13) = 'e' then (
+                  12
                 )
                 else (
                   -1
@@ -9098,7 +9454,17 @@ let read_cli_match_extra = (
               field_fixed_lines := (
                 Some (
                   (
-                    read__7
+                    read__10
+                  ) p lb
+                )
+              );
+            )
+          | 12 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_dataflow_trace := (
+                Some (
+                  (
+                    read_dataflow_trace
                   ) p lb
                 )
               );
@@ -9219,6 +9585,14 @@ let read_cli_match_extra = (
                       | _ -> (
                           -1
                         )
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 14 -> (
+                  if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'f' && String.unsafe_get s (pos+5) = 'l' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'w' && String.unsafe_get s (pos+8) = '_' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 'a' && String.unsafe_get s (pos+12) = 'c' && String.unsafe_get s (pos+13) = 'e' then (
+                    12
                   )
                   else (
                     -1
@@ -9353,7 +9727,17 @@ let read_cli_match_extra = (
                 field_fixed_lines := (
                   Some (
                     (
-                      read__7
+                      read__10
+                    ) p lb
+                  )
+                );
+              )
+            | 12 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_dataflow_trace := (
+                  Some (
+                    (
+                      read_dataflow_trace
                     ) p lb
                   )
                 );
@@ -9379,6 +9763,7 @@ let read_cli_match_extra = (
             dependency_match_only = !field_dependency_match_only;
             dependency_matches = !field_dependency_matches;
             fixed_lines = !field_fixed_lines;
+            dataflow_trace = !field_dataflow_trace;
           }
          : cli_match_extra)
       )
@@ -9679,32 +10064,32 @@ let read_cli_match = (
 )
 let cli_match_of_string s =
   read_cli_match (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__20 = (
+let write__22 = (
   Atdgen_runtime.Oj_run.write_list (
     write_error_span
   )
 )
-let string_of__20 ?(len = 1024) x =
+let string_of__22 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__20 ob x;
+  write__22 ob x;
   Bi_outbuf.contents ob
-let read__20 = (
+let read__22 = (
   Atdgen_runtime.Oj_run.read_list (
     read_error_span
   )
 )
-let _20_of_string s =
-  read__20 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__21 = (
+let _22_of_string s =
+  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__23 = (
   Atdgen_runtime.Oj_run.write_std_option (
-    write__20
+    write__22
   )
 )
-let string_of__21 ?(len = 1024) x =
+let string_of__23 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__21 ob x;
+  write__23 ob x;
   Bi_outbuf.contents ob
-let read__21 = (
+let read__23 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -9717,7 +10102,7 @@ let read__21 = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__20
+                  read__22
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -9740,7 +10125,7 @@ let read__21 = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__20
+                  read__22
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -9750,8 +10135,8 @@ let read__21 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _21_of_string s =
-  read__21 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _23_of_string s =
+  read__23 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_error : _ -> cli_error -> _ = (
   fun ob (x : cli_error) ->
     Bi_outbuf.add_char ob '{';
@@ -9845,7 +10230,7 @@ let write_cli_error : _ -> cli_error -> _ = (
         Bi_outbuf.add_char ob ',';
       Bi_outbuf.add_string ob "\"spans\":";
       (
-        write__20
+        write__22
       )
         ob x;
     );
@@ -10074,7 +10459,7 @@ let read_cli_error = (
               field_spans := (
                 Some (
                   (
-                    read__20
+                    read__22
                   ) p lb
                 )
               );
@@ -10287,7 +10672,7 @@ let read_cli_error = (
                 field_spans := (
                   Some (
                     (
-                      read__20
+                      read__22
                     ) p lb
                   )
                 );
@@ -10327,9 +10712,41 @@ let read_cli_error = (
 )
 let cli_error_of_string s =
   read_cli_error (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__33 = (
+let write__35 = (
   Atdgen_runtime.Oj_run.write_list (
     write_cli_match
+  )
+)
+let string_of__35 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__35 ob x;
+  Bi_outbuf.contents ob
+let read__35 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_cli_match
+  )
+)
+let _35_of_string s =
+  read__35 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__34 = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_cli_error
+  )
+)
+let string_of__34 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__34 ob x;
+  Bi_outbuf.contents ob
+let read__34 = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_cli_error
+  )
+)
+let _34_of_string s =
+  read__34 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__33 = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_semver
   )
 )
 let string_of__33 ?(len = 1024) x =
@@ -10337,38 +10754,6 @@ let string_of__33 ?(len = 1024) x =
   write__33 ob x;
   Bi_outbuf.contents ob
 let read__33 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_cli_match
-  )
-)
-let _33_of_string s =
-  read__33 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__32 = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_cli_error
-  )
-)
-let string_of__32 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__32 ob x;
-  Bi_outbuf.contents ob
-let read__32 = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_cli_error
-  )
-)
-let _32_of_string s =
-  read__32 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__31 = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_semver
-  )
-)
-let string_of__31 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__31 ob x;
-  Bi_outbuf.contents ob
-let read__31 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -10414,8 +10799,8 @@ let read__31 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _31_of_string s =
-  read__31 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _33_of_string s =
+  read__33 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cli_output : _ -> cli_output -> _ = (
   fun ob (x : cli_output) ->
     Bi_outbuf.add_char ob '{';
@@ -10437,7 +10822,7 @@ let write_cli_output : _ -> cli_output -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"errors\":";
     (
-      write__32
+      write__34
     )
       ob x.errors;
     if !is_first then
@@ -10446,7 +10831,7 @@ let write_cli_output : _ -> cli_output -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"results\":";
     (
-      write__33
+      write__35
     )
       ob x.results;
     if !is_first then
@@ -10561,7 +10946,7 @@ let read_cli_output = (
             field_errors := (
               Some (
                 (
-                  read__32
+                  read__34
                 ) p lb
               )
             );
@@ -10569,7 +10954,7 @@ let read_cli_output = (
             field_results := (
               Some (
                 (
-                  read__33
+                  read__35
                 ) p lb
               )
             );
@@ -10672,7 +11057,7 @@ let read_cli_output = (
               field_errors := (
                 Some (
                   (
-                    read__32
+                    read__34
                   ) p lb
                 )
               );
@@ -10680,7 +11065,7 @@ let read_cli_output = (
               field_results := (
                 Some (
                   (
-                    read__33
+                    read__35
                   ) p lb
                 )
               );
@@ -10722,16 +11107,16 @@ let read_cli_output = (
 )
 let cli_output_of_string s =
   read_cli_output (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__42 = (
+let write__44 = (
   Atdgen_runtime.Oj_run.write_nullable (
     Yojson.Safe.write_string
   )
 )
-let string_of__42 ?(len = 1024) x =
+let string_of__44 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__42 ob x;
+  write__44 ob x;
   Bi_outbuf.contents ob
-let read__42 = (
+let read__44 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     (if Yojson.Safe.read_null_if_possible p lb then None
@@ -10739,24 +11124,24 @@ let read__42 = (
       Atdgen_runtime.Oj_run.read_string
     ) p lb) : _ option)
 )
-let _42_of_string s =
-  read__42 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__41 = (
+let _44_of_string s =
+  read__44 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__43 = (
   Atdgen_runtime.Oj_run.write_list (
     write_finding
   )
 )
-let string_of__41 ?(len = 1024) x =
+let string_of__43 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__41 ob x;
+  write__43 ob x;
   Bi_outbuf.contents ob
-let read__41 = (
+let read__43 = (
   Atdgen_runtime.Oj_run.read_list (
     read_finding
   )
 )
-let _41_of_string s =
-  read__41 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _43_of_string s =
+  read__43 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_api_scans_findings : _ -> api_scans_findings -> _ = (
   fun ob (x : api_scans_findings) ->
     Bi_outbuf.add_char ob '{';
@@ -10767,7 +11152,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"findings\":";
     (
-      write__41
+      write__43
     )
       ob x.findings;
     if !is_first then
@@ -10776,7 +11161,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"token\":";
     (
-      write__42
+      write__44
     )
       ob x.token;
     if !is_first then
@@ -10785,7 +11170,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"gitlab_token\":";
     (
-      write__42
+      write__44
     )
       ob x.gitlab_token;
     if !is_first then
@@ -10794,7 +11179,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"searched_paths\":";
     (
-      write__7
+      write__10
     )
       ob x.searched_paths;
     if !is_first then
@@ -10803,7 +11188,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"rule_ids\":";
     (
-      write__7
+      write__10
     )
       ob x.rule_ids;
     if !is_first then
@@ -10812,7 +11197,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"cai_ids\":";
     (
-      write__7
+      write__10
     )
       ob x.cai_ids;
     Bi_outbuf.add_char ob '}';
@@ -10906,7 +11291,7 @@ let read_api_scans_findings = (
             field_findings := (
               Some (
                 (
-                  read__41
+                  read__43
                 ) p lb
               )
             );
@@ -10914,7 +11299,7 @@ let read_api_scans_findings = (
             field_token := (
               Some (
                 (
-                  read__42
+                  read__44
                 ) p lb
               )
             );
@@ -10922,7 +11307,7 @@ let read_api_scans_findings = (
             field_gitlab_token := (
               Some (
                 (
-                  read__42
+                  read__44
                 ) p lb
               )
             );
@@ -10930,7 +11315,7 @@ let read_api_scans_findings = (
             field_searched_paths := (
               Some (
                 (
-                  read__7
+                  read__10
                 ) p lb
               )
             );
@@ -10938,7 +11323,7 @@ let read_api_scans_findings = (
             field_rule_ids := (
               Some (
                 (
-                  read__7
+                  read__10
                 ) p lb
               )
             );
@@ -10946,7 +11331,7 @@ let read_api_scans_findings = (
             field_cai_ids := (
               Some (
                 (
-                  read__7
+                  read__10
                 ) p lb
               )
             );
@@ -11029,7 +11414,7 @@ let read_api_scans_findings = (
               field_findings := (
                 Some (
                   (
-                    read__41
+                    read__43
                   ) p lb
                 )
               );
@@ -11037,7 +11422,7 @@ let read_api_scans_findings = (
               field_token := (
                 Some (
                   (
-                    read__42
+                    read__44
                   ) p lb
                 )
               );
@@ -11045,7 +11430,7 @@ let read_api_scans_findings = (
               field_gitlab_token := (
                 Some (
                   (
-                    read__42
+                    read__44
                   ) p lb
                 )
               );
@@ -11053,7 +11438,7 @@ let read_api_scans_findings = (
               field_searched_paths := (
                 Some (
                   (
-                    read__7
+                    read__10
                   ) p lb
                 )
               );
@@ -11061,7 +11446,7 @@ let read_api_scans_findings = (
               field_rule_ids := (
                 Some (
                   (
-                    read__7
+                    read__10
                   ) p lb
                 )
               );
@@ -11069,7 +11454,7 @@ let read_api_scans_findings = (
               field_cai_ids := (
                 Some (
                   (
-                    read__7
+                    read__10
                   ) p lb
                 )
               );

--- a/semgrep_output_v0_j.mli
+++ b/semgrep_output_v0_j.mli
@@ -138,6 +138,12 @@ type error_span = Semgrep_output_v0_t.error_span = {
 }
   [@@deriving show]
 
+type dataflow_trace = Semgrep_output_v0_t.dataflow_trace = {
+  taint_source: location list option;
+  intermediate_vars: location list option
+}
+  [@@deriving show]
+
 type cve_result = Semgrep_output_v0_t.cve_result = {
   url: string;
   filename: string;
@@ -165,7 +171,8 @@ type core_severity = Semgrep_output_v0_t.core_severity =  Error | Warning
 
 type core_match_extra = Semgrep_output_v0_t.core_match_extra = {
   message: string option;
-  metavars: metavars
+  metavars: metavars;
+  dataflow_trace: dataflow_trace option
 }
   [@@deriving show]
 
@@ -263,7 +270,8 @@ type cli_match_extra = Semgrep_output_v0_t.cli_match_extra = {
   is_ignored: bool option;
   dependency_match_only: bool option;
   dependency_matches: raw_json option;
-  fixed_lines: string list option
+  fixed_lines: string list option;
+  dataflow_trace: dataflow_trace option
 }
   [@@deriving show]
 
@@ -311,11 +319,11 @@ type api_scans_findings = Semgrep_output_v0_t.api_scans_findings = {
 
 val write_unique_id_type :
   Bi_outbuf.t -> unique_id_type -> unit
-  (** Output a JSON value of type {!unique_id_type}. *)
+  (** Output a JSON value of type {!type:unique_id_type}. *)
 
 val string_of_unique_id_type :
   ?len:int -> unique_id_type -> string
-  (** Serialize a value of type {!unique_id_type}
+  (** Serialize a value of type {!type:unique_id_type}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -323,19 +331,19 @@ val string_of_unique_id_type :
 
 val read_unique_id_type :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> unique_id_type
-  (** Input JSON data of type {!unique_id_type}. *)
+  (** Input JSON data of type {!type:unique_id_type}. *)
 
 val unique_id_type_of_string :
   string -> unique_id_type
-  (** Deserialize JSON data of type {!unique_id_type}. *)
+  (** Deserialize JSON data of type {!type:unique_id_type}. *)
 
 val write_unique_id :
   Bi_outbuf.t -> unique_id -> unit
-  (** Output a JSON value of type {!unique_id}. *)
+  (** Output a JSON value of type {!type:unique_id}. *)
 
 val string_of_unique_id :
   ?len:int -> unique_id -> string
-  (** Serialize a value of type {!unique_id}
+  (** Serialize a value of type {!type:unique_id}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -343,19 +351,19 @@ val string_of_unique_id :
 
 val read_unique_id :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> unique_id
-  (** Input JSON data of type {!unique_id}. *)
+  (** Input JSON data of type {!type:unique_id}. *)
 
 val unique_id_of_string :
   string -> unique_id
-  (** Deserialize JSON data of type {!unique_id}. *)
+  (** Deserialize JSON data of type {!type:unique_id}. *)
 
 val write_rule_id :
   Bi_outbuf.t -> rule_id -> unit
-  (** Output a JSON value of type {!rule_id}. *)
+  (** Output a JSON value of type {!type:rule_id}. *)
 
 val string_of_rule_id :
   ?len:int -> rule_id -> string
-  (** Serialize a value of type {!rule_id}
+  (** Serialize a value of type {!type:rule_id}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -363,19 +371,19 @@ val string_of_rule_id :
 
 val read_rule_id :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> rule_id
-  (** Input JSON data of type {!rule_id}. *)
+  (** Input JSON data of type {!type:rule_id}. *)
 
 val rule_id_of_string :
   string -> rule_id
-  (** Deserialize JSON data of type {!rule_id}. *)
+  (** Deserialize JSON data of type {!type:rule_id}. *)
 
 val write_rule_times :
   Bi_outbuf.t -> rule_times -> unit
-  (** Output a JSON value of type {!rule_times}. *)
+  (** Output a JSON value of type {!type:rule_times}. *)
 
 val string_of_rule_times :
   ?len:int -> rule_times -> string
-  (** Serialize a value of type {!rule_times}
+  (** Serialize a value of type {!type:rule_times}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -383,19 +391,19 @@ val string_of_rule_times :
 
 val read_rule_times :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> rule_times
-  (** Input JSON data of type {!rule_times}. *)
+  (** Input JSON data of type {!type:rule_times}. *)
 
 val rule_times_of_string :
   string -> rule_times
-  (** Deserialize JSON data of type {!rule_times}. *)
+  (** Deserialize JSON data of type {!type:rule_times}. *)
 
 val write_target_time :
   Bi_outbuf.t -> target_time -> unit
-  (** Output a JSON value of type {!target_time}. *)
+  (** Output a JSON value of type {!type:target_time}. *)
 
 val string_of_target_time :
   ?len:int -> target_time -> string
-  (** Serialize a value of type {!target_time}
+  (** Serialize a value of type {!type:target_time}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -403,19 +411,19 @@ val string_of_target_time :
 
 val read_target_time :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> target_time
-  (** Input JSON data of type {!target_time}. *)
+  (** Input JSON data of type {!type:target_time}. *)
 
 val target_time_of_string :
   string -> target_time
-  (** Deserialize JSON data of type {!target_time}. *)
+  (** Deserialize JSON data of type {!type:target_time}. *)
 
 val write_position :
   Bi_outbuf.t -> position -> unit
-  (** Output a JSON value of type {!position}. *)
+  (** Output a JSON value of type {!type:position}. *)
 
 val string_of_position :
   ?len:int -> position -> string
-  (** Serialize a value of type {!position}
+  (** Serialize a value of type {!type:position}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -423,19 +431,19 @@ val string_of_position :
 
 val read_position :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> position
-  (** Input JSON data of type {!position}. *)
+  (** Input JSON data of type {!type:position}. *)
 
 val position_of_string :
   string -> position
-  (** Deserialize JSON data of type {!position}. *)
+  (** Deserialize JSON data of type {!type:position}. *)
 
 val write_svalue_value :
   Bi_outbuf.t -> svalue_value -> unit
-  (** Output a JSON value of type {!svalue_value}. *)
+  (** Output a JSON value of type {!type:svalue_value}. *)
 
 val string_of_svalue_value :
   ?len:int -> svalue_value -> string
-  (** Serialize a value of type {!svalue_value}
+  (** Serialize a value of type {!type:svalue_value}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -443,19 +451,19 @@ val string_of_svalue_value :
 
 val read_svalue_value :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> svalue_value
-  (** Input JSON data of type {!svalue_value}. *)
+  (** Input JSON data of type {!type:svalue_value}. *)
 
 val svalue_value_of_string :
   string -> svalue_value
-  (** Deserialize JSON data of type {!svalue_value}. *)
+  (** Deserialize JSON data of type {!type:svalue_value}. *)
 
 val write_skip_reason :
   Bi_outbuf.t -> skip_reason -> unit
-  (** Output a JSON value of type {!skip_reason}. *)
+  (** Output a JSON value of type {!type:skip_reason}. *)
 
 val string_of_skip_reason :
   ?len:int -> skip_reason -> string
-  (** Serialize a value of type {!skip_reason}
+  (** Serialize a value of type {!type:skip_reason}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -463,19 +471,19 @@ val string_of_skip_reason :
 
 val read_skip_reason :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> skip_reason
-  (** Input JSON data of type {!skip_reason}. *)
+  (** Input JSON data of type {!type:skip_reason}. *)
 
 val skip_reason_of_string :
   string -> skip_reason
-  (** Deserialize JSON data of type {!skip_reason}. *)
+  (** Deserialize JSON data of type {!type:skip_reason}. *)
 
 val write_skipped_target :
   Bi_outbuf.t -> skipped_target -> unit
-  (** Output a JSON value of type {!skipped_target}. *)
+  (** Output a JSON value of type {!type:skipped_target}. *)
 
 val string_of_skipped_target :
   ?len:int -> skipped_target -> string
-  (** Serialize a value of type {!skipped_target}
+  (** Serialize a value of type {!type:skipped_target}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -483,19 +491,19 @@ val string_of_skipped_target :
 
 val read_skipped_target :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> skipped_target
-  (** Input JSON data of type {!skipped_target}. *)
+  (** Input JSON data of type {!type:skipped_target}. *)
 
 val skipped_target_of_string :
   string -> skipped_target
-  (** Deserialize JSON data of type {!skipped_target}. *)
+  (** Deserialize JSON data of type {!type:skipped_target}. *)
 
 val write_skipped_rule :
   Bi_outbuf.t -> skipped_rule -> unit
-  (** Output a JSON value of type {!skipped_rule}. *)
+  (** Output a JSON value of type {!type:skipped_rule}. *)
 
 val string_of_skipped_rule :
   ?len:int -> skipped_rule -> string
-  (** Serialize a value of type {!skipped_rule}
+  (** Serialize a value of type {!type:skipped_rule}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -503,19 +511,19 @@ val string_of_skipped_rule :
 
 val read_skipped_rule :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> skipped_rule
-  (** Input JSON data of type {!skipped_rule}. *)
+  (** Input JSON data of type {!type:skipped_rule}. *)
 
 val skipped_rule_of_string :
   string -> skipped_rule
-  (** Deserialize JSON data of type {!skipped_rule}. *)
+  (** Deserialize JSON data of type {!type:skipped_rule}. *)
 
 val write_semver :
   Bi_outbuf.t -> semver -> unit
-  (** Output a JSON value of type {!semver}. *)
+  (** Output a JSON value of type {!type:semver}. *)
 
 val string_of_semver :
   ?len:int -> semver -> string
-  (** Serialize a value of type {!semver}
+  (** Serialize a value of type {!type:semver}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -523,19 +531,19 @@ val string_of_semver :
 
 val read_semver :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> semver
-  (** Input JSON data of type {!semver}. *)
+  (** Input JSON data of type {!type:semver}. *)
 
 val semver_of_string :
   string -> semver
-  (** Deserialize JSON data of type {!semver}. *)
+  (** Deserialize JSON data of type {!type:semver}. *)
 
 val write_raw_json :
   Bi_outbuf.t -> raw_json -> unit
-  (** Output a JSON value of type {!raw_json}. *)
+  (** Output a JSON value of type {!type:raw_json}. *)
 
 val string_of_raw_json :
   ?len:int -> raw_json -> string
-  (** Serialize a value of type {!raw_json}
+  (** Serialize a value of type {!type:raw_json}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -543,19 +551,19 @@ val string_of_raw_json :
 
 val read_raw_json :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> raw_json
-  (** Input JSON data of type {!raw_json}. *)
+  (** Input JSON data of type {!type:raw_json}. *)
 
 val raw_json_of_string :
   string -> raw_json
-  (** Deserialize JSON data of type {!raw_json}. *)
+  (** Deserialize JSON data of type {!type:raw_json}. *)
 
 val write_sca_info :
   Bi_outbuf.t -> sca_info -> unit
-  (** Output a JSON value of type {!sca_info}. *)
+  (** Output a JSON value of type {!type:sca_info}. *)
 
 val string_of_sca_info :
   ?len:int -> sca_info -> string
-  (** Serialize a value of type {!sca_info}
+  (** Serialize a value of type {!type:sca_info}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -563,19 +571,19 @@ val string_of_sca_info :
 
 val read_sca_info :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> sca_info
-  (** Input JSON data of type {!sca_info}. *)
+  (** Input JSON data of type {!type:sca_info}. *)
 
 val sca_info_of_string :
   string -> sca_info
-  (** Deserialize JSON data of type {!sca_info}. *)
+  (** Deserialize JSON data of type {!type:sca_info}. *)
 
 val write_rule_id_dict :
   Bi_outbuf.t -> rule_id_dict -> unit
-  (** Output a JSON value of type {!rule_id_dict}. *)
+  (** Output a JSON value of type {!type:rule_id_dict}. *)
 
 val string_of_rule_id_dict :
   ?len:int -> rule_id_dict -> string
-  (** Serialize a value of type {!rule_id_dict}
+  (** Serialize a value of type {!type:rule_id_dict}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -583,19 +591,19 @@ val string_of_rule_id_dict :
 
 val read_rule_id_dict :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> rule_id_dict
-  (** Input JSON data of type {!rule_id_dict}. *)
+  (** Input JSON data of type {!type:rule_id_dict}. *)
 
 val rule_id_dict_of_string :
   string -> rule_id_dict
-  (** Deserialize JSON data of type {!rule_id_dict}. *)
+  (** Deserialize JSON data of type {!type:rule_id_dict}. *)
 
 val write_position_bis :
   Bi_outbuf.t -> position_bis -> unit
-  (** Output a JSON value of type {!position_bis}. *)
+  (** Output a JSON value of type {!type:position_bis}. *)
 
 val string_of_position_bis :
   ?len:int -> position_bis -> string
-  (** Serialize a value of type {!position_bis}
+  (** Serialize a value of type {!type:position_bis}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -603,19 +611,19 @@ val string_of_position_bis :
 
 val read_position_bis :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> position_bis
-  (** Input JSON data of type {!position_bis}. *)
+  (** Input JSON data of type {!type:position_bis}. *)
 
 val position_bis_of_string :
   string -> position_bis
-  (** Deserialize JSON data of type {!position_bis}. *)
+  (** Deserialize JSON data of type {!type:position_bis}. *)
 
 val write_metavar_value :
   Bi_outbuf.t -> metavar_value -> unit
-  (** Output a JSON value of type {!metavar_value}. *)
+  (** Output a JSON value of type {!type:metavar_value}. *)
 
 val string_of_metavar_value :
   ?len:int -> metavar_value -> string
-  (** Serialize a value of type {!metavar_value}
+  (** Serialize a value of type {!type:metavar_value}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -623,19 +631,19 @@ val string_of_metavar_value :
 
 val read_metavar_value :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> metavar_value
-  (** Input JSON data of type {!metavar_value}. *)
+  (** Input JSON data of type {!type:metavar_value}. *)
 
 val metavar_value_of_string :
   string -> metavar_value
-  (** Deserialize JSON data of type {!metavar_value}. *)
+  (** Deserialize JSON data of type {!type:metavar_value}. *)
 
 val write_metavars :
   Bi_outbuf.t -> metavars -> unit
-  (** Output a JSON value of type {!metavars}. *)
+  (** Output a JSON value of type {!type:metavars}. *)
 
 val string_of_metavars :
   ?len:int -> metavars -> string
-  (** Serialize a value of type {!metavars}
+  (** Serialize a value of type {!type:metavars}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -643,19 +651,19 @@ val string_of_metavars :
 
 val read_metavars :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> metavars
-  (** Input JSON data of type {!metavars}. *)
+  (** Input JSON data of type {!type:metavars}. *)
 
 val metavars_of_string :
   string -> metavars
-  (** Deserialize JSON data of type {!metavars}. *)
+  (** Deserialize JSON data of type {!type:metavars}. *)
 
 val write_location :
   Bi_outbuf.t -> location -> unit
-  (** Output a JSON value of type {!location}. *)
+  (** Output a JSON value of type {!type:location}. *)
 
 val string_of_location :
   ?len:int -> location -> string
-  (** Serialize a value of type {!location}
+  (** Serialize a value of type {!type:location}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -663,19 +671,19 @@ val string_of_location :
 
 val read_location :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> location
-  (** Input JSON data of type {!location}. *)
+  (** Input JSON data of type {!type:location}. *)
 
 val location_of_string :
   string -> location
-  (** Deserialize JSON data of type {!location}. *)
+  (** Deserialize JSON data of type {!type:location}. *)
 
 val write_fix_regex :
   Bi_outbuf.t -> fix_regex -> unit
-  (** Output a JSON value of type {!fix_regex}. *)
+  (** Output a JSON value of type {!type:fix_regex}. *)
 
 val string_of_fix_regex :
   ?len:int -> fix_regex -> string
-  (** Serialize a value of type {!fix_regex}
+  (** Serialize a value of type {!type:fix_regex}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -683,19 +691,19 @@ val string_of_fix_regex :
 
 val read_fix_regex :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> fix_regex
-  (** Input JSON data of type {!fix_regex}. *)
+  (** Input JSON data of type {!type:fix_regex}. *)
 
 val fix_regex_of_string :
   string -> fix_regex
-  (** Deserialize JSON data of type {!fix_regex}. *)
+  (** Deserialize JSON data of type {!type:fix_regex}. *)
 
 val write_finding :
   Bi_outbuf.t -> finding -> unit
-  (** Output a JSON value of type {!finding}. *)
+  (** Output a JSON value of type {!type:finding}. *)
 
 val string_of_finding :
   ?len:int -> finding -> string
-  (** Serialize a value of type {!finding}
+  (** Serialize a value of type {!type:finding}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -703,19 +711,19 @@ val string_of_finding :
 
 val read_finding :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> finding
-  (** Input JSON data of type {!finding}. *)
+  (** Input JSON data of type {!type:finding}. *)
 
 val finding_of_string :
   string -> finding
-  (** Deserialize JSON data of type {!finding}. *)
+  (** Deserialize JSON data of type {!type:finding}. *)
 
 val write_error_span :
   Bi_outbuf.t -> error_span -> unit
-  (** Output a JSON value of type {!error_span}. *)
+  (** Output a JSON value of type {!type:error_span}. *)
 
 val string_of_error_span :
   ?len:int -> error_span -> string
-  (** Serialize a value of type {!error_span}
+  (** Serialize a value of type {!type:error_span}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -723,19 +731,39 @@ val string_of_error_span :
 
 val read_error_span :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> error_span
-  (** Input JSON data of type {!error_span}. *)
+  (** Input JSON data of type {!type:error_span}. *)
 
 val error_span_of_string :
   string -> error_span
-  (** Deserialize JSON data of type {!error_span}. *)
+  (** Deserialize JSON data of type {!type:error_span}. *)
+
+val write_dataflow_trace :
+  Bi_outbuf.t -> dataflow_trace -> unit
+  (** Output a JSON value of type {!type:dataflow_trace}. *)
+
+val string_of_dataflow_trace :
+  ?len:int -> dataflow_trace -> string
+  (** Serialize a value of type {!type:dataflow_trace}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_dataflow_trace :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> dataflow_trace
+  (** Input JSON data of type {!type:dataflow_trace}. *)
+
+val dataflow_trace_of_string :
+  string -> dataflow_trace
+  (** Deserialize JSON data of type {!type:dataflow_trace}. *)
 
 val write_cve_result :
   Bi_outbuf.t -> cve_result -> unit
-  (** Output a JSON value of type {!cve_result}. *)
+  (** Output a JSON value of type {!type:cve_result}. *)
 
 val string_of_cve_result :
   ?len:int -> cve_result -> string
-  (** Serialize a value of type {!cve_result}
+  (** Serialize a value of type {!type:cve_result}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -743,19 +771,19 @@ val string_of_cve_result :
 
 val read_cve_result :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cve_result
-  (** Input JSON data of type {!cve_result}. *)
+  (** Input JSON data of type {!type:cve_result}. *)
 
 val cve_result_of_string :
   string -> cve_result
-  (** Deserialize JSON data of type {!cve_result}. *)
+  (** Deserialize JSON data of type {!type:cve_result}. *)
 
 val write_cve_results :
   Bi_outbuf.t -> cve_results -> unit
-  (** Output a JSON value of type {!cve_results}. *)
+  (** Output a JSON value of type {!type:cve_results}. *)
 
 val string_of_cve_results :
   ?len:int -> cve_results -> string
-  (** Serialize a value of type {!cve_results}
+  (** Serialize a value of type {!type:cve_results}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -763,19 +791,19 @@ val string_of_cve_results :
 
 val read_cve_results :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cve_results
-  (** Input JSON data of type {!cve_results}. *)
+  (** Input JSON data of type {!type:cve_results}. *)
 
 val cve_results_of_string :
   string -> cve_results
-  (** Deserialize JSON data of type {!cve_results}. *)
+  (** Deserialize JSON data of type {!type:cve_results}. *)
 
 val write_core_timing :
   Bi_outbuf.t -> core_timing -> unit
-  (** Output a JSON value of type {!core_timing}. *)
+  (** Output a JSON value of type {!type:core_timing}. *)
 
 val string_of_core_timing :
   ?len:int -> core_timing -> string
-  (** Serialize a value of type {!core_timing}
+  (** Serialize a value of type {!type:core_timing}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -783,19 +811,19 @@ val string_of_core_timing :
 
 val read_core_timing :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_timing
-  (** Input JSON data of type {!core_timing}. *)
+  (** Input JSON data of type {!type:core_timing}. *)
 
 val core_timing_of_string :
   string -> core_timing
-  (** Deserialize JSON data of type {!core_timing}. *)
+  (** Deserialize JSON data of type {!type:core_timing}. *)
 
 val write_core_stats :
   Bi_outbuf.t -> core_stats -> unit
-  (** Output a JSON value of type {!core_stats}. *)
+  (** Output a JSON value of type {!type:core_stats}. *)
 
 val string_of_core_stats :
   ?len:int -> core_stats -> string
-  (** Serialize a value of type {!core_stats}
+  (** Serialize a value of type {!type:core_stats}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -803,19 +831,19 @@ val string_of_core_stats :
 
 val read_core_stats :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_stats
-  (** Input JSON data of type {!core_stats}. *)
+  (** Input JSON data of type {!type:core_stats}. *)
 
 val core_stats_of_string :
   string -> core_stats
-  (** Deserialize JSON data of type {!core_stats}. *)
+  (** Deserialize JSON data of type {!type:core_stats}. *)
 
 val write_core_severity :
   Bi_outbuf.t -> core_severity -> unit
-  (** Output a JSON value of type {!core_severity}. *)
+  (** Output a JSON value of type {!type:core_severity}. *)
 
 val string_of_core_severity :
   ?len:int -> core_severity -> string
-  (** Serialize a value of type {!core_severity}
+  (** Serialize a value of type {!type:core_severity}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -823,19 +851,19 @@ val string_of_core_severity :
 
 val read_core_severity :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_severity
-  (** Input JSON data of type {!core_severity}. *)
+  (** Input JSON data of type {!type:core_severity}. *)
 
 val core_severity_of_string :
   string -> core_severity
-  (** Deserialize JSON data of type {!core_severity}. *)
+  (** Deserialize JSON data of type {!type:core_severity}. *)
 
 val write_core_match_extra :
   Bi_outbuf.t -> core_match_extra -> unit
-  (** Output a JSON value of type {!core_match_extra}. *)
+  (** Output a JSON value of type {!type:core_match_extra}. *)
 
 val string_of_core_match_extra :
   ?len:int -> core_match_extra -> string
-  (** Serialize a value of type {!core_match_extra}
+  (** Serialize a value of type {!type:core_match_extra}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -843,19 +871,19 @@ val string_of_core_match_extra :
 
 val read_core_match_extra :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_match_extra
-  (** Input JSON data of type {!core_match_extra}. *)
+  (** Input JSON data of type {!type:core_match_extra}. *)
 
 val core_match_extra_of_string :
   string -> core_match_extra
-  (** Deserialize JSON data of type {!core_match_extra}. *)
+  (** Deserialize JSON data of type {!type:core_match_extra}. *)
 
 val write_core_match :
   Bi_outbuf.t -> core_match -> unit
-  (** Output a JSON value of type {!core_match}. *)
+  (** Output a JSON value of type {!type:core_match}. *)
 
 val string_of_core_match :
   ?len:int -> core_match -> string
-  (** Serialize a value of type {!core_match}
+  (** Serialize a value of type {!type:core_match}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -863,19 +891,19 @@ val string_of_core_match :
 
 val read_core_match :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_match
-  (** Input JSON data of type {!core_match}. *)
+  (** Input JSON data of type {!type:core_match}. *)
 
 val core_match_of_string :
   string -> core_match
-  (** Deserialize JSON data of type {!core_match}. *)
+  (** Deserialize JSON data of type {!type:core_match}. *)
 
 val write_core_error_kind :
   Bi_outbuf.t -> core_error_kind -> unit
-  (** Output a JSON value of type {!core_error_kind}. *)
+  (** Output a JSON value of type {!type:core_error_kind}. *)
 
 val string_of_core_error_kind :
   ?len:int -> core_error_kind -> string
-  (** Serialize a value of type {!core_error_kind}
+  (** Serialize a value of type {!type:core_error_kind}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -883,19 +911,19 @@ val string_of_core_error_kind :
 
 val read_core_error_kind :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_error_kind
-  (** Input JSON data of type {!core_error_kind}. *)
+  (** Input JSON data of type {!type:core_error_kind}. *)
 
 val core_error_kind_of_string :
   string -> core_error_kind
-  (** Deserialize JSON data of type {!core_error_kind}. *)
+  (** Deserialize JSON data of type {!type:core_error_kind}. *)
 
 val write_core_error :
   Bi_outbuf.t -> core_error -> unit
-  (** Output a JSON value of type {!core_error}. *)
+  (** Output a JSON value of type {!type:core_error}. *)
 
 val string_of_core_error :
   ?len:int -> core_error -> string
-  (** Serialize a value of type {!core_error}
+  (** Serialize a value of type {!type:core_error}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -903,19 +931,19 @@ val string_of_core_error :
 
 val read_core_error :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_error
-  (** Input JSON data of type {!core_error}. *)
+  (** Input JSON data of type {!type:core_error}. *)
 
 val core_error_of_string :
   string -> core_error
-  (** Deserialize JSON data of type {!core_error}. *)
+  (** Deserialize JSON data of type {!type:core_error}. *)
 
 val write_core_match_results :
   Bi_outbuf.t -> core_match_results -> unit
-  (** Output a JSON value of type {!core_match_results}. *)
+  (** Output a JSON value of type {!type:core_match_results}. *)
 
 val string_of_core_match_results :
   ?len:int -> core_match_results -> string
-  (** Serialize a value of type {!core_match_results}
+  (** Serialize a value of type {!type:core_match_results}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -923,19 +951,19 @@ val string_of_core_match_results :
 
 val read_core_match_results :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> core_match_results
-  (** Input JSON data of type {!core_match_results}. *)
+  (** Input JSON data of type {!type:core_match_results}. *)
 
 val core_match_results_of_string :
   string -> core_match_results
-  (** Deserialize JSON data of type {!core_match_results}. *)
+  (** Deserialize JSON data of type {!type:core_match_results}. *)
 
 val write_cli_target_times :
   Bi_outbuf.t -> cli_target_times -> unit
-  (** Output a JSON value of type {!cli_target_times}. *)
+  (** Output a JSON value of type {!type:cli_target_times}. *)
 
 val string_of_cli_target_times :
   ?len:int -> cli_target_times -> string
-  (** Serialize a value of type {!cli_target_times}
+  (** Serialize a value of type {!type:cli_target_times}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -943,19 +971,19 @@ val string_of_cli_target_times :
 
 val read_cli_target_times :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_target_times
-  (** Input JSON data of type {!cli_target_times}. *)
+  (** Input JSON data of type {!type:cli_target_times}. *)
 
 val cli_target_times_of_string :
   string -> cli_target_times
-  (** Deserialize JSON data of type {!cli_target_times}. *)
+  (** Deserialize JSON data of type {!type:cli_target_times}. *)
 
 val write_cli_timing :
   Bi_outbuf.t -> cli_timing -> unit
-  (** Output a JSON value of type {!cli_timing}. *)
+  (** Output a JSON value of type {!type:cli_timing}. *)
 
 val string_of_cli_timing :
   ?len:int -> cli_timing -> string
-  (** Serialize a value of type {!cli_timing}
+  (** Serialize a value of type {!type:cli_timing}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -963,19 +991,19 @@ val string_of_cli_timing :
 
 val read_cli_timing :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_timing
-  (** Input JSON data of type {!cli_timing}. *)
+  (** Input JSON data of type {!type:cli_timing}. *)
 
 val cli_timing_of_string :
   string -> cli_timing
-  (** Deserialize JSON data of type {!cli_timing}. *)
+  (** Deserialize JSON data of type {!type:cli_timing}. *)
 
 val write_cli_skipped_target :
   Bi_outbuf.t -> cli_skipped_target -> unit
-  (** Output a JSON value of type {!cli_skipped_target}. *)
+  (** Output a JSON value of type {!type:cli_skipped_target}. *)
 
 val string_of_cli_skipped_target :
   ?len:int -> cli_skipped_target -> string
-  (** Serialize a value of type {!cli_skipped_target}
+  (** Serialize a value of type {!type:cli_skipped_target}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -983,19 +1011,19 @@ val string_of_cli_skipped_target :
 
 val read_cli_skipped_target :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_skipped_target
-  (** Input JSON data of type {!cli_skipped_target}. *)
+  (** Input JSON data of type {!type:cli_skipped_target}. *)
 
 val cli_skipped_target_of_string :
   string -> cli_skipped_target
-  (** Deserialize JSON data of type {!cli_skipped_target}. *)
+  (** Deserialize JSON data of type {!type:cli_skipped_target}. *)
 
 val write_cli_paths :
   Bi_outbuf.t -> cli_paths -> unit
-  (** Output a JSON value of type {!cli_paths}. *)
+  (** Output a JSON value of type {!type:cli_paths}. *)
 
 val string_of_cli_paths :
   ?len:int -> cli_paths -> string
-  (** Serialize a value of type {!cli_paths}
+  (** Serialize a value of type {!type:cli_paths}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1003,19 +1031,19 @@ val string_of_cli_paths :
 
 val read_cli_paths :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_paths
-  (** Input JSON data of type {!cli_paths}. *)
+  (** Input JSON data of type {!type:cli_paths}. *)
 
 val cli_paths_of_string :
   string -> cli_paths
-  (** Deserialize JSON data of type {!cli_paths}. *)
+  (** Deserialize JSON data of type {!type:cli_paths}. *)
 
 val write_cli_output_extra :
   Bi_outbuf.t -> cli_output_extra -> unit
-  (** Output a JSON value of type {!cli_output_extra}. *)
+  (** Output a JSON value of type {!type:cli_output_extra}. *)
 
 val string_of_cli_output_extra :
   ?len:int -> cli_output_extra -> string
-  (** Serialize a value of type {!cli_output_extra}
+  (** Serialize a value of type {!type:cli_output_extra}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1023,19 +1051,19 @@ val string_of_cli_output_extra :
 
 val read_cli_output_extra :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_output_extra
-  (** Input JSON data of type {!cli_output_extra}. *)
+  (** Input JSON data of type {!type:cli_output_extra}. *)
 
 val cli_output_extra_of_string :
   string -> cli_output_extra
-  (** Deserialize JSON data of type {!cli_output_extra}. *)
+  (** Deserialize JSON data of type {!type:cli_output_extra}. *)
 
 val write_cli_match_extra :
   Bi_outbuf.t -> cli_match_extra -> unit
-  (** Output a JSON value of type {!cli_match_extra}. *)
+  (** Output a JSON value of type {!type:cli_match_extra}. *)
 
 val string_of_cli_match_extra :
   ?len:int -> cli_match_extra -> string
-  (** Serialize a value of type {!cli_match_extra}
+  (** Serialize a value of type {!type:cli_match_extra}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1043,19 +1071,19 @@ val string_of_cli_match_extra :
 
 val read_cli_match_extra :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_match_extra
-  (** Input JSON data of type {!cli_match_extra}. *)
+  (** Input JSON data of type {!type:cli_match_extra}. *)
 
 val cli_match_extra_of_string :
   string -> cli_match_extra
-  (** Deserialize JSON data of type {!cli_match_extra}. *)
+  (** Deserialize JSON data of type {!type:cli_match_extra}. *)
 
 val write_cli_match :
   Bi_outbuf.t -> cli_match -> unit
-  (** Output a JSON value of type {!cli_match}. *)
+  (** Output a JSON value of type {!type:cli_match}. *)
 
 val string_of_cli_match :
   ?len:int -> cli_match -> string
-  (** Serialize a value of type {!cli_match}
+  (** Serialize a value of type {!type:cli_match}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1063,19 +1091,19 @@ val string_of_cli_match :
 
 val read_cli_match :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_match
-  (** Input JSON data of type {!cli_match}. *)
+  (** Input JSON data of type {!type:cli_match}. *)
 
 val cli_match_of_string :
   string -> cli_match
-  (** Deserialize JSON data of type {!cli_match}. *)
+  (** Deserialize JSON data of type {!type:cli_match}. *)
 
 val write_cli_error :
   Bi_outbuf.t -> cli_error -> unit
-  (** Output a JSON value of type {!cli_error}. *)
+  (** Output a JSON value of type {!type:cli_error}. *)
 
 val string_of_cli_error :
   ?len:int -> cli_error -> string
-  (** Serialize a value of type {!cli_error}
+  (** Serialize a value of type {!type:cli_error}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1083,19 +1111,19 @@ val string_of_cli_error :
 
 val read_cli_error :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_error
-  (** Input JSON data of type {!cli_error}. *)
+  (** Input JSON data of type {!type:cli_error}. *)
 
 val cli_error_of_string :
   string -> cli_error
-  (** Deserialize JSON data of type {!cli_error}. *)
+  (** Deserialize JSON data of type {!type:cli_error}. *)
 
 val write_cli_output :
   Bi_outbuf.t -> cli_output -> unit
-  (** Output a JSON value of type {!cli_output}. *)
+  (** Output a JSON value of type {!type:cli_output}. *)
 
 val string_of_cli_output :
   ?len:int -> cli_output -> string
-  (** Serialize a value of type {!cli_output}
+  (** Serialize a value of type {!type:cli_output}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1103,19 +1131,19 @@ val string_of_cli_output :
 
 val read_cli_output :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_output
-  (** Input JSON data of type {!cli_output}. *)
+  (** Input JSON data of type {!type:cli_output}. *)
 
 val cli_output_of_string :
   string -> cli_output
-  (** Deserialize JSON data of type {!cli_output}. *)
+  (** Deserialize JSON data of type {!type:cli_output}. *)
 
 val write_api_scans_findings :
   Bi_outbuf.t -> api_scans_findings -> unit
-  (** Output a JSON value of type {!api_scans_findings}. *)
+  (** Output a JSON value of type {!type:api_scans_findings}. *)
 
 val string_of_api_scans_findings :
   ?len:int -> api_scans_findings -> string
-  (** Serialize a value of type {!api_scans_findings}
+  (** Serialize a value of type {!type:api_scans_findings}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
@@ -1123,9 +1151,9 @@ val string_of_api_scans_findings :
 
 val read_api_scans_findings :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> api_scans_findings
-  (** Input JSON data of type {!api_scans_findings}. *)
+  (** Input JSON data of type {!type:api_scans_findings}. *)
 
 val api_scans_findings_of_string :
   string -> api_scans_findings
-  (** Deserialize JSON data of type {!api_scans_findings}. *)
+  (** Deserialize JSON data of type {!type:api_scans_findings}. *)
 


### PR DESCRIPTION
This is a simplified version of semgrep-core's `Pattern_match.taint_trace` type. It makes a couple of simplifications:
* It omits the sink. The sink is already going to be the primary location of the error message, except for more complicated behavior with DeepSemgrep. We can add it in later if we need to.
* It simplifies the source. The `Call` case is only used for DeepSemgrep, and atdpy does not support recursive types so it would be difficult to represent here anyway. Instead, we can just provide a list of locations.

I believe that despite these simplifications, we will still be able to achieve our goals of providing taint trace information to end users and improving our ability to make PR/MR comments.

This is also meant to be extended to other kinds of dataflow traces (such as explaining constant propagation) without a breaking change.