### PR TITLE
refactor dataflow traces

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -122,6 +122,13 @@ type core_match_extra
   ?rendered_fix: string option;
 }
 
+type core_match_call_trace
+  <ocaml attr="deriving show">
+  <python decorator="dataclass(frozen=True, order=True)"> = [
+  | CoreLoc of location
+  | CoreCall of (location * core_match_intermediate_var list * core_match_call_trace) 
+] <ocaml repr="classic">
+
 (* Provides information about dataflow that leads to a finding. For now, just
  * provides taint traces (i.e. information about the taint source and how the
  * source reaches the sink). In the future, we may want to include more dataflow
@@ -130,13 +137,14 @@ type core_match_extra
 type core_match_dataflow_trace
   <ocaml attr="deriving show">
   <python decorator="dataclass(frozen=True)"> = {
-  ?taint_source: location option;
+  ?taint_source: core_match_call_trace option;
   (* Intermediate variables which are involved in the dataflow. For taint, this
    * explains how the taint flows from the source to the sink. *)
   ?intermediate_vars: core_match_intermediate_var list option;
   (* For now, omitting the taint sink, since it's redundant data except for
    * certain cases that only appear with DeepSemgrep. We can add it in later
    * without breaking consumers. *)
+  ?taint_sink: core_match_call_trace option;
 }
 
 type core_match_intermediate_var
@@ -484,6 +492,13 @@ type position_bis <ocaml attr="deriving show"> = {
   col: int; (* starts from 1 *)
   }
 
+type cli_match_call_trace
+  <ocaml attr="deriving show">
+  <python decorator="dataclass(frozen=True, order=True)"> = [
+  | CliLoc of (location * string)
+  | CliCall of ((location * string) * cli_match_intermediate_var list * cli_match_call_trace) 
+] <ocaml repr="classic">
+
 (* from rule_lang.py in the Span class
  * "The path to the pattern in the yaml rule
  *  and an adjusted start/end within just the pattern
@@ -493,13 +508,14 @@ type position_bis <ocaml attr="deriving show"> = {
 type cli_match_dataflow_trace
   <ocaml attr="deriving show">
   <python decorator="dataclass(frozen=True)"> = {
-  ?taint_source: cli_match_taint_source option;
+  ?taint_source: cli_match_call_trace option;
   (* Intermediate variables which are involved in the dataflow. For taint, this
    * explains how the taint flows from the source to the sink. *)
   ?intermediate_vars: cli_match_intermediate_var list option;
   (* For now, omitting the taint sink, since it's redundant data except for
    * certain cases that only appear with DeepSemgrep. We can add it in later
    * without breaking consumers. *)
+  ?taint_sink: cli_match_call_trace option;
 }
 
 (* EXPERIMENTAL *)

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -64,15 +64,52 @@
         "rendered_fix": { "type": "string" }
       }
     },
+    "core_match_call_trace": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": false,
+          "prefixItems": [
+            { "const": "CoreLoc" },
+            { "$ref": "#/definitions/location" }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": false,
+          "prefixItems": [
+            { "const": "CoreCall" },
+            {
+              "type": "array",
+              "minItems": 3,
+              "items": false,
+              "prefixItems": [
+                { "$ref": "#/definitions/location" },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/core_match_intermediate_var"
+                  }
+                },
+                { "$ref": "#/definitions/core_match_call_trace" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "core_match_dataflow_trace": {
       "type": "object",
       "required": [],
       "properties": {
-        "taint_source": { "$ref": "#/definitions/location" },
+        "taint_source": { "$ref": "#/definitions/core_match_call_trace" },
         "intermediate_vars": {
           "type": "array",
           "items": { "$ref": "#/definitions/core_match_intermediate_var" }
-        }
+        },
+        "taint_sink": { "$ref": "#/definitions/core_match_call_trace" }
       }
     },
     "core_match_intermediate_var": {
@@ -357,15 +394,68 @@
         "col": { "type": "integer" }
       }
     },
+    "cli_match_call_trace": {
+      "oneOf": [
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": false,
+          "prefixItems": [
+            { "const": "CliLoc" },
+            {
+              "type": "array",
+              "minItems": 2,
+              "items": false,
+              "prefixItems": [
+                { "$ref": "#/definitions/location" },
+                { "type": "string" }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "array",
+          "minItems": 2,
+          "items": false,
+          "prefixItems": [
+            { "const": "CliCall" },
+            {
+              "type": "array",
+              "minItems": 3,
+              "items": false,
+              "prefixItems": [
+                {
+                  "type": "array",
+                  "minItems": 2,
+                  "items": false,
+                  "prefixItems": [
+                    { "$ref": "#/definitions/location" },
+                    { "type": "string" }
+                  ]
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/cli_match_intermediate_var"
+                  }
+                },
+                { "$ref": "#/definitions/cli_match_call_trace" }
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "cli_match_dataflow_trace": {
       "type": "object",
       "required": [],
       "properties": {
-        "taint_source": { "$ref": "#/definitions/cli_match_taint_source" },
+        "taint_source": { "$ref": "#/definitions/cli_match_call_trace" },
         "intermediate_vars": {
           "type": "array",
           "items": { "$ref": "#/definitions/cli_match_intermediate_var" }
-        }
+        },
+        "taint_sink": { "$ref": "#/definitions/cli_match_call_trace" }
       }
     },
     "cli_match_taint_source": {

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -39,9 +39,14 @@ export type CoreMatchExtra = {
   rendered_fix?: string;
 }
 
+export type CoreMatchCallTrace =
+| { kind: 'CoreLoc'; value: Location }
+| { kind: 'CoreCall'; value: [Location, CoreMatchIntermediateVar[], CoreMatchCallTrace] }
+
 export type CoreMatchDataflowTrace = {
-  taint_source?: Location;
+  taint_source?: CoreMatchCallTrace;
   intermediate_vars?: CoreMatchIntermediateVar[];
+  taint_sink?: CoreMatchCallTrace;
 }
 
 export type CoreMatchIntermediateVar = {
@@ -206,9 +211,14 @@ export type PositionBis = {
   col: Int;
 }
 
+export type CliMatchCallTrace =
+| { kind: 'CliLoc'; value: [Location, string] }
+| { kind: 'CliCall'; value: [[Location, string], CliMatchIntermediateVar[], CliMatchCallTrace] }
+
 export type CliMatchDataflowTrace = {
-  taint_source?: CliMatchTaintSource;
+  taint_source?: CliMatchCallTrace;
   intermediate_vars?: CliMatchIntermediateVar[];
+  taint_sink?: CliMatchCallTrace;
 }
 
 export type CliMatchTaintSource = {
@@ -457,17 +467,41 @@ export function readCoreMatchExtra(x: any, context: any = x): CoreMatchExtra {
   };
 }
 
+export function writeCoreMatchCallTrace(x: CoreMatchCallTrace, context: any = x): any {
+  switch (x.kind) {
+    case 'CoreLoc':
+      return ['CoreLoc', writeLocation(x.value, x)]
+    case 'CoreCall':
+      return ['CoreCall', ((x, context) => [writeLocation(x[0], x), _atd_write_array(writeCoreMatchIntermediateVar)(x[1], x), writeCoreMatchCallTrace(x[2], x)])(x.value, x)]
+  }
+}
+
+export function readCoreMatchCallTrace(x: any, context: any = x): CoreMatchCallTrace {
+  _atd_check_json_tuple(2, x, context)
+  switch (x[0]) {
+    case 'CoreLoc':
+      return { kind: 'CoreLoc', value: readLocation(x[1], x) }
+    case 'CoreCall':
+      return { kind: 'CoreCall', value: ((x, context): [Location, CoreMatchIntermediateVar[], CoreMatchCallTrace] => { _atd_check_json_tuple(3, x, context); return [readLocation(x[0], x), _atd_read_array(readCoreMatchIntermediateVar)(x[1], x), readCoreMatchCallTrace(x[2], x)] })(x[1], x) }
+    default:
+      _atd_bad_json('CoreMatchCallTrace', x, context)
+      throw new Error('impossible')
+  }
+}
+
 export function writeCoreMatchDataflowTrace(x: CoreMatchDataflowTrace, context: any = x): any {
   return {
-    'taint_source': _atd_write_optional_field(writeLocation, x.taint_source, x),
+    'taint_source': _atd_write_optional_field(writeCoreMatchCallTrace, x.taint_source, x),
     'intermediate_vars': _atd_write_optional_field(_atd_write_array(writeCoreMatchIntermediateVar), x.intermediate_vars, x),
+    'taint_sink': _atd_write_optional_field(writeCoreMatchCallTrace, x.taint_sink, x),
   };
 }
 
 export function readCoreMatchDataflowTrace(x: any, context: any = x): CoreMatchDataflowTrace {
   return {
-    taint_source: _atd_read_optional_field(readLocation, x['taint_source'], x),
+    taint_source: _atd_read_optional_field(readCoreMatchCallTrace, x['taint_source'], x),
     intermediate_vars: _atd_read_optional_field(_atd_read_array(readCoreMatchIntermediateVar), x['intermediate_vars'], x),
+    taint_sink: _atd_read_optional_field(readCoreMatchCallTrace, x['taint_sink'], x),
   };
 }
 
@@ -993,17 +1027,41 @@ export function readPositionBis(x: any, context: any = x): PositionBis {
   };
 }
 
+export function writeCliMatchCallTrace(x: CliMatchCallTrace, context: any = x): any {
+  switch (x.kind) {
+    case 'CliLoc':
+      return ['CliLoc', ((x, context) => [writeLocation(x[0], x), _atd_write_string(x[1], x)])(x.value, x)]
+    case 'CliCall':
+      return ['CliCall', ((x, context) => [((x, context) => [writeLocation(x[0], x), _atd_write_string(x[1], x)])(x[0], x), _atd_write_array(writeCliMatchIntermediateVar)(x[1], x), writeCliMatchCallTrace(x[2], x)])(x.value, x)]
+  }
+}
+
+export function readCliMatchCallTrace(x: any, context: any = x): CliMatchCallTrace {
+  _atd_check_json_tuple(2, x, context)
+  switch (x[0]) {
+    case 'CliLoc':
+      return { kind: 'CliLoc', value: ((x, context): [Location, string] => { _atd_check_json_tuple(2, x, context); return [readLocation(x[0], x), _atd_read_string(x[1], x)] })(x[1], x) }
+    case 'CliCall':
+      return { kind: 'CliCall', value: ((x, context): [[Location, string], CliMatchIntermediateVar[], CliMatchCallTrace] => { _atd_check_json_tuple(3, x, context); return [((x, context): [Location, string] => { _atd_check_json_tuple(2, x, context); return [readLocation(x[0], x), _atd_read_string(x[1], x)] })(x[0], x), _atd_read_array(readCliMatchIntermediateVar)(x[1], x), readCliMatchCallTrace(x[2], x)] })(x[1], x) }
+    default:
+      _atd_bad_json('CliMatchCallTrace', x, context)
+      throw new Error('impossible')
+  }
+}
+
 export function writeCliMatchDataflowTrace(x: CliMatchDataflowTrace, context: any = x): any {
   return {
-    'taint_source': _atd_write_optional_field(writeCliMatchTaintSource, x.taint_source, x),
+    'taint_source': _atd_write_optional_field(writeCliMatchCallTrace, x.taint_source, x),
     'intermediate_vars': _atd_write_optional_field(_atd_write_array(writeCliMatchIntermediateVar), x.intermediate_vars, x),
+    'taint_sink': _atd_write_optional_field(writeCliMatchCallTrace, x.taint_sink, x),
   };
 }
 
 export function readCliMatchDataflowTrace(x: any, context: any = x): CliMatchDataflowTrace {
   return {
-    taint_source: _atd_read_optional_field(readCliMatchTaintSource, x['taint_source'], x),
+    taint_source: _atd_read_optional_field(readCliMatchCallTrace, x['taint_source'], x),
     intermediate_vars: _atd_read_optional_field(_atd_read_array(readCliMatchIntermediateVar), x['intermediate_vars'], x),
+    taint_sink: _atd_read_optional_field(readCliMatchCallTrace, x['taint_sink'], x),
   };
 }
 


### PR DESCRIPTION
Added call traces to the output of the Semgrep CLI. This will allow us to output dataflow traces in the JSON, text, and SARIF output from Semgrep CLI