### PR TITLE
Include a list of imports in ImportFrom node

### DIFF
--- a/ast_generic_v1.atd
+++ b/ast_generic_v1.atd
@@ -1001,7 +1001,7 @@ type macro_definition = {
 type directive = [
   (* newvar: *)
   | ImportFrom of (tok (* 'import'/'from' for Python, 'include' for C *) *
-                  module_name * ident * alias option) (* as name alias *)
+                  module_name * (ident * alias option (* as name alias *)) list)
 
   | ImportAs   of (tok * module_name * alias option) (* as name *)
   (* bad practice! hard to resolve name locally *)


### PR DESCRIPTION
Some languages (JS/TS and Python, that I'm aware of) allow a single import statement to import multiple symbols, e.g. in JS:

```import {x, y} from 'z'```

Currently, we desugar these into multiple imports, but this leads to
strange edge case behavior.