### PR TITLE
fix bug in schema

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -6,30 +6,39 @@ $defs:
     title: "Return finding where code matches against the following pattern"
     oneOf:
     - type: string
-    - type: object
-      oneOf:
-        - required: [ pattern ]
-        - required: [ pattern-regex ]
-        - required: [ patterns ]
-        - required: [ pattern-either ]
-        - required: [ pattern-not ]
-        - required: [ pattern-inside ]
-        - required: [ pattern-not-inside ]
-      properties:
-        pattern:
-          type: string
-        pattern-regex:
-          type: string
-        patterns:
-          $ref: "#/$defs/patterns-content"
-        pattern-either:
-          $ref: "#/$defs/pattern-either-content"
-        pattern-not:
-          $ref: "#/$defs/general-pattern-content"
-        pattern-inside:
-          $ref: "#/$defs/general-pattern-content"
-        pattern-not-inside:
-          $ref: "#/$defs/general-pattern-content"
+    # This is scuffed, but it seems that `allOf` does not short circuit.
+    # This schema can potentially run on things which are not objects (such as lists), and if that happens,
+    # the validator will crash when it checks the keys of the object.
+    # I would normally just use `allOf`, but since it doensn't short circuit, I had to instead make it this
+    # weird `if-then-else` thing to properly skip the keys check on a non-object.
+    - if:
+        type: object
+      then:
+        oneOf:
+          - required: [ pattern ]
+          - required: [ pattern-regex ]
+          - required: [ patterns ]
+          - required: [ pattern-either ]
+          - required: [ pattern-not ]
+          - required: [ pattern-inside ]
+          - required: [ pattern-not-inside ]
+        properties:
+          pattern:
+            type: string
+          pattern-regex:
+            type: string
+          patterns:
+            $ref: "#/$defs/patterns-content"
+          pattern-either:
+            $ref: "#/$defs/pattern-either-content"
+          pattern-not:
+            $ref: "#/$defs/general-pattern-content"
+          pattern-inside:
+            $ref: "#/$defs/general-pattern-content"
+          pattern-not-inside:
+            $ref: "#/$defs/general-pattern-content"
+      else:
+        type: object
   patterns-content:
     type: array
     title: "Return finding where all of the nested conditions are true"


### PR DESCRIPTION
## What:
we fail ungracefully on certain rules, due to a bug in the schema. I think there's actually a bug in the validator. If we check for the presence of a key on something which is not a dictionary (object), Semgrep will die in the CLI

## Why:
we want to fail gracefully, by having the schema reject the unvalidated rule

## How:
I had to change it to first explicitly make it safe that it's an object, and if so, then do the `keys()` check. Otherwise, it will just fail (by reusing the same condition).

## Test plan:
I tested this with the `semgrep` snapshots, and it seems good now.