### PR TITLE
Update required atdpy and atdts version

### DIFF
--- a/dev.opam
+++ b/dev.opam
@@ -8,6 +8,6 @@ bug-reports: "n/a"
 synopsis: "OCaml development dependencies"
 
 depends: [
-  "atdpy" {>= "2.7.0"}
-  "atdts" {>= "2.7.0"}
+  "atdpy" {>= "2.10.0"}
+  "atdts" {>= "2.10.0"}
 ]


### PR DESCRIPTION
As of 2.10.0, atdpy supports recursive types, which we now use.

Test plan:

```
$ opam install -y --deps-only .
$ make clean && make
```