### PR TITLE
feat(schema): update rule schema for syntax extensions

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -416,6 +416,7 @@ $defs:
     type: object
     properties:
       pattern-inside:
+        title: Return findings only from within snippets Semgrep pattern matches
         $ref: "#/$defs/general-pattern-content"
     required:
       - pattern-inside
@@ -424,6 +425,7 @@ $defs:
     type: object
     properties:
       pattern-not-inside:
+        title: Do not return findings from within snippets Semgrep pattern matches
         $ref: "#/$defs/general-pattern-content"
     required:
       - pattern-not-inside
@@ -432,6 +434,7 @@ $defs:
     type: object
     properties:
       pattern-not:
+        title: Do not return finding where Semgrep pattern matches exactly
         $ref: "#/$defs/general-pattern-content"
     required:
       - pattern-not

--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -2,6 +2,34 @@ $id: https://raw.githubusercontent.com/returntocorp/semgrep-interfaces/main/rule
 $schema: http://json-schema.org/draft-07/schema#
 $comment: "!!If you modify this file, you need to update the submodule in returntocorp/semgrep and returntocorp/semgrep-app!!"
 $defs:
+  general-pattern-content:
+    title: "Return finding where code matches against the following pattern"
+    oneOf:
+    - type: string
+    - type: object
+      oneOf:
+        - required: [ pattern ]
+        - required: [ pattern-regex ]
+        - required: [ patterns ]
+        - required: [ pattern-either ]
+        - required: [ pattern-not ]
+        - required: [ pattern-inside ]
+        - required: [ pattern-not-inside ]
+      properties:
+        pattern:
+          type: string
+        pattern-regex:
+          type: string
+        patterns:
+          $ref: "#/$defs/patterns-content"
+        pattern-either:
+          $ref: "#/$defs/pattern-either-content"
+        pattern-not:
+          $ref: "#/$defs/general-pattern-content"
+        pattern-inside:
+          $ref: "#/$defs/general-pattern-content"
+        pattern-not-inside:
+          $ref: "#/$defs/general-pattern-content"
   patterns-content:
     type: array
     title: "Return finding where all of the nested conditions are true"
@@ -388,8 +416,7 @@ $defs:
     type: object
     properties:
       pattern-inside:
-        title: Return findings only from within snippets Semgrep pattern matches
-        type: string
+        $ref: "#/$defs/general-pattern-content"
     required:
       - pattern-inside
     additionalProperties: false
@@ -397,8 +424,7 @@ $defs:
     type: object
     properties:
       pattern-not-inside:
-        title: Do not return findings from within snippets Semgrep pattern matches
-        type: string
+        $ref: "#/$defs/general-pattern-content"
     required:
       - pattern-not-inside
     additionalProperties: false
@@ -406,8 +432,7 @@ $defs:
     type: object
     properties:
       pattern-not:
-        title: Do not return finding where Semgrep pattern matches exactly
-        type: string
+        $ref: "#/$defs/general-pattern-content"
     required:
       - pattern-not
     additionalProperties: false


### PR DESCRIPTION
## What:
This is meant to go along with https://github.com/returntocorp/semgrep/pull/6474. We update the rule schema here to match the corresponding syntax changes.

## Why:
Make SR lives easier!

## How:
Just updated the schema, in hopefully the right way.

## Test plan:
I can't add a test in this repo, but this file parses properly:
```
rules:
- id: rule-extensions 
  patterns:
  - pattern-not: "A"
  - pattern-not: 
      pattern: "A"
  - pattern-inside:
      pattern-regex: "B"
  - pattern-not-inside:
      pattern-not: "C"
  message: This rule is just meant to illustrate that we can parse "extensions" to old-grammar rules. 
  severity: WARNING
  languages: [python]
```

