### PR TITLE
feat: dot operators

### DIFF
--- a/ast_generic_v0.atd
+++ b/ast_generic_v0.atd
@@ -242,7 +242,7 @@ type expr = [
    * In the last case it should be rewritten as a (N IdQualified) with a
    * qualifier though.
   *)
-  | DotAccess of (expr * tok (* ., ::, ->, # *) * name_or_dynamic)
+  | DotAccess of (expr * dot_operator wrap_ (* ., ::, ->, # *) * name_or_dynamic)
 
   (* in Js ArrayAccess is also abused to perform DotAccess (..., FDynamic) *)
   | ArrayAccess of (expr * expr bracket)
@@ -307,6 +307,11 @@ type container_operator = [
   | List | Set
   | Dict (* a.k.a Hash or Map (combine with Tuple to get Key/value pair) *)
   ]
+
+type dot_operator = [
+  | Dot
+  | QuestDot
+]
 
 (* It's useful to keep track in the AST of all those special identifiers.
  * They need to be handled in a special way by certain analysis and just

--- a/ast_generic_v0_j.ml
+++ b/ast_generic_v0_j.ml
@@ -9,6 +9,8 @@ type const_type = Ast_generic_v0_t.const_type
 
 type container_operator = Ast_generic_v0_t.container_operator
 
+type dot_operator = Ast_generic_v0_t.dot_operator
+
 type function_kind = Ast_generic_v0_t.function_kind
 
 type incr_decr = Ast_generic_v0_t.incr_decr
@@ -202,16 +204,16 @@ and xml_body = Ast_generic_v0_t.xml_body
 
 type program = Ast_generic_v0_t.program
 
-let write__21 = (
+let write__22 = (
   Atdgen_runtime.Oj_run.write_std_option (
     Yojson.Safe.write_int
   )
 )
-let string_of__21 ?(len = 1024) x =
+let string_of__22 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__21 ob x;
+  write__22 ob x;
   Bi_outbuf.contents ob
-let read__21 = (
+let read__22 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -257,18 +259,18 @@ let read__21 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _21_of_string s =
-  read__21 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__23 = (
+let _22_of_string s =
+  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__24 = (
   Atdgen_runtime.Oj_run.write_std_option (
     Yojson.Safe.write_std_float
   )
 )
-let string_of__23 ?(len = 1024) x =
+let string_of__24 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__23 ob x;
+  write__24 ob x;
   Bi_outbuf.contents ob
-let read__23 = (
+let read__24 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -314,8 +316,8 @@ let read__23 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _23_of_string s =
-  read__23 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _24_of_string s =
+  read__24 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_class_kind = (
   fun ob x ->
     match x with
@@ -574,6 +576,50 @@ let read_container_operator = (
 )
 let container_operator_of_string s =
   read_container_operator (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_dot_operator = (
+  fun ob x ->
+    match x with
+      | `Dot -> Bi_outbuf.add_string ob "\"Dot\""
+      | `QuestDot -> Bi_outbuf.add_string ob "\"QuestDot\""
+)
+let string_of_dot_operator ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write_dot_operator ob x;
+  Bi_outbuf.contents ob
+let read_dot_operator = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "Dot" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Dot
+            | "QuestDot" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `QuestDot
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "Dot" ->
+              `Dot
+            | "QuestDot" ->
+              `QuestDot
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let dot_operator_of_string s =
+  read_dot_operator (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_function_kind = (
   fun ob x ->
     match x with
@@ -2204,7 +2250,73 @@ let read__14 = (
 )
 let _14_of_string s =
   read__14 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__20 = (
+let write__15 = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '[';
+    (let x, _ = x in
+    (
+      write_dot_operator
+    ) ob x
+    );
+    Bi_outbuf.add_char ob ',';
+    (let _, x = x in
+    (
+      write_tok
+    ) ob x
+    );
+    Bi_outbuf.add_char ob ']';
+)
+let string_of__15 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__15 ob x;
+  Bi_outbuf.contents ob
+let read__15 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    let std_tuple = Yojson.Safe.start_any_tuple p lb in
+    let len = ref 0 in
+    let end_of_tuple = ref false in
+    (try
+      let x0 =
+        let x =
+          (
+            read_dot_operator
+          ) p lb
+        in
+        incr len;
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+        x
+      in
+      let x1 =
+        let x =
+          (
+            read_tok
+          ) p lb
+        in
+        incr len;
+        (try
+          Yojson.Safe.read_space p lb;
+          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+        with Yojson.End_of_tuple -> end_of_tuple := true);
+        x
+      in
+      if not !end_of_tuple then (
+        try
+          while true do
+            Yojson.Safe.skip_json p lb;
+            Yojson.Safe.read_space p lb;
+            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+          done
+        with Yojson.End_of_tuple -> ()
+      );
+      (x0, x1)
+    with Yojson.End_of_tuple ->
+      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
+)
+let _15_of_string s =
+  read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__21 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
@@ -2220,11 +2332,11 @@ let write__20 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__20 ?(len = 1024) x =
+let string_of__21 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__20 ob x;
+  write__21 ob x;
   Bi_outbuf.contents ob
-let read__20 = (
+let read__21 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2268,14 +2380,14 @@ let read__20 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _20_of_string s =
-  read__20 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__22 = (
+let _21_of_string s =
+  read__21 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__23 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
     (
-      write__21
+      write__22
     ) ob x
     );
     Bi_outbuf.add_char ob ',';
@@ -2286,11 +2398,11 @@ let write__22 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__22 ?(len = 1024) x =
+let string_of__23 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__22 ob x;
+  write__23 ob x;
   Bi_outbuf.contents ob
-let read__22 = (
+let read__23 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2300,7 +2412,7 @@ let read__22 = (
       let x0 =
         let x =
           (
-            read__21
+            read__22
           ) p lb
         in
         incr len;
@@ -2334,14 +2446,14 @@ let read__22 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _22_of_string s =
-  read__22 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__24 = (
+let _23_of_string s =
+  read__23 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__25 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
     (
-      write__23
+      write__24
     ) ob x
     );
     Bi_outbuf.add_char ob ',';
@@ -2352,11 +2464,11 @@ let write__24 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__24 ?(len = 1024) x =
+let string_of__25 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__24 ob x;
+  write__25 ob x;
   Bi_outbuf.contents ob
-let read__24 = (
+let read__25 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2366,7 +2478,7 @@ let read__24 = (
       let x0 =
         let x =
           (
-            read__23
+            read__24
           ) p lb
         in
         incr len;
@@ -2400,9 +2512,9 @@ let read__24 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _24_of_string s =
-  read__24 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__36 = (
+let _25_of_string s =
+  read__25 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__37 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
@@ -2418,11 +2530,11 @@ let write__36 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__36 ?(len = 1024) x =
+let string_of__37 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__36 ob x;
+  write__37 ob x;
   Bi_outbuf.contents ob
-let read__36 = (
+let read__37 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2466,9 +2578,9 @@ let read__36 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _36_of_string s =
-  read__36 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__48 = (
+let _37_of_string s =
+  read__37 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__49 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
@@ -2484,11 +2596,11 @@ let write__48 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__48 ?(len = 1024) x =
+let string_of__49 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__48 ob x;
+  write__49 ob x;
   Bi_outbuf.contents ob
-let read__48 = (
+let read__49 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2532,9 +2644,9 @@ let read__48 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _48_of_string s =
-  read__48 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__52 = (
+let _49_of_string s =
+  read__49 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__53 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
@@ -2550,11 +2662,11 @@ let write__52 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__52 ?(len = 1024) x =
+let string_of__53 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__52 ob x;
+  write__53 ob x;
   Bi_outbuf.contents ob
-let read__52 = (
+let read__53 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2598,9 +2710,9 @@ let read__52 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _52_of_string s =
-  read__52 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__55 = (
+let _53_of_string s =
+  read__53 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__56 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _ = x in
@@ -2616,11 +2728,11 @@ let write__55 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-let string_of__55 ?(len = 1024) x =
+let string_of__56 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__55 ob x;
+  write__56 ob x;
   Bi_outbuf.contents ob
-let read__55 = (
+let read__56 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -2664,8 +2776,8 @@ let read__55 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
 )
-let _55_of_string s =
-  read__55 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _56_of_string s =
+  read__56 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_ident = (
   write__1
 )
@@ -2694,16 +2806,16 @@ let read__2 = (
 )
 let _2_of_string s =
   read__2 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__53 = (
+let write__54 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_ident
   )
 )
-let string_of__53 ?(len = 1024) x =
+let string_of__54 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__53 ob x;
+  write__54 ob x;
   Bi_outbuf.contents ob
-let read__53 = (
+let read__54 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -2749,8 +2861,8 @@ let read__53 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _53_of_string s =
-  read__53 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _54_of_string s =
+  read__54 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_dotted_ident = (
   write__2
 )
@@ -2763,16 +2875,16 @@ let read_dotted_ident = (
 )
 let dotted_ident_of_string s =
   read_dotted_ident (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__56 = (
+let write__57 = (
   Atdgen_runtime.Oj_run.write_std_option (
     write_dotted_ident
   )
 )
-let string_of__56 ?(len = 1024) x =
+let string_of__57 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__56 ob x;
+  write__57 ob x;
   Bi_outbuf.contents ob
-let read__56 = (
+let read__57 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -2818,8 +2930,8 @@ let read__56 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _56_of_string s =
-  read__56 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _57_of_string s =
+  read__57 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_label = (
   write_ident
 )
@@ -2838,19 +2950,19 @@ let write_literal = (
       | `Bool x ->
         Bi_outbuf.add_string ob "[\"Bool\",";
         (
-          write__20
+          write__21
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `Int x ->
         Bi_outbuf.add_string ob "[\"Int\",";
         (
-          write__22
+          write__23
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `Float x ->
         Bi_outbuf.add_string ob "[\"Float\",";
         (
-          write__24
+          write__25
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `Char x ->
@@ -2921,7 +3033,7 @@ let read_literal = (
             | "Bool" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__20
+                  read__21
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -2930,7 +3042,7 @@ let read_literal = (
             | "Int" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__22
+                  read__23
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -2939,7 +3051,7 @@ let read_literal = (
             | "Float" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__24
+                  read__25
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -3041,7 +3153,7 @@ let read_literal = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__20
+                  read__21
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -3052,7 +3164,7 @@ let read_literal = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__22
+                  read__23
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -3063,7 +3175,7 @@ let read_literal = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__24
+                  read__25
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -4206,7 +4318,7 @@ and string_of__13 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__13 ob x;
   Bi_outbuf.contents ob
-and write__15 = (
+and write__16 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _, _ = x in
@@ -4228,20 +4340,20 @@ and write__15 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-and string_of__15 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__15 ob x;
-  Bi_outbuf.contents ob
-and write__16 ob x = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_expr
-  )
-) ob x
 and string_of__16 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__16 ob x;
   Bi_outbuf.contents ob
-and write__17 = (
+and write__17 ob x = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_expr
+  )
+) ob x
+and string_of__17 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__17 ob x;
+  Bi_outbuf.contents ob
+and write__18 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _, _ = x in
@@ -4256,19 +4368,19 @@ and write__17 = (
         Bi_outbuf.add_char ob '[';
         (let x, _, _ = x in
         (
-          write__16
+          write__17
         ) ob x
         );
         Bi_outbuf.add_char ob ',';
         (let _, x, _ = x in
         (
-          write__16
+          write__17
         ) ob x
         );
         Bi_outbuf.add_char ob ',';
         (let _, _, x = x in
         (
-          write__16
+          write__17
         ) ob x
         );
         Bi_outbuf.add_char ob ']';
@@ -4282,47 +4394,47 @@ and write__17 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-and string_of__17 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__17 ob x;
-  Bi_outbuf.contents ob
-and write__18 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_action
-  )
-) ob x
 and string_of__18 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__18 ob x;
   Bi_outbuf.contents ob
 and write__19 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_any
+    write_action
   )
 ) ob x
 and string_of__19 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__19 ob x;
   Bi_outbuf.contents ob
-and write__25 ob x = (
+and write__20 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_xml_attribute
+    write_any
   )
 ) ob x
-and string_of__25 ?(len = 1024) x =
+and string_of__20 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__25 ob x;
+  write__20 ob x;
   Bi_outbuf.contents ob
 and write__26 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_xml_body
+    write_xml_attribute
   )
 ) ob x
 and string_of__26 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__26 ob x;
   Bi_outbuf.contents ob
-and write__27 = (
+and write__27 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_xml_body
+  )
+) ob x
+and string_of__27 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__27 ob x;
+  Bi_outbuf.contents ob
+and write__28 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _, _ = x in
@@ -4333,7 +4445,7 @@ and write__27 = (
     Bi_outbuf.add_char ob ',';
     (let _, x, _ = x in
     (
-      write__16
+      write__17
     ) ob x
     );
     Bi_outbuf.add_char ob ',';
@@ -4344,22 +4456,13 @@ and write__27 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-and string_of__27 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__27 ob x;
-  Bi_outbuf.contents ob
-and write__28 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_argument
-  )
-) ob x
 and string_of__28 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__28 ob x;
   Bi_outbuf.contents ob
 and write__29 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_stmt
+    write_argument
   )
 ) ob x
 and string_of__29 ?(len = 1024) x =
@@ -4375,7 +4478,16 @@ and string_of__3 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__3 ob x;
   Bi_outbuf.contents ob
-and write__30 = (
+and write__30 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_stmt
+  )
+) ob x
+and string_of__30 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__30 ob x;
+  Bi_outbuf.contents ob
+and write__31 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _, _ = x in
@@ -4386,7 +4498,7 @@ and write__30 = (
     Bi_outbuf.add_char ob ',';
     (let _, x, _ = x in
     (
-      write__29
+      write__30
     ) ob x
     );
     Bi_outbuf.add_char ob ',';
@@ -4397,22 +4509,13 @@ and write__30 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-and string_of__30 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__30 ob x;
-  Bi_outbuf.contents ob
-and write__31 ob x = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_stmt
-  )
-) ob x
 and string_of__31 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__31 ob x;
   Bi_outbuf.contents ob
 and write__32 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_case_and_body
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_stmt
   )
 ) ob x
 and string_of__32 ?(len = 1024) x =
@@ -4421,7 +4524,7 @@ and string_of__32 ?(len = 1024) x =
   Bi_outbuf.contents ob
 and write__33 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_catch
+    write_case_and_body
   )
 ) ob x
 and string_of__33 ?(len = 1024) x =
@@ -4429,8 +4532,8 @@ and string_of__33 ?(len = 1024) x =
   write__33 ob x;
   Bi_outbuf.contents ob
 and write__34 ob x = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_finally
+  Atdgen_runtime.Oj_run.write_list (
+    write_catch
   )
 ) ob x
 and string_of__34 ?(len = 1024) x =
@@ -4438,26 +4541,26 @@ and string_of__34 ?(len = 1024) x =
   write__34 ob x;
   Bi_outbuf.contents ob
 and write__35 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_case
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_finally
   )
 ) ob x
 and string_of__35 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__35 ob x;
   Bi_outbuf.contents ob
-and write__37 ob x = (
+and write__36 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_for_var_or_expr
+    write_case
   )
 ) ob x
-and string_of__37 ?(len = 1024) x =
+and string_of__36 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__37 ob x;
+  write__36 ob x;
   Bi_outbuf.contents ob
 and write__38 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_pattern
+    write_for_var_or_expr
   )
 ) ob x
 and string_of__38 ?(len = 1024) x =
@@ -4465,6 +4568,24 @@ and string_of__38 ?(len = 1024) x =
   write__38 ob x;
   Bi_outbuf.contents ob
 and write__39 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_pattern
+  )
+) ob x
+and string_of__39 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__39 ob x;
+  Bi_outbuf.contents ob
+and write__4 ob x = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_type_arguments
+  )
+) ob x
+and string_of__4 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__4 ob x;
+  Bi_outbuf.contents ob
+and write__40 ob x = (
   Atdgen_runtime.Oj_run.write_list (
     fun ob x ->
       Bi_outbuf.add_char ob '[';
@@ -4482,20 +4603,37 @@ and write__39 ob x = (
       Bi_outbuf.add_char ob ']';
   )
 ) ob x
-and string_of__39 ?(len = 1024) x =
+and string_of__40 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__39 ob x;
+  write__40 ob x;
   Bi_outbuf.contents ob
-and write__4 ob x = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_type_arguments
-  )
-) ob x
-and string_of__4 ?(len = 1024) x =
+and write__41 = (
+  fun ob x ->
+    Bi_outbuf.add_char ob '[';
+    (let x, _, _ = x in
+    (
+      write_tok
+    ) ob x
+    );
+    Bi_outbuf.add_char ob ',';
+    (let _, x, _ = x in
+    (
+      write__40
+    ) ob x
+    );
+    Bi_outbuf.add_char ob ',';
+    (let _, _, x = x in
+    (
+      write_tok
+    ) ob x
+    );
+    Bi_outbuf.add_char ob ']';
+)
+and string_of__41 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__4 ob x;
+  write__41 ob x;
   Bi_outbuf.contents ob
-and write__40 = (
+and write__42 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _, _ = x in
@@ -4517,37 +4655,11 @@ and write__40 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-and string_of__40 ?(len = 1024) x =
+and string_of__42 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__40 ob x;
+  write__42 ob x;
   Bi_outbuf.contents ob
-and write__41 = (
-  fun ob x ->
-    Bi_outbuf.add_char ob '[';
-    (let x, _, _ = x in
-    (
-      write_tok
-    ) ob x
-    );
-    Bi_outbuf.add_char ob ',';
-    (let _, x, _ = x in
-    (
-      write__38
-    ) ob x
-    );
-    Bi_outbuf.add_char ob ',';
-    (let _, _, x = x in
-    (
-      write_tok
-    ) ob x
-    );
-    Bi_outbuf.add_char ob ']';
-)
-and string_of__41 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__41 ob x;
-  Bi_outbuf.contents ob
-and write__42 ob x = (
+and write__43 ob x = (
   Atdgen_runtime.Oj_run.write_std_option (
     fun ob x ->
       Bi_outbuf.add_char ob '[';
@@ -4565,29 +4677,29 @@ and write__42 ob x = (
       Bi_outbuf.add_char ob ']';
   )
 ) ob x
-and string_of__42 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__42 ob x;
-  Bi_outbuf.contents ob
-and write__43 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_parameter
-  )
-) ob x
 and string_of__43 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__43 ob x;
   Bi_outbuf.contents ob
 and write__44 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_type_
+    write_parameter
   )
 ) ob x
 and string_of__44 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__44 ob x;
   Bi_outbuf.contents ob
-and write__45 = (
+and write__45 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_type_
+  )
+) ob x
+and string_of__45 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__45 ob x;
+  Bi_outbuf.contents ob
+and write__46 = (
   fun ob x ->
     Bi_outbuf.add_char ob '[';
     (let x, _, _ = x in
@@ -4598,7 +4710,7 @@ and write__45 = (
     Bi_outbuf.add_char ob ',';
     (let _, x, _ = x in
     (
-      write__44
+      write__45
     ) ob x
     );
     Bi_outbuf.add_char ob ',';
@@ -4609,26 +4721,26 @@ and write__45 = (
     );
     Bi_outbuf.add_char ob ']';
 )
-and string_of__45 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__45 ob x;
-  Bi_outbuf.contents ob
-and write__46 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_type_argument
-  )
-) ob x
 and string_of__46 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__46 ob x;
   Bi_outbuf.contents ob
 and write__47 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_type_argument
+  )
+) ob x
+and string_of__47 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__47 ob x;
+  Bi_outbuf.contents ob
+and write__48 ob x = (
   Atdgen_runtime.Oj_run.write_std_option (
     fun ob x ->
       Bi_outbuf.add_char ob '[';
       (let x, _ = x in
       (
-        write__20
+        write__21
       ) ob x
       );
       Bi_outbuf.add_char ob ',';
@@ -4640,22 +4752,13 @@ and write__47 ob x = (
       Bi_outbuf.add_char ob ']';
   )
 ) ob x
-and string_of__47 ?(len = 1024) x =
+and string_of__48 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__47 ob x;
-  Bi_outbuf.contents ob
-and write__49 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_attribute
-  )
-) ob x
-and string_of__49 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__49 ob x;
+  write__48 ob x;
   Bi_outbuf.contents ob
 and write__50 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_type_parameter
+    write_attribute
   )
 ) ob x
 and string_of__50 ?(len = 1024) x =
@@ -4664,39 +4767,48 @@ and string_of__50 ?(len = 1024) x =
   Bi_outbuf.contents ob
 and write__51 ob x = (
   Atdgen_runtime.Oj_run.write_list (
-    write_type_parameter_constraint
+    write_type_parameter
   )
 ) ob x
 and string_of__51 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__51 ob x;
   Bi_outbuf.contents ob
-and write__54 ob x = (
+and write__52 ob x = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_type_parameter_constraint
+  )
+) ob x
+and string_of__52 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__52 ob x;
+  Bi_outbuf.contents ob
+and write__55 ob x = (
   Atdgen_runtime.Oj_run.write_list (
     write_or_type_element
   )
 ) ob x
-and string_of__54 ?(len = 1024) x =
+and string_of__55 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
-  write__54 ob x;
-  Bi_outbuf.contents ob
-and write__57 ob x = (
-  Atdgen_runtime.Oj_run.write_list (
-    write_item
-  )
-) ob x
-and string_of__57 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__57 ob x;
+  write__55 ob x;
   Bi_outbuf.contents ob
 and write__58 ob x = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_alias
+  Atdgen_runtime.Oj_run.write_list (
+    write_item
   )
 ) ob x
 and string_of__58 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__58 ob x;
+  Bi_outbuf.contents ob
+and write__59 ob x = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_alias
+  )
+) ob x
+and string_of__59 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__59 ob x;
   Bi_outbuf.contents ob
 and write__6 ob x = (
   Atdgen_runtime.Oj_run.write_std_option (
@@ -4800,7 +4912,7 @@ and write_any = (
       | `Ss x ->
         Bi_outbuf.add_string ob "[\"Ss\",";
         (
-          write__29
+          write__30
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `T x ->
@@ -4830,7 +4942,7 @@ and write_any = (
       | `Args x ->
         Bi_outbuf.add_string ob "[\"Args\",";
         (
-          write__28
+          write__29
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `I x ->
@@ -4928,7 +5040,7 @@ and write_argument = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -4940,7 +5052,7 @@ and string_of_argument ?(len = 1024) x =
   write_argument ob x;
   Bi_outbuf.contents ob
 and write_arguments ob x = (
-  write__28
+  write__29
 ) ob x
 and string_of_arguments ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
@@ -4952,7 +5064,7 @@ and write_attribute = (
       | `KeywordAttr x ->
         Bi_outbuf.add_string ob "[\"KeywordAttr\",";
         (
-          write__48
+          write__49
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `NamedAttr x ->
@@ -4993,7 +5105,7 @@ and write_attribute = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5066,7 +5178,7 @@ and write_case_and_body = (
             Bi_outbuf.add_char ob '[';
             (let x, _ = x in
             (
-              write__35
+              write__36
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -5125,7 +5237,7 @@ and write_class_definition : _ -> class_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"ckind\":";
     (
-      write__55
+      write__56
     )
       ob x.ckind;
     if !is_first then
@@ -5134,7 +5246,7 @@ and write_class_definition : _ -> class_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"cextends\":";
     (
-      write__44
+      write__45
     )
       ob x.cextends;
     if !is_first then
@@ -5143,7 +5255,7 @@ and write_class_definition : _ -> class_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"cimplements\":";
     (
-      write__44
+      write__45
     )
       ob x.cimplements;
     if !is_first then
@@ -5152,7 +5264,7 @@ and write_class_definition : _ -> class_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"cmixins\":";
     (
-      write__44
+      write__45
     )
       ob x.cmixins;
     if !is_first then
@@ -5269,7 +5381,7 @@ and write_definition_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5308,7 +5420,7 @@ and write_directive = (
             Bi_outbuf.add_char ob ',';
             (let _, _, _, x = x in
             (
-              write__58
+              write__59
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5333,7 +5445,7 @@ and write_directive = (
             Bi_outbuf.add_char ob ',';
             (let _, _, x = x in
             (
-              write__58
+              write__59
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5402,7 +5514,7 @@ and write_directive = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5421,7 +5533,7 @@ and write_directive = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5451,7 +5563,7 @@ and write_entity : _ -> entity -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"attrs\":";
     (
-      write__49
+      write__50
     )
       ob x.attrs;
     if !is_first then
@@ -5460,7 +5572,7 @@ and write_entity : _ -> entity -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"tparams\":";
     (
-      write__50
+      write__51
     )
       ob x.tparams;
     Bi_outbuf.add_char ob '}';
@@ -5647,7 +5759,7 @@ and write_expr = (
             Bi_outbuf.add_char ob ',';
             (let _, x, _ = x in
             (
-              write_tok
+              write__15
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -5672,7 +5784,7 @@ and write_expr = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__15
+              write__16
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5691,7 +5803,7 @@ and write_expr = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__17
+              write__18
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5747,7 +5859,7 @@ and write_expr = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__18
+              write__19
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -5766,7 +5878,7 @@ and write_expr = (
             Bi_outbuf.add_char ob ',';
             (let _, x, _ = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -5869,7 +5981,7 @@ and write_expr = (
       | `DeepEllipsis x ->
         Bi_outbuf.add_string ob "[\"DeepEllipsis\",";
         (
-          write__15
+          write__16
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `DisjExpr x ->
@@ -5948,7 +6060,7 @@ and write_expr = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6022,19 +6134,19 @@ and write_for_header = (
             Bi_outbuf.add_char ob '[';
             (let x, _, _ = x in
             (
-              write__37
+              write__38
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
             (let _, x, _ = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
             (let _, _, x = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6078,7 +6190,7 @@ and write_for_header = (
             Bi_outbuf.add_char ob '[';
             (let x, _ = x in
             (
-              write__37
+              write__38
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -6138,7 +6250,7 @@ and write_function_definition : _ -> function_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"fkind\":";
     (
-      write__52
+      write__53
     )
       ob x.fkind;
     if !is_first then
@@ -6231,7 +6343,7 @@ and write_label_ident = (
       | `LInt x ->
         Bi_outbuf.add_string ob "[\"LInt\",";
         (
-          write__36
+          write__37
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `LDynamic x ->
@@ -6264,7 +6376,7 @@ and write_macro_definition : _ -> macro_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"macrobody\":";
     (
-      write__19
+      write__20
     )
       ob x.macrobody;
     Bi_outbuf.add_char ob '}';
@@ -6308,13 +6420,13 @@ and write_module_definition_kind = (
             Bi_outbuf.add_char ob '[';
             (let x, _ = x in
             (
-              write__56
+              write__57
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__57
+              write__58
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6333,7 +6445,7 @@ and write_module_definition_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6467,7 +6579,7 @@ and write_or_type_element = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__44
+              write__45
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6486,7 +6598,7 @@ and write_or_type_element = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6524,7 +6636,7 @@ and write_or_type_element = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6607,7 +6719,7 @@ and write_parameter = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6628,7 +6740,7 @@ and write_parameter_classic : _ -> parameter_classic -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"pname\":";
     (
-      write__53
+      write__54
     )
       ob x.pname;
     if !is_first then
@@ -6646,7 +6758,7 @@ and write_parameter_classic : _ -> parameter_classic -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"pdefault\":";
     (
-      write__16
+      write__17
     )
       ob x.pdefault;
     if !is_first then
@@ -6655,7 +6767,7 @@ and write_parameter_classic : _ -> parameter_classic -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"pattrs\":";
     (
-      write__49
+      write__50
     )
       ob x.pattrs;
     if !is_first then
@@ -6674,7 +6786,7 @@ and string_of_parameter_classic ?(len = 1024) x =
   write_parameter_classic ob x;
   Bi_outbuf.contents ob
 and write_parameters ob x = (
-  write__43
+  write__44
 ) ob x
 and string_of_parameters ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
@@ -6702,7 +6814,7 @@ and write_pattern = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__38
+              write__39
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6711,7 +6823,7 @@ and write_pattern = (
       | `PatRecord x ->
         Bi_outbuf.add_string ob "[\"PatRecord\",";
         (
-          write__40
+          write__41
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `PatId x ->
@@ -6736,13 +6848,13 @@ and write_pattern = (
       | `PatTuple x ->
         Bi_outbuf.add_string ob "[\"PatTuple\",";
         (
-          write__41
+          write__42
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `PatList x ->
         Bi_outbuf.add_string ob "[\"PatList\",";
         (
-          write__41
+          write__42
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `PatKeyVal x ->
@@ -6878,7 +6990,7 @@ and write_pattern = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__42
+              write__43
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -6922,7 +7034,7 @@ and write_pattern = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7025,7 +7137,7 @@ and write_stmt_kind = (
       | `Block x ->
         Bi_outbuf.add_string ob "[\"Block\",";
         (
-          write__30
+          write__31
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `If x ->
@@ -7053,7 +7165,7 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, _, _, x = x in
             (
-              write__31
+              write__32
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7097,7 +7209,7 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x, _ = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -7172,13 +7284,13 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x, _ = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
             (let _, _, x = x in
             (
-              write__32
+              write__33
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7316,13 +7428,13 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, _, x, _ = x in
             (
-              write__33
+              write__34
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
             (let _, _, _, x = x in
             (
-              write__34
+              write__35
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7372,7 +7484,7 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, _, x, _ = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -7428,7 +7540,7 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x, _ = x in
             (
-              write__16
+              write__17
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -7453,7 +7565,7 @@ and write_stmt_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7480,7 +7592,7 @@ and write_type_ = (
             Bi_outbuf.add_char ob '[';
             (let x, _ = x in
             (
-              write__43
+              write__44
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -7499,7 +7611,7 @@ and write_type_ = (
             Bi_outbuf.add_char ob '[';
             (let x, _ = x in
             (
-              write__27
+              write__28
             ) ob x
             );
             Bi_outbuf.add_char ob ',';
@@ -7514,7 +7626,7 @@ and write_type_ = (
       | `TyTuple x ->
         Bi_outbuf.add_string ob "[\"TyTuple\",";
         (
-          write__45
+          write__46
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `TyN x ->
@@ -7737,7 +7849,7 @@ and write_type_ = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7770,7 +7882,7 @@ and write_type_argument = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__47
+              write__48
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7795,7 +7907,7 @@ and write_type_argument = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7807,7 +7919,7 @@ and string_of_type_argument ?(len = 1024) x =
   write_type_argument ob x;
   Bi_outbuf.contents ob
 and write_type_arguments ob x = (
-  write__46
+  write__47
 ) ob x
 and string_of_type_arguments ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
@@ -7838,7 +7950,7 @@ and write_type_definition_kind = (
       | `OrType x ->
         Bi_outbuf.add_string ob "[\"OrType\",";
         (
-          write__54
+          write__55
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `AndType x ->
@@ -7872,7 +7984,7 @@ and write_type_definition_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__44
+              write__45
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7891,7 +8003,7 @@ and write_type_definition_kind = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7913,7 +8025,7 @@ and write_type_parameter = (
     Bi_outbuf.add_char ob ',';
     (let _, x = x in
     (
-      write__51
+      write__52
     ) ob x
     );
     Bi_outbuf.add_char ob ']';
@@ -7950,7 +8062,7 @@ and write_type_parameter_constraint = (
             Bi_outbuf.add_char ob ',';
             (let _, x = x in
             (
-              write__19
+              write__20
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -7971,7 +8083,7 @@ and write_variable_definition : _ -> variable_definition -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"vinit\":";
     (
-      write__16
+      write__17
     )
       ob x.vinit;
     if !is_first then
@@ -8008,7 +8120,7 @@ and write_xml : _ -> xml -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"xml_attrs\":";
     (
-      write__25
+      write__26
     )
       ob x.xml_attrs;
     if !is_first then
@@ -8017,7 +8129,7 @@ and write_xml : _ -> xml -> _ = (
       Bi_outbuf.add_char ob ',';
     Bi_outbuf.add_string ob "\"xml_body\":";
     (
-      write__26
+      write__27
     )
       ob x.xml_body;
     Bi_outbuf.add_char ob '}';
@@ -8064,7 +8176,7 @@ and write_xml_attribute = (
       | `XmlAttrExpr x ->
         Bi_outbuf.add_string ob "[\"XmlAttrExpr\",";
         (
-          write__15
+          write__16
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `XmlEllipsis x ->
@@ -8090,7 +8202,7 @@ and write_xml_body = (
       | `XmlExpr x ->
         Bi_outbuf.add_string ob "[\"XmlExpr\",";
         (
-          write__27
+          write__28
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `XmlXml x ->
@@ -8225,7 +8337,7 @@ and read__13 = (
 )
 and _13_of_string s =
   read__13 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__15 = (
+and read__16 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -8280,9 +8392,9 @@ and read__15 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
 )
-and _15_of_string s =
-  read__15 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__16 = (
+and _16_of_string s =
+  read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__17 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -8328,9 +8440,9 @@ and read__16 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _16_of_string s =
-  read__16 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__17 = (
+and _17_of_string s =
+  read__17 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__18 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -8360,7 +8472,7 @@ and read__17 = (
                 let x0 =
                   let x =
                     (
-                      read__16
+                      read__17
                     ) p lb
                   in
                   incr len;
@@ -8371,7 +8483,7 @@ and read__17 = (
                 let x1 =
                   let x =
                     (
-                      read__16
+                      read__17
                     ) p lb
                   in
                   incr len;
@@ -8382,7 +8494,7 @@ and read__17 = (
                 let x2 =
                   let x =
                     (
-                      read__16
+                      read__17
                     ) p lb
                   in
                   incr len;
@@ -8437,37 +8549,37 @@ and read__17 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
 )
-and _17_of_string s =
-  read__17 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__18 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_action
-  )
-) p lb
 and _18_of_string s =
   read__18 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__19 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_any
+    read_action
   )
 ) p lb
 and _19_of_string s =
   read__19 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__25 p lb = (
+and read__20 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_any
+  )
+) p lb
+and _20_of_string s =
+  read__20 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__26 p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_xml_attribute
   )
 ) p lb
-and _25_of_string s =
-  read__25 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__26 p lb = (
+and _26_of_string s =
+  read__26 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__27 p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_xml_body
   )
 ) p lb
-and _26_of_string s =
-  read__26 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__27 = (
+and _27_of_string s =
+  read__27 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__28 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -8488,7 +8600,7 @@ and read__27 = (
       let x1 =
         let x =
           (
-            read__16
+            read__17
           ) p lb
         in
         incr len;
@@ -8522,18 +8634,11 @@ and read__27 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
 )
-and _27_of_string s =
-  read__27 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__28 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_argument
-  )
-) p lb
 and _28_of_string s =
   read__28 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__29 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_stmt
+    read_argument
   )
 ) p lb
 and _29_of_string s =
@@ -8586,7 +8691,14 @@ and read__3 = (
 )
 and _3_of_string s =
   read__3 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__30 = (
+and read__30 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_stmt
+  )
+) p lb
+and _30_of_string s =
+  read__30 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__31 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -8607,7 +8719,7 @@ and read__30 = (
       let x1 =
         let x =
           (
-            read__29
+            read__30
           ) p lb
         in
         incr len;
@@ -8641,9 +8753,9 @@ and read__30 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
 )
-and _30_of_string s =
-  read__30 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__31 = (
+and _31_of_string s =
+  read__31 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__32 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -8689,23 +8801,23 @@ and read__31 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _31_of_string s =
-  read__31 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__32 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_case_and_body
-  )
-) p lb
 and _32_of_string s =
   read__32 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__33 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_catch
+    read_case_and_body
   )
 ) p lb
 and _33_of_string s =
   read__33 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__34 = (
+and read__34 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_catch
+  )
+) p lb
+and _34_of_string s =
+  read__34 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__35 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -8751,73 +8863,25 @@ and read__34 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _34_of_string s =
-  read__34 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__35 p lb = (
+and _35_of_string s =
+  read__35 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__36 p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_case
   )
 ) p lb
-and _35_of_string s =
-  read__35 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__37 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_for_var_or_expr
-  )
-) p lb
-and _37_of_string s =
-  read__37 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _36_of_string s =
+  read__36 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__38 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_pattern
+    read_for_var_or_expr
   )
 ) p lb
 and _38_of_string s =
   read__38 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__39 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    fun p lb ->
-      Yojson.Safe.read_space p lb;
-      let std_tuple = Yojson.Safe.start_any_tuple p lb in
-      let len = ref 0 in
-      let end_of_tuple = ref false in
-      (try
-        let x0 =
-          let x =
-            (
-              read_dotted_ident
-            ) p lb
-          in
-          incr len;
-          Yojson.Safe.read_space p lb;
-          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-          x
-        in
-        let x1 =
-          let x =
-            (
-              read_pattern
-            ) p lb
-          in
-          incr len;
-          (try
-            Yojson.Safe.read_space p lb;
-            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-          with Yojson.End_of_tuple -> end_of_tuple := true);
-          x
-        in
-        if not !end_of_tuple then (
-          try
-            while true do
-              Yojson.Safe.skip_json p lb;
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-            done
-          with Yojson.End_of_tuple -> ()
-        );
-        (x0, x1)
-      with Yojson.End_of_tuple ->
-        Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
+    read_pattern
   )
 ) p lb
 and _39_of_string s =
@@ -8870,7 +8934,112 @@ and read__4 = (
 )
 and _4_of_string s =
   read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__40 = (
+and read__40 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    fun p lb ->
+      Yojson.Safe.read_space p lb;
+      let std_tuple = Yojson.Safe.start_any_tuple p lb in
+      let len = ref 0 in
+      let end_of_tuple = ref false in
+      (try
+        let x0 =
+          let x =
+            (
+              read_dotted_ident
+            ) p lb
+          in
+          incr len;
+          Yojson.Safe.read_space p lb;
+          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+          x
+        in
+        let x1 =
+          let x =
+            (
+              read_pattern
+            ) p lb
+          in
+          incr len;
+          (try
+            Yojson.Safe.read_space p lb;
+            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+          with Yojson.End_of_tuple -> end_of_tuple := true);
+          x
+        in
+        if not !end_of_tuple then (
+          try
+            while true do
+              Yojson.Safe.skip_json p lb;
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+            done
+          with Yojson.End_of_tuple -> ()
+        );
+        (x0, x1)
+      with Yojson.End_of_tuple ->
+        Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
+  )
+) p lb
+and _40_of_string s =
+  read__40 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__41 = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    let std_tuple = Yojson.Safe.start_any_tuple p lb in
+    let len = ref 0 in
+    let end_of_tuple = ref false in
+    (try
+      let x0 =
+        let x =
+          (
+            read_tok
+          ) p lb
+        in
+        incr len;
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+        x
+      in
+      let x1 =
+        let x =
+          (
+            read__40
+          ) p lb
+        in
+        incr len;
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+        x
+      in
+      let x2 =
+        let x =
+          (
+            read_tok
+          ) p lb
+        in
+        incr len;
+        (try
+          Yojson.Safe.read_space p lb;
+          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+        with Yojson.End_of_tuple -> end_of_tuple := true);
+        x
+      in
+      if not !end_of_tuple then (
+        try
+          while true do
+            Yojson.Safe.skip_json p lb;
+            Yojson.Safe.read_space p lb;
+            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+          done
+        with Yojson.End_of_tuple -> ()
+      );
+      (x0, x1, x2)
+    with Yojson.End_of_tuple ->
+      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
+)
+and _41_of_string s =
+  read__41 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__42 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -8925,66 +9094,9 @@ and read__40 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
 )
-and _40_of_string s =
-  read__40 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__41 = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    let std_tuple = Yojson.Safe.start_any_tuple p lb in
-    let len = ref 0 in
-    let end_of_tuple = ref false in
-    (try
-      let x0 =
-        let x =
-          (
-            read_tok
-          ) p lb
-        in
-        incr len;
-        Yojson.Safe.read_space p lb;
-        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-        x
-      in
-      let x1 =
-        let x =
-          (
-            read__38
-          ) p lb
-        in
-        incr len;
-        Yojson.Safe.read_space p lb;
-        Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-        x
-      in
-      let x2 =
-        let x =
-          (
-            read_tok
-          ) p lb
-        in
-        incr len;
-        (try
-          Yojson.Safe.read_space p lb;
-          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-        with Yojson.End_of_tuple -> end_of_tuple := true);
-        x
-      in
-      if not !end_of_tuple then (
-        try
-          while true do
-            Yojson.Safe.skip_json p lb;
-            Yojson.Safe.read_space p lb;
-            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-          done
-        with Yojson.End_of_tuple -> ()
-      );
-      (x0, x1, x2)
-    with Yojson.End_of_tuple ->
-      Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
-)
-and _41_of_string s =
-  read__41 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__42 = (
+and _42_of_string s =
+  read__42 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__43 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -9112,23 +9224,23 @@ and read__42 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _42_of_string s =
-  read__42 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__43 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_parameter
-  )
-) p lb
 and _43_of_string s =
   read__43 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__44 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_type_
+    read_parameter
   )
 ) p lb
 and _44_of_string s =
   read__44 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__45 = (
+and read__45 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_type_
+  )
+) p lb
+and _45_of_string s =
+  read__45 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__46 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     let std_tuple = Yojson.Safe.start_any_tuple p lb in
@@ -9149,7 +9261,7 @@ and read__45 = (
       let x1 =
         let x =
           (
-            read__44
+            read__45
           ) p lb
         in
         incr len;
@@ -9183,16 +9295,16 @@ and read__45 = (
     with Yojson.End_of_tuple ->
       Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1; 2 ]);
 )
-and _45_of_string s =
-  read__45 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__46 p lb = (
+and _46_of_string s =
+  read__46 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__47 p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_type_argument
   )
 ) p lb
-and _46_of_string s =
-  read__46 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__47 = (
+and _47_of_string s =
+  read__47 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__48 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -9214,7 +9326,7 @@ and read__47 = (
                       let x0 =
                         let x =
                           (
-                            read__20
+                            read__21
                           ) p lb
                         in
                         incr len;
@@ -9278,7 +9390,7 @@ and read__47 = (
                       let x0 =
                         let x =
                           (
-                            read__20
+                            read__21
                           ) p lb
                         in
                         incr len;
@@ -9320,44 +9432,44 @@ and read__47 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _47_of_string s =
-  read__47 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__49 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    read_attribute
-  )
-) p lb
-and _49_of_string s =
-  read__49 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _48_of_string s =
+  read__48 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__50 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_type_parameter
+    read_attribute
   )
 ) p lb
 and _50_of_string s =
   read__50 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__51 p lb = (
   Atdgen_runtime.Oj_run.read_list (
-    read_type_parameter_constraint
+    read_type_parameter
   )
 ) p lb
 and _51_of_string s =
   read__51 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__54 p lb = (
+and read__52 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_type_parameter_constraint
+  )
+) p lb
+and _52_of_string s =
+  read__52 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__55 p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_or_type_element
   )
 ) p lb
-and _54_of_string s =
-  read__54 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__57 p lb = (
+and _55_of_string s =
+  read__55 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__58 p lb = (
   Atdgen_runtime.Oj_run.read_list (
     read_item
   )
 ) p lb
-and _57_of_string s =
-  read__57 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__58 = (
+and _58_of_string s =
+  read__58 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__59 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -9403,8 +9515,8 @@ and read__58 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-and _58_of_string s =
-  read__58 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and _59_of_string s =
+  read__59 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__6 = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
@@ -9636,7 +9748,7 @@ and read_any = (
             | "Ss" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__29
+                  read__30
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -9681,7 +9793,7 @@ and read_any = (
             | "Args" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__28
+                  read__29
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -9760,7 +9872,7 @@ and read_any = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__29
+                  read__30
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -9815,7 +9927,7 @@ and read_any = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__28
+                  read__29
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -10018,7 +10130,7 @@ and read_argument = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -10206,7 +10318,7 @@ and read_argument = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -10240,7 +10352,7 @@ and read_argument = (
 and argument_of_string s =
   read_argument (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_arguments p lb = (
-  read__28
+  read__29
 ) p lb
 and arguments_of_string s =
   read_arguments (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -10253,7 +10365,7 @@ and read_attribute = (
             | "KeywordAttr" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__48
+                  read__49
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -10343,7 +10455,7 @@ and read_attribute = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -10385,7 +10497,7 @@ and read_attribute = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__48
+                  read__49
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -10479,7 +10591,7 @@ and read_attribute = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -10776,7 +10888,7 @@ and read_case_and_body = (
                       let x0 =
                         let x =
                           (
-                            read__35
+                            read__36
                           ) p lb
                         in
                         incr len;
@@ -10847,7 +10959,7 @@ and read_case_and_body = (
                       let x0 =
                         let x =
                           (
-                            read__35
+                            read__36
                           ) p lb
                         in
                         incr len;
@@ -11060,7 +11172,7 @@ and read_class_definition = (
             field_ckind := (
               Some (
                 (
-                  read__55
+                  read__56
                 ) p lb
               )
             );
@@ -11068,7 +11180,7 @@ and read_class_definition = (
             field_cextends := (
               Some (
                 (
-                  read__44
+                  read__45
                 ) p lb
               )
             );
@@ -11076,7 +11188,7 @@ and read_class_definition = (
             field_cimplements := (
               Some (
                 (
-                  read__44
+                  read__45
                 ) p lb
               )
             );
@@ -11084,7 +11196,7 @@ and read_class_definition = (
             field_cmixins := (
               Some (
                 (
-                  read__44
+                  read__45
                 ) p lb
               )
             );
@@ -11199,7 +11311,7 @@ and read_class_definition = (
               field_ckind := (
                 Some (
                   (
-                    read__55
+                    read__56
                   ) p lb
                 )
               );
@@ -11207,7 +11319,7 @@ and read_class_definition = (
               field_cextends := (
                 Some (
                   (
-                    read__44
+                    read__45
                   ) p lb
                 )
               );
@@ -11215,7 +11327,7 @@ and read_class_definition = (
               field_cimplements := (
                 Some (
                   (
-                    read__44
+                    read__45
                   ) p lb
                 )
               );
@@ -11223,7 +11335,7 @@ and read_class_definition = (
               field_cmixins := (
                 Some (
                   (
-                    read__44
+                    read__45
                   ) p lb
                 )
               );
@@ -11420,7 +11532,7 @@ and read_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -11581,7 +11693,7 @@ and read_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -11665,7 +11777,7 @@ and read_directive = (
                       let x3 =
                         let x =
                           (
-                            read__58
+                            read__59
                           ) p lb
                         in
                         incr len;
@@ -11726,7 +11838,7 @@ and read_directive = (
                       let x2 =
                         let x =
                           (
-                            read__58
+                            read__59
                           ) p lb
                         in
                         incr len;
@@ -11896,7 +12008,7 @@ and read_directive = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -11946,7 +12058,7 @@ and read_directive = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -12030,7 +12142,7 @@ and read_directive = (
                       let x3 =
                         let x =
                           (
-                            read__58
+                            read__59
                           ) p lb
                         in
                         incr len;
@@ -12093,7 +12205,7 @@ and read_directive = (
                       let x2 =
                         let x =
                           (
-                            read__58
+                            read__59
                           ) p lb
                         in
                         incr len;
@@ -12271,7 +12383,7 @@ and read_directive = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -12323,7 +12435,7 @@ and read_directive = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -12416,7 +12528,7 @@ and read_entity = (
             field_attrs := (
               Some (
                 (
-                  read__49
+                  read__50
                 ) p lb
               )
             );
@@ -12424,7 +12536,7 @@ and read_entity = (
             field_tparams := (
               Some (
                 (
-                  read__50
+                  read__51
                 ) p lb
               )
             );
@@ -12485,7 +12597,7 @@ and read_entity = (
               field_attrs := (
                 Some (
                   (
-                    read__49
+                    read__50
                   ) p lb
                 )
               );
@@ -12493,7 +12605,7 @@ and read_entity = (
               field_tparams := (
                 Some (
                   (
-                    read__50
+                    read__51
                   ) p lb
                 )
               );
@@ -12920,7 +13032,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read_tok
+                            read__15
                           ) p lb
                         in
                         incr len;
@@ -12981,7 +13093,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__15
+                            read__16
                           ) p lb
                         in
                         incr len;
@@ -13031,7 +13143,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__17
+                            read__18
                           ) p lb
                         in
                         incr len;
@@ -13160,7 +13272,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__18
+                            read__19
                           ) p lb
                         in
                         incr len;
@@ -13210,7 +13322,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -13469,7 +13581,7 @@ and read_expr = (
             | "DeepEllipsis" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__15
+                  read__16
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -13659,7 +13771,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -14121,7 +14233,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read_tok
+                            read__15
                           ) p lb
                         in
                         incr len;
@@ -14184,7 +14296,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__15
+                            read__16
                           ) p lb
                         in
                         incr len;
@@ -14236,7 +14348,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__17
+                            read__18
                           ) p lb
                         in
                         incr len;
@@ -14373,7 +14485,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__18
+                            read__19
                           ) p lb
                         in
                         incr len;
@@ -14425,7 +14537,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -14698,7 +14810,7 @@ and read_expr = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__15
+                  read__16
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -14896,7 +15008,7 @@ and read_expr = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -15137,7 +15249,7 @@ and read_for_header = (
                       let x0 =
                         let x =
                           (
-                            read__37
+                            read__38
                           ) p lb
                         in
                         incr len;
@@ -15148,7 +15260,7 @@ and read_for_header = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -15159,7 +15271,7 @@ and read_for_header = (
                       let x2 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -15268,7 +15380,7 @@ and read_for_header = (
                       let x0 =
                         let x =
                           (
-                            read__37
+                            read__38
                           ) p lb
                         in
                         incr len;
@@ -15330,7 +15442,7 @@ and read_for_header = (
                       let x0 =
                         let x =
                           (
-                            read__37
+                            read__38
                           ) p lb
                         in
                         incr len;
@@ -15341,7 +15453,7 @@ and read_for_header = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -15352,7 +15464,7 @@ and read_for_header = (
                       let x2 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -15467,7 +15579,7 @@ and read_for_header = (
                       let x0 =
                         let x =
                           (
-                            read__37
+                            read__38
                           ) p lb
                         in
                         incr len;
@@ -15727,7 +15839,7 @@ and read_function_definition = (
             field_fkind := (
               Some (
                 (
-                  read__52
+                  read__53
                 ) p lb
               )
             );
@@ -15823,7 +15935,7 @@ and read_function_definition = (
               field_fkind := (
                 Some (
                   (
-                    read__52
+                    read__53
                   ) p lb
                 )
               );
@@ -16056,7 +16168,7 @@ and read_label_ident = (
             | "LInt" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__36
+                  read__37
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -16099,7 +16211,7 @@ and read_label_ident = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__36
+                  read__37
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -16173,7 +16285,7 @@ and read_macro_definition = (
             field_macrobody := (
               Some (
                 (
-                  read__19
+                  read__20
                 ) p lb
               )
             );
@@ -16226,7 +16338,7 @@ and read_macro_definition = (
               field_macrobody := (
                 Some (
                   (
-                    read__19
+                    read__20
                   ) p lb
                 )
               );
@@ -16353,7 +16465,7 @@ and read_module_definition_kind = (
                       let x0 =
                         let x =
                           (
-                            read__56
+                            read__57
                           ) p lb
                         in
                         incr len;
@@ -16364,7 +16476,7 @@ and read_module_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__57
+                            read__58
                           ) p lb
                         in
                         incr len;
@@ -16414,7 +16526,7 @@ and read_module_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -16476,7 +16588,7 @@ and read_module_definition_kind = (
                       let x0 =
                         let x =
                           (
-                            read__56
+                            read__57
                           ) p lb
                         in
                         incr len;
@@ -16487,7 +16599,7 @@ and read_module_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__57
+                            read__58
                           ) p lb
                         in
                         incr len;
@@ -16539,7 +16651,7 @@ and read_module_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -17096,7 +17208,7 @@ and read_or_type_element = (
                       let x1 =
                         let x =
                           (
-                            read__44
+                            read__45
                           ) p lb
                         in
                         incr len;
@@ -17146,7 +17258,7 @@ and read_or_type_element = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -17246,7 +17358,7 @@ and read_or_type_element = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -17308,7 +17420,7 @@ and read_or_type_element = (
                       let x1 =
                         let x =
                           (
-                            read__44
+                            read__45
                           ) p lb
                         in
                         incr len;
@@ -17360,7 +17472,7 @@ and read_or_type_element = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -17464,7 +17576,7 @@ and read_or_type_element = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -17653,7 +17765,7 @@ and read_parameter = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -17852,7 +17964,7 @@ and read_parameter = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -17966,7 +18078,7 @@ and read_parameter_classic = (
             field_pname := (
               Some (
                 (
-                  read__53
+                  read__54
                 ) p lb
               )
             );
@@ -17982,7 +18094,7 @@ and read_parameter_classic = (
             field_pdefault := (
               Some (
                 (
-                  read__16
+                  read__17
                 ) p lb
               )
             );
@@ -17990,7 +18102,7 @@ and read_parameter_classic = (
             field_pattrs := (
               Some (
                 (
-                  read__49
+                  read__50
                 ) p lb
               )
             );
@@ -18078,7 +18190,7 @@ and read_parameter_classic = (
               field_pname := (
                 Some (
                   (
-                    read__53
+                    read__54
                   ) p lb
                 )
               );
@@ -18094,7 +18206,7 @@ and read_parameter_classic = (
               field_pdefault := (
                 Some (
                   (
-                    read__16
+                    read__17
                   ) p lb
                 )
               );
@@ -18102,7 +18214,7 @@ and read_parameter_classic = (
               field_pattrs := (
                 Some (
                   (
-                    read__49
+                    read__50
                   ) p lb
                 )
               );
@@ -18135,7 +18247,7 @@ and read_parameter_classic = (
 and parameter_classic_of_string s =
   read_parameter_classic (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_parameters p lb = (
-  read__43
+  read__44
 ) p lb
 and parameters_of_string s =
   read_parameters (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -18177,7 +18289,7 @@ and read_pattern = (
                       let x1 =
                         let x =
                           (
-                            read__38
+                            read__39
                           ) p lb
                         in
                         incr len;
@@ -18207,7 +18319,7 @@ and read_pattern = (
             | "PatRecord" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__40
+                  read__41
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -18266,7 +18378,7 @@ and read_pattern = (
             | "PatTuple" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__41
+                  read__42
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -18275,7 +18387,7 @@ and read_pattern = (
             | "PatList" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__41
+                  read__42
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -18613,7 +18725,7 @@ and read_pattern = (
                       let x1 =
                         let x =
                           (
-                            read__42
+                            read__43
                           ) p lb
                         in
                         incr len;
@@ -18722,7 +18834,7 @@ and read_pattern = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -18795,7 +18907,7 @@ and read_pattern = (
                       let x1 =
                         let x =
                           (
-                            read__38
+                            read__39
                           ) p lb
                         in
                         incr len;
@@ -18827,7 +18939,7 @@ and read_pattern = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__40
+                  read__41
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -18890,7 +19002,7 @@ and read_pattern = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__41
+                  read__42
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -18901,7 +19013,7 @@ and read_pattern = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__41
+                  read__42
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -19255,7 +19367,7 @@ and read_pattern = (
                       let x1 =
                         let x =
                           (
-                            read__42
+                            read__43
                           ) p lb
                         in
                         incr len;
@@ -19370,7 +19482,7 @@ and read_pattern = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -19751,7 +19863,7 @@ and read_stmt_kind = (
             | "Block" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__30
+                  read__31
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -19802,7 +19914,7 @@ and read_stmt_kind = (
                       let x3 =
                         let x =
                           (
-                            read__31
+                            read__32
                           ) p lb
                         in
                         incr len;
@@ -19913,7 +20025,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -20096,7 +20208,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -20107,7 +20219,7 @@ and read_stmt_kind = (
                       let x2 =
                         let x =
                           (
-                            read__32
+                            read__33
                           ) p lb
                         in
                         incr len;
@@ -20451,7 +20563,7 @@ and read_stmt_kind = (
                       let x2 =
                         let x =
                           (
-                            read__33
+                            read__34
                           ) p lb
                         in
                         incr len;
@@ -20462,7 +20574,7 @@ and read_stmt_kind = (
                       let x3 =
                         let x =
                           (
-                            read__34
+                            read__35
                           ) p lb
                         in
                         incr len;
@@ -20584,7 +20696,7 @@ and read_stmt_kind = (
                       let x2 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -20713,7 +20825,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -20774,7 +20886,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -20868,7 +20980,7 @@ and read_stmt_kind = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__30
+                  read__31
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -20921,7 +21033,7 @@ and read_stmt_kind = (
                       let x3 =
                         let x =
                           (
-                            read__31
+                            read__32
                           ) p lb
                         in
                         incr len;
@@ -21036,7 +21148,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -21225,7 +21337,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -21236,7 +21348,7 @@ and read_stmt_kind = (
                       let x2 =
                         let x =
                           (
-                            read__32
+                            read__33
                           ) p lb
                         in
                         incr len;
@@ -21592,7 +21704,7 @@ and read_stmt_kind = (
                       let x2 =
                         let x =
                           (
-                            read__33
+                            read__34
                           ) p lb
                         in
                         incr len;
@@ -21603,7 +21715,7 @@ and read_stmt_kind = (
                       let x3 =
                         let x =
                           (
-                            read__34
+                            read__35
                           ) p lb
                         in
                         incr len;
@@ -21729,7 +21841,7 @@ and read_stmt_kind = (
                       let x2 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -21866,7 +21978,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__16
+                            read__17
                           ) p lb
                         in
                         incr len;
@@ -21929,7 +22041,7 @@ and read_stmt_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -21989,7 +22101,7 @@ and read_type_ = (
                       let x0 =
                         let x =
                           (
-                            read__43
+                            read__44
                           ) p lb
                         in
                         incr len;
@@ -22039,7 +22151,7 @@ and read_type_ = (
                       let x0 =
                         let x =
                           (
-                            read__27
+                            read__28
                           ) p lb
                         in
                         incr len;
@@ -22080,7 +22192,7 @@ and read_type_ = (
             | "TyTuple" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__45
+                  read__46
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -22617,7 +22729,7 @@ and read_type_ = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -22679,7 +22791,7 @@ and read_type_ = (
                       let x0 =
                         let x =
                           (
-                            read__43
+                            read__44
                           ) p lb
                         in
                         incr len;
@@ -22731,7 +22843,7 @@ and read_type_ = (
                       let x0 =
                         let x =
                           (
-                            read__27
+                            read__28
                           ) p lb
                         in
                         incr len;
@@ -22774,7 +22886,7 @@ and read_type_ = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__45
+                  read__46
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -23339,7 +23451,7 @@ and read_type_ = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -23410,7 +23522,7 @@ and read_type_argument = (
                       let x1 =
                         let x =
                           (
-                            read__47
+                            read__48
                           ) p lb
                         in
                         incr len;
@@ -23469,7 +23581,7 @@ and read_type_argument = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -23542,7 +23654,7 @@ and read_type_argument = (
                       let x1 =
                         let x =
                           (
-                            read__47
+                            read__48
                           ) p lb
                         in
                         incr len;
@@ -23605,7 +23717,7 @@ and read_type_argument = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -23639,7 +23751,7 @@ and read_type_argument = (
 and type_argument_of_string s =
   read_type_argument (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read_type_arguments p lb = (
-  read__46
+  read__47
 ) p lb
 and type_arguments_of_string s =
   read_type_arguments (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
@@ -23731,7 +23843,7 @@ and read_type_definition_kind = (
             | "OrType" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__54
+                  read__55
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -23787,7 +23899,7 @@ and read_type_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__44
+                            read__45
                           ) p lb
                         in
                         incr len;
@@ -23837,7 +23949,7 @@ and read_type_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -23879,7 +23991,7 @@ and read_type_definition_kind = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__54
+                  read__55
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -23943,7 +24055,7 @@ and read_type_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__44
+                            read__45
                           ) p lb
                         in
                         incr len;
@@ -23995,7 +24107,7 @@ and read_type_definition_kind = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -24049,7 +24161,7 @@ and read_type_parameter = (
       let x1 =
         let x =
           (
-            read__51
+            read__52
           ) p lb
         in
         incr len;
@@ -24121,7 +24233,7 @@ and read_type_parameter_constraint = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -24205,7 +24317,7 @@ and read_type_parameter_constraint = (
                       let x1 =
                         let x =
                           (
-                            read__19
+                            read__20
                           ) p lb
                         in
                         incr len;
@@ -24286,7 +24398,7 @@ and read_variable_definition = (
             field_vinit := (
               Some (
                 (
-                  read__16
+                  read__17
                 ) p lb
               )
             );
@@ -24344,7 +24456,7 @@ and read_variable_definition = (
               field_vinit := (
                 Some (
                   (
-                    read__16
+                    read__17
                   ) p lb
                 )
               );
@@ -24444,7 +24556,7 @@ and read_xml = (
             field_xml_attrs := (
               Some (
                 (
-                  read__25
+                  read__26
                 ) p lb
               )
             );
@@ -24452,7 +24564,7 @@ and read_xml = (
             field_xml_body := (
               Some (
                 (
-                  read__26
+                  read__27
                 ) p lb
               )
             );
@@ -24524,7 +24636,7 @@ and read_xml = (
               field_xml_attrs := (
                 Some (
                   (
-                    read__25
+                    read__26
                   ) p lb
                 )
               );
@@ -24532,7 +24644,7 @@ and read_xml = (
               field_xml_body := (
                 Some (
                   (
-                    read__26
+                    read__27
                   ) p lb
                 )
               );
@@ -24629,7 +24741,7 @@ and read_xml_attribute = (
             | "XmlAttrExpr" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__15
+                  read__16
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -24722,7 +24834,7 @@ and read_xml_attribute = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__15
+                  read__16
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -24763,7 +24875,7 @@ and read_xml_body = (
             | "XmlExpr" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__27
+                  read__28
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -24804,7 +24916,7 @@ and read_xml_body = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__27
+                  read__28
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -24894,14 +25006,14 @@ let read_wrap_ read__a = (
 let wrap__of_string read__a s =
   read_wrap_ read__a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_program = (
-  write__57
+  write__58
 )
 let string_of_program ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write_program ob x;
   Bi_outbuf.contents ob
 let read_program = (
-  read__57
+  read__58
 )
 let program_of_string s =
   read_program (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/ast_generic_v0_j.mli
+++ b/ast_generic_v0_j.mli
@@ -9,6 +9,8 @@ type const_type = Ast_generic_v0_t.const_type
 
 type container_operator = Ast_generic_v0_t.container_operator
 
+type dot_operator = Ast_generic_v0_t.dot_operator
+
 type function_kind = Ast_generic_v0_t.function_kind
 
 type incr_decr = Ast_generic_v0_t.incr_decr
@@ -281,6 +283,26 @@ val read_container_operator :
 val container_operator_of_string :
   string -> container_operator
   (** Deserialize JSON data of type {!type:container_operator}. *)
+
+val write_dot_operator :
+  Bi_outbuf.t -> dot_operator -> unit
+  (** Output a JSON value of type {!type:dot_operator}. *)
+
+val string_of_dot_operator :
+  ?len:int -> dot_operator -> string
+  (** Serialize a value of type {!type:dot_operator}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_dot_operator :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> dot_operator
+  (** Input JSON data of type {!type:dot_operator}. *)
+
+val dot_operator_of_string :
+  string -> dot_operator
+  (** Deserialize JSON data of type {!type:dot_operator}. *)
 
 val write_function_kind :
   Bi_outbuf.t -> function_kind -> unit


### PR DESCRIPTION
## What:
Added a new `dot_operator` which will help us differentiate different kinds of DotAccesses.

## Why:
We want to be able to match in a way that is different for different kinds of dot accesses, such as `x.y` and `x?.y` in JS, or some more examples for Kotlin.

## How:
Added a new `dot_operator` type, which is extensible and may be used in the future to add other varieties of dot accesses.
