### PR TITLE
feat(swift): added modifiers for Swift

### DIFF
--- a/ast_generic_v0.atd
+++ b/ast_generic_v0.atd
@@ -720,6 +720,8 @@ type keyword_attribute = [
   | Generator (* '*' in JS *) | Async
   | Recursive | MutuallyRecursive
   | Inline
+  (* Swift *)
+  | Throws | Rethrows
   (* for methods *)
   | Ctor | Dtor
   | Getter | Setter


### PR DESCRIPTION
Swift has some keyword attributes which are not currently in the generic AST, namely `Throws` and `Rethrows`. I decided to just put it in here.

Let me know if that's not something that I should do.

