### PR TITLE
metavariable-comparison: Make `metavariable` field optional

### DIFF
--- a/rule_schema.yaml
+++ b/rule_schema.yaml
@@ -322,7 +322,6 @@ $defs:
           base:
             type: integer
         required:
-          - metavariable
           - comparison
         additionalProperties: false
     required:


### PR DESCRIPTION
This field is pointless unles `strip: true`.