### PR TITLE
feat!: add memory usage

### DIFF
--- a/ast_generic_v1_j.ml
+++ b/ast_generic_v1_j.ml
@@ -1458,15 +1458,12 @@ let write_special = (
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `Require -> Bi_outbuf.add_string ob "\"Require\""
-<<<<<<< HEAD
       | `OtherSpecial x ->
         Bi_outbuf.add_string ob "[\"OtherSpecial\",";
         (
           Yojson.Safe.write_string
         ) ob x;
         Bi_outbuf.add_char ob ']'
-=======
->>>>>>> 04a9cb3 (add memory usage)
 )
 let string_of_special ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
@@ -1611,7 +1608,6 @@ let read_special = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `Require
-<<<<<<< HEAD
             | "OtherSpecial" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
@@ -1621,8 +1617,6 @@ let read_special = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `OtherSpecial x
-=======
->>>>>>> 04a9cb3 (add memory usage)
             | x ->
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
@@ -5372,11 +5366,7 @@ and string_of__69 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__69 ob x;
   Bi_outbuf.contents ob
-<<<<<<< HEAD
 and write__70 ob x = (
-=======
-and write__59 ob x = (
->>>>>>> 04a9cb3 (add memory usage)
   Atdgen_runtime.Oj_run.write_list (
     fun ob x ->
       Bi_outbuf.add_char ob '[';
@@ -5388,26 +5378,10 @@ and write__59 ob x = (
       Bi_outbuf.add_char ob ',';
       (let _, x = x in
       (
-<<<<<<< HEAD
         write__69
       ) ob x
       );
       Bi_outbuf.add_char ob ']';
-=======
-        write__58
-      ) ob x
-      );
-      Bi_outbuf.add_char ob ']';
-  )
-) ob x
-and string_of__59 ?(len = 1024) x =
-  let ob = Bi_outbuf.create len in
-  write__59 ob x;
-  Bi_outbuf.contents ob
-and write__6 ob x = (
-  Atdgen_runtime.Oj_run.write_std_option (
-    write_type_
->>>>>>> 04a9cb3 (add memory usage)
   )
 ) ob x
 and string_of__70 ?(len = 1024) x =
@@ -6164,11 +6138,7 @@ and write_directive = (
             Bi_outbuf.add_char ob ',';
             (let _, _, x = x in
             (
-<<<<<<< HEAD
               write__70
-=======
-              write__59
->>>>>>> 04a9cb3 (add memory usage)
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -9836,63 +9806,9 @@ and read__4 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-<<<<<<< HEAD
 and _4_of_string s =
   read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__40 = (
-=======
-and _58_of_string s =
-  read__58 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__59 p lb = (
-  Atdgen_runtime.Oj_run.read_list (
-    fun p lb ->
-      Yojson.Safe.read_space p lb;
-      let std_tuple = Yojson.Safe.start_any_tuple p lb in
-      let len = ref 0 in
-      let end_of_tuple = ref false in
-      (try
-        let x0 =
-          let x =
-            (
-              read_ident
-            ) p lb
-          in
-          incr len;
-          Yojson.Safe.read_space p lb;
-          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-          x
-        in
-        let x1 =
-          let x =
-            (
-              read__58
-            ) p lb
-          in
-          incr len;
-          (try
-            Yojson.Safe.read_space p lb;
-            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-          with Yojson.End_of_tuple -> end_of_tuple := true);
-          x
-        in
-        if not !end_of_tuple then (
-          try
-            while true do
-              Yojson.Safe.skip_json p lb;
-              Yojson.Safe.read_space p lb;
-              Yojson.Safe.read_tuple_sep2 p std_tuple lb;
-            done
-          with Yojson.End_of_tuple -> ()
-        );
-        (x0, x1)
-      with Yojson.End_of_tuple ->
-        Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
-  )
-) p lb
-and _59_of_string s =
-  read__59 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-and read__6 = (
->>>>>>> 04a9cb3 (add memory usage)
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -13599,11 +13515,7 @@ and read_directive = (
                       let x2 =
                         let x =
                           (
-<<<<<<< HEAD
                             read__70
-=======
-                            read__59
->>>>>>> 04a9cb3 (add memory usage)
                           ) p lb
                         in
                         incr len;
@@ -13957,11 +13869,7 @@ and read_directive = (
                       let x2 =
                         let x =
                           (
-<<<<<<< HEAD
                             read__70
-=======
-                            read__59
->>>>>>> 04a9cb3 (add memory usage)
                           ) p lb
                         in
                         incr len;

--- a/ast_generic_v1_j.ml
+++ b/ast_generic_v1_j.ml
@@ -1458,12 +1458,15 @@ let write_special = (
         ) ob x;
         Bi_outbuf.add_char ob ']'
       | `Require -> Bi_outbuf.add_string ob "\"Require\""
+<<<<<<< HEAD
       | `OtherSpecial x ->
         Bi_outbuf.add_string ob "[\"OtherSpecial\",";
         (
           Yojson.Safe.write_string
         ) ob x;
         Bi_outbuf.add_char ob ']'
+=======
+>>>>>>> 04a9cb3 (add memory usage)
 )
 let string_of_special ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
@@ -1608,6 +1611,7 @@ let read_special = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `Require
+<<<<<<< HEAD
             | "OtherSpecial" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
@@ -1617,6 +1621,8 @@ let read_special = (
               Yojson.Safe.read_space p lb;
               Yojson.Safe.read_gt p lb;
               `OtherSpecial x
+=======
+>>>>>>> 04a9cb3 (add memory usage)
             | x ->
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
@@ -5366,7 +5372,11 @@ and string_of__69 ?(len = 1024) x =
   let ob = Bi_outbuf.create len in
   write__69 ob x;
   Bi_outbuf.contents ob
+<<<<<<< HEAD
 and write__70 ob x = (
+=======
+and write__59 ob x = (
+>>>>>>> 04a9cb3 (add memory usage)
   Atdgen_runtime.Oj_run.write_list (
     fun ob x ->
       Bi_outbuf.add_char ob '[';
@@ -5378,10 +5388,26 @@ and write__70 ob x = (
       Bi_outbuf.add_char ob ',';
       (let _, x = x in
       (
+<<<<<<< HEAD
         write__69
       ) ob x
       );
       Bi_outbuf.add_char ob ']';
+=======
+        write__58
+      ) ob x
+      );
+      Bi_outbuf.add_char ob ']';
+  )
+) ob x
+and string_of__59 ?(len = 1024) x =
+  let ob = Bi_outbuf.create len in
+  write__59 ob x;
+  Bi_outbuf.contents ob
+and write__6 ob x = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_type_
+>>>>>>> 04a9cb3 (add memory usage)
   )
 ) ob x
 and string_of__70 ?(len = 1024) x =
@@ -6138,7 +6164,11 @@ and write_directive = (
             Bi_outbuf.add_char ob ',';
             (let _, _, x = x in
             (
+<<<<<<< HEAD
               write__70
+=======
+              write__59
+>>>>>>> 04a9cb3 (add memory usage)
             ) ob x
             );
             Bi_outbuf.add_char ob ']';
@@ -9806,9 +9836,63 @@ and read__4 = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
+<<<<<<< HEAD
 and _4_of_string s =
   read__4 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 and read__40 = (
+=======
+and _58_of_string s =
+  read__58 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__59 p lb = (
+  Atdgen_runtime.Oj_run.read_list (
+    fun p lb ->
+      Yojson.Safe.read_space p lb;
+      let std_tuple = Yojson.Safe.start_any_tuple p lb in
+      let len = ref 0 in
+      let end_of_tuple = ref false in
+      (try
+        let x0 =
+          let x =
+            (
+              read_ident
+            ) p lb
+          in
+          incr len;
+          Yojson.Safe.read_space p lb;
+          Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+          x
+        in
+        let x1 =
+          let x =
+            (
+              read__58
+            ) p lb
+          in
+          incr len;
+          (try
+            Yojson.Safe.read_space p lb;
+            Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+          with Yojson.End_of_tuple -> end_of_tuple := true);
+          x
+        in
+        if not !end_of_tuple then (
+          try
+            while true do
+              Yojson.Safe.skip_json p lb;
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_tuple_sep2 p std_tuple lb;
+            done
+          with Yojson.End_of_tuple -> ()
+        );
+        (x0, x1)
+      with Yojson.End_of_tuple ->
+        Atdgen_runtime.Oj_run.missing_tuple_fields p !len [ 0; 1 ]);
+  )
+) p lb
+and _59_of_string s =
+  read__59 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+and read__6 = (
+>>>>>>> 04a9cb3 (add memory usage)
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -13515,7 +13599,11 @@ and read_directive = (
                       let x2 =
                         let x =
                           (
+<<<<<<< HEAD
                             read__70
+=======
+                            read__59
+>>>>>>> 04a9cb3 (add memory usage)
                           ) p lb
                         in
                         incr len;
@@ -13869,7 +13957,11 @@ and read_directive = (
                       let x2 =
                         let x =
                           (
+<<<<<<< HEAD
                             read__70
+=======
+                            read__59
+>>>>>>> 04a9cb3 (add memory usage)
                           ) p lb
                         in
                         incr len;

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -604,7 +604,6 @@ type cli_output <ocaml attr="deriving show"> = {
 
     errors: cli_error list;
     results: cli_match list;
-
     inherit cli_output_extra;
 }
 
@@ -628,7 +627,7 @@ type cli_paths <ocaml attr="deriving show"> = {
 }
 
 (* LATER: could merge with skipped_target above *)
-type cli_skipped_target <ocaml attr="deriving show"> ={
+type cli_skipped_target <ocaml attr="deriving show"> = {
     path: string;
     (* LATER: use a variant, reuse skip_reason above *)
     reason: string;

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -426,6 +426,8 @@ type core_match_results
   stats: core_stats;
   (* LATER: rename timing *)
   ?time: core_timing option;
+
+  max_ocaml_heap_words : int;
 }
 
 (*****************************************************************************)
@@ -615,6 +617,8 @@ type cli_output_extra <ocaml attr="deriving show"> = {
      *)
     (* EXPERIMENTAL: since semgrep 0.109? *)
     ?explanations: matching_explanation list option;
+
+    max_ocaml_heap_words: int;
 }
 
 type cli_paths <ocaml attr="deriving show"> = {

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -316,6 +316,8 @@ type core_timing
   (* Needs to be separate to include rules read but not run on any target *)
   rules: rule_id list;
   ?rules_parse_time: float option; (* not used in spacegrep *)
+
+  max_ocaml_heap_words : int;
 }
 
 (* later: could refactor [target_time] and [rule_times] to be equal
@@ -426,8 +428,6 @@ type core_match_results
   stats: core_stats;
   (* LATER: rename timing *)
   ?time: core_timing option;
-
-  max_ocaml_heap_words : int;
 }
 
 (*****************************************************************************)
@@ -618,8 +618,6 @@ type cli_output_extra <ocaml attr="deriving show"> = {
      *)
     (* EXPERIMENTAL: since semgrep 0.109? *)
     ?explanations: matching_explanation list option;
-
-    ?max_ocaml_heap_words: int option;
 }
 
 type cli_paths <ocaml attr="deriving show"> = {
@@ -647,6 +645,8 @@ type cli_timing <ocaml attr="deriving show"> = {
     profiling_times: (string * float) list <json repr="object"> <python repr="dict">;
     targets: cli_target_times list;
     total_bytes: int;
+
+    ?max_ocaml_heap_words : int option;
   }
 
 (* LATER: should just use rule_id *)

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -604,6 +604,7 @@ type cli_output <ocaml attr="deriving show"> = {
 
     errors: cli_error list;
     results: cli_match list;
+
     inherit cli_output_extra;
 }
 
@@ -618,7 +619,7 @@ type cli_output_extra <ocaml attr="deriving show"> = {
     (* EXPERIMENTAL: since semgrep 0.109? *)
     ?explanations: matching_explanation list option;
 
-    max_ocaml_heap_words: int;
+    ?max_ocaml_heap_words: int option;
 }
 
 type cli_paths <ocaml attr="deriving show"> = {
@@ -629,7 +630,7 @@ type cli_paths <ocaml attr="deriving show"> = {
 }
 
 (* LATER: could merge with skipped_target above *)
-type cli_skipped_target <ocaml attr="deriving show"> = {
+type cli_skipped_target <ocaml attr="deriving show"> ={
     path: string;
     (* LATER: use a variant, reuse skip_reason above *)
     reason: string;

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -317,7 +317,7 @@ type core_timing
   rules: rule_id list;
   ?rules_parse_time: float option; (* not used in spacegrep *)
 
-  max_ocaml_heap_words : int;
+  max_memory_bytes : int;
 }
 
 (* later: could refactor [target_time] and [rule_times] to be equal
@@ -645,7 +645,7 @@ type cli_timing <ocaml attr="deriving show"> = {
     targets: cli_target_times list;
     total_bytes: int;
 
-    ?max_ocaml_heap_words : int option;
+    ?max_memory_bytes : int option;
   }
 
 (* LATER: should just use rule_id *)

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -323,7 +323,7 @@
     },
     "core_match_results": {
       "type": "object",
-      "required": [ "matches", "errors", "stats" ],
+      "required": [ "matches", "errors", "stats", "max_ocaml_heap_words" ],
       "properties": {
         "matches": {
           "type": "array",
@@ -346,7 +346,8 @@
           "items": { "$ref": "#/definitions/matching_explanation" }
         },
         "stats": { "$ref": "#/definitions/core_stats" },
-        "time": { "$ref": "#/definitions/core_timing" }
+        "time": { "$ref": "#/definitions/core_timing" },
+        "max_ocaml_heap_words": { "type": "integer" }
       }
     },
     "cli_error": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -3,7 +3,7 @@
   "title": "cli_output",
   "description": "Translated by atdcat from 'semgrep_output_v1.atd'.",
   "type": "object",
-  "required": [ "errors", "results", "paths" ],
+  "required": [ "errors", "results", "paths", "max_ocaml_heap_words" ],
   "properties": {
     "version": { "$ref": "#/definitions/version" },
     "errors": {
@@ -19,7 +19,8 @@
     "explanations": {
       "type": "array",
       "items": { "$ref": "#/definitions/matching_explanation" }
-    }
+    },
+    "max_ocaml_heap_words": { "type": "integer" }
   },
   "definitions": {
     "raw_json": {},
@@ -519,14 +520,15 @@
     },
     "cli_output_extra": {
       "type": "object",
-      "required": [ "paths" ],
+      "required": [ "paths", "max_ocaml_heap_words" ],
       "properties": {
         "paths": { "$ref": "#/definitions/cli_paths" },
         "time": { "$ref": "#/definitions/cli_timing" },
         "explanations": {
           "type": "array",
           "items": { "$ref": "#/definitions/matching_explanation" }
-        }
+        },
+        "max_ocaml_heap_words": { "type": "integer" }
       }
     },
     "cli_paths": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -19,8 +19,7 @@
     "explanations": {
       "type": "array",
       "items": { "$ref": "#/definitions/matching_explanation" }
-    },
-    "max_ocaml_heap_words": { "type": "integer" }
+    }
   },
   "definitions": {
     "raw_json": {},
@@ -233,7 +232,7 @@
     },
     "core_timing": {
       "type": "object",
-      "required": [ "targets", "rules" ],
+      "required": [ "targets", "rules", "max_ocaml_heap_words" ],
       "properties": {
         "targets": {
           "type": "array",
@@ -243,7 +242,8 @@
           "type": "array",
           "items": { "$ref": "#/definitions/rule_id" }
         },
-        "rules_parse_time": { "type": "number" }
+        "rules_parse_time": { "type": "number" },
+        "max_ocaml_heap_words": { "type": "integer" }
       }
     },
     "target_time": {
@@ -324,7 +324,7 @@
     },
     "core_match_results": {
       "type": "object",
-      "required": [ "matches", "errors", "stats", "max_ocaml_heap_words" ],
+      "required": [ "matches", "errors", "stats" ],
       "properties": {
         "matches": {
           "type": "array",
@@ -347,8 +347,7 @@
           "items": { "$ref": "#/definitions/matching_explanation" }
         },
         "stats": { "$ref": "#/definitions/core_stats" },
-        "time": { "$ref": "#/definitions/core_timing" },
-        "max_ocaml_heap_words": { "type": "integer" }
+        "time": { "$ref": "#/definitions/core_timing" }
       }
     },
     "cli_error": {
@@ -527,8 +526,7 @@
         "explanations": {
           "type": "array",
           "items": { "$ref": "#/definitions/matching_explanation" }
-        },
-        "max_ocaml_heap_words": { "type": "integer" }
+        }
       }
     },
     "cli_paths": {
@@ -571,7 +569,8 @@
           "type": "array",
           "items": { "$ref": "#/definitions/cli_target_times" }
         },
-        "total_bytes": { "type": "integer" }
+        "total_bytes": { "type": "integer" },
+        "max_ocaml_heap_words": { "type": "integer" }
       }
     },
     "rule_id_dict": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -3,7 +3,7 @@
   "title": "cli_output",
   "description": "Translated by atdcat from 'semgrep_output_v1.atd'.",
   "type": "object",
-  "required": [ "errors", "results", "paths", "max_ocaml_heap_words" ],
+  "required": [ "errors", "results", "paths" ],
   "properties": {
     "version": { "$ref": "#/definitions/version" },
     "errors": {
@@ -520,7 +520,7 @@
     },
     "cli_output_extra": {
       "type": "object",
-      "required": [ "paths", "max_ocaml_heap_words" ],
+      "required": [ "paths" ],
       "properties": {
         "paths": { "$ref": "#/definitions/cli_paths" },
         "time": { "$ref": "#/definitions/cli_timing" },

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -232,7 +232,7 @@
     },
     "core_timing": {
       "type": "object",
-      "required": [ "targets", "rules", "max_ocaml_heap_words" ],
+      "required": [ "targets", "rules", "max_memory_bytes" ],
       "properties": {
         "targets": {
           "type": "array",
@@ -243,7 +243,7 @@
           "items": { "$ref": "#/definitions/rule_id" }
         },
         "rules_parse_time": { "type": "number" },
-        "max_ocaml_heap_words": { "type": "integer" }
+        "max_memory_bytes": { "type": "integer" }
       }
     },
     "target_time": {
@@ -570,7 +570,7 @@
           "items": { "$ref": "#/definitions/cli_target_times" }
         },
         "total_bytes": { "type": "integer" },
-        "max_ocaml_heap_words": { "type": "integer" }
+        "max_memory_bytes": { "type": "integer" }
       }
     },
     "rule_id_dict": {

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2080,6 +2080,7 @@ class CoreTiming:
 
     targets: List[TargetTime]
     rules: List[RuleId]
+    max_ocaml_heap_words: int
     rules_parse_time: Optional[float] = None
 
     @classmethod
@@ -2088,6 +2089,7 @@ class CoreTiming:
             return cls(
                 targets=_atd_read_list(TargetTime.from_json)(x['targets']) if 'targets' in x else _atd_missing_json_field('CoreTiming', 'targets'),
                 rules=_atd_read_list(RuleId.from_json)(x['rules']) if 'rules' in x else _atd_missing_json_field('CoreTiming', 'rules'),
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CoreTiming', 'max_ocaml_heap_words'),
                 rules_parse_time=_atd_read_float(x['rules_parse_time']) if 'rules_parse_time' in x else None,
             )
         else:
@@ -2097,6 +2099,7 @@ class CoreTiming:
         res: Dict[str, Any] = {}
         res['targets'] = _atd_write_list((lambda x: x.to_json()))(self.targets)
         res['rules'] = _atd_write_list((lambda x: x.to_json()))(self.rules)
+        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.rules_parse_time is not None:
             res['rules_parse_time'] = _atd_write_float(self.rules_parse_time)
         return res
@@ -2557,7 +2560,6 @@ class CoreMatchResults:
     matches: List[CoreMatch]
     errors: List[CoreError]
     stats: CoreStats
-    max_ocaml_heap_words: int
     skipped_targets: Optional[List[SkippedTarget]] = None
     skipped_rules: Optional[List[SkippedRule]] = None
     explanations: Optional[List[MatchingExplanation]] = None
@@ -2570,7 +2572,6 @@ class CoreMatchResults:
                 matches=_atd_read_list(CoreMatch.from_json)(x['matches']) if 'matches' in x else _atd_missing_json_field('CoreMatchResults', 'matches'),
                 errors=_atd_read_list(CoreError.from_json)(x['errors']) if 'errors' in x else _atd_missing_json_field('CoreMatchResults', 'errors'),
                 stats=CoreStats.from_json(x['stats']) if 'stats' in x else _atd_missing_json_field('CoreMatchResults', 'stats'),
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CoreMatchResults', 'max_ocaml_heap_words'),
                 skipped_targets=_atd_read_list(SkippedTarget.from_json)(x['skipped']) if 'skipped' in x else None,
                 skipped_rules=_atd_read_list(SkippedRule.from_json)(x['skipped_rules']) if 'skipped_rules' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
@@ -2584,7 +2585,6 @@ class CoreMatchResults:
         res['matches'] = _atd_write_list((lambda x: x.to_json()))(self.matches)
         res['errors'] = _atd_write_list((lambda x: x.to_json()))(self.errors)
         res['stats'] = (lambda x: x.to_json())(self.stats)
-        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.skipped_targets is not None:
             res['skipped'] = _atd_write_list((lambda x: x.to_json()))(self.skipped_targets)
         if self.skipped_rules is not None:
@@ -2652,6 +2652,7 @@ class CliTiming:
     profiling_times: Dict[str, float]
     targets: List[CliTargetTimes]
     total_bytes: int
+    max_ocaml_heap_words: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliTiming':
@@ -2662,6 +2663,7 @@ class CliTiming:
                 profiling_times=_atd_read_assoc_object_into_dict(_atd_read_float)(x['profiling_times']) if 'profiling_times' in x else _atd_missing_json_field('CliTiming', 'profiling_times'),
                 targets=_atd_read_list(CliTargetTimes.from_json)(x['targets']) if 'targets' in x else _atd_missing_json_field('CliTiming', 'targets'),
                 total_bytes=_atd_read_int(x['total_bytes']) if 'total_bytes' in x else _atd_missing_json_field('CliTiming', 'total_bytes'),
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else None,
             )
         else:
             _atd_bad_json('CliTiming', x)
@@ -2673,6 +2675,8 @@ class CliTiming:
         res['profiling_times'] = _atd_write_assoc_dict_to_object(_atd_write_float)(self.profiling_times)
         res['targets'] = _atd_write_list((lambda x: x.to_json()))(self.targets)
         res['total_bytes'] = _atd_write_int(self.total_bytes)
+        if self.max_ocaml_heap_words is not None:
+            res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         return res
 
     @classmethod
@@ -2757,7 +2761,6 @@ class CliOutputExtra:
     paths: CliPaths
     time: Optional[CliTiming] = None
     explanations: Optional[List[MatchingExplanation]] = None
-    max_ocaml_heap_words: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliOutputExtra':
@@ -2766,7 +2769,6 @@ class CliOutputExtra:
                 paths=CliPaths.from_json(x['paths']) if 'paths' in x else _atd_missing_json_field('CliOutputExtra', 'paths'),
                 time=CliTiming.from_json(x['time']) if 'time' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else None,
             )
         else:
             _atd_bad_json('CliOutputExtra', x)
@@ -2778,8 +2780,6 @@ class CliOutputExtra:
             res['time'] = (lambda x: x.to_json())(self.time)
         if self.explanations is not None:
             res['explanations'] = _atd_write_list((lambda x: x.to_json()))(self.explanations)
-        if self.max_ocaml_heap_words is not None:
-            res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         return res
 
     @classmethod
@@ -2970,7 +2970,6 @@ class CliOutput:
     version: Optional[Version] = None
     time: Optional[CliTiming] = None
     explanations: Optional[List[MatchingExplanation]] = None
-    max_ocaml_heap_words: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliOutput':
@@ -2982,7 +2981,6 @@ class CliOutput:
                 version=Version.from_json(x['version']) if 'version' in x else None,
                 time=CliTiming.from_json(x['time']) if 'time' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else None,
             )
         else:
             _atd_bad_json('CliOutput', x)
@@ -2998,8 +2996,6 @@ class CliOutput:
             res['time'] = (lambda x: x.to_json())(self.time)
         if self.explanations is not None:
             res['explanations'] = _atd_write_list((lambda x: x.to_json()))(self.explanations)
-        if self.max_ocaml_heap_words is not None:
-            res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         return res
 
     @classmethod

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2755,6 +2755,7 @@ class CliOutputExtra:
     """Original type: cli_output_extra = { ... }"""
 
     paths: CliPaths
+    max_ocaml_heap_words: int
     time: Optional[CliTiming] = None
     explanations: Optional[List[MatchingExplanation]] = None
 
@@ -2763,6 +2764,7 @@ class CliOutputExtra:
         if isinstance(x, dict):
             return cls(
                 paths=CliPaths.from_json(x['paths']) if 'paths' in x else _atd_missing_json_field('CliOutputExtra', 'paths'),
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CliOutputExtra', 'max_ocaml_heap_words'),
                 time=CliTiming.from_json(x['time']) if 'time' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
             )
@@ -2772,6 +2774,7 @@ class CliOutputExtra:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['paths'] = (lambda x: x.to_json())(self.paths)
+        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.time is not None:
             res['time'] = (lambda x: x.to_json())(self.time)
         if self.explanations is not None:
@@ -2963,6 +2966,7 @@ class CliOutput:
     errors: List[CliError]
     results: List[CliMatch]
     paths: CliPaths
+    max_ocaml_heap_words: int
     version: Optional[Version] = None
     time: Optional[CliTiming] = None
     explanations: Optional[List[MatchingExplanation]] = None
@@ -2974,6 +2978,7 @@ class CliOutput:
                 errors=_atd_read_list(CliError.from_json)(x['errors']) if 'errors' in x else _atd_missing_json_field('CliOutput', 'errors'),
                 results=_atd_read_list(CliMatch.from_json)(x['results']) if 'results' in x else _atd_missing_json_field('CliOutput', 'results'),
                 paths=CliPaths.from_json(x['paths']) if 'paths' in x else _atd_missing_json_field('CliOutput', 'paths'),
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CliOutput', 'max_ocaml_heap_words'),
                 version=Version.from_json(x['version']) if 'version' in x else None,
                 time=CliTiming.from_json(x['time']) if 'time' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
@@ -2986,6 +2991,7 @@ class CliOutput:
         res['errors'] = _atd_write_list((lambda x: x.to_json()))(self.errors)
         res['results'] = _atd_write_list((lambda x: x.to_json()))(self.results)
         res['paths'] = (lambda x: x.to_json())(self.paths)
+        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.version is not None:
             res['version'] = (lambda x: x.to_json())(self.version)
         if self.time is not None:

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2557,6 +2557,7 @@ class CoreMatchResults:
     matches: List[CoreMatch]
     errors: List[CoreError]
     stats: CoreStats
+    max_ocaml_heap_words: int
     skipped_targets: Optional[List[SkippedTarget]] = None
     skipped_rules: Optional[List[SkippedRule]] = None
     explanations: Optional[List[MatchingExplanation]] = None
@@ -2569,6 +2570,7 @@ class CoreMatchResults:
                 matches=_atd_read_list(CoreMatch.from_json)(x['matches']) if 'matches' in x else _atd_missing_json_field('CoreMatchResults', 'matches'),
                 errors=_atd_read_list(CoreError.from_json)(x['errors']) if 'errors' in x else _atd_missing_json_field('CoreMatchResults', 'errors'),
                 stats=CoreStats.from_json(x['stats']) if 'stats' in x else _atd_missing_json_field('CoreMatchResults', 'stats'),
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CoreMatchResults', 'max_ocaml_heap_words'),
                 skipped_targets=_atd_read_list(SkippedTarget.from_json)(x['skipped']) if 'skipped' in x else None,
                 skipped_rules=_atd_read_list(SkippedRule.from_json)(x['skipped_rules']) if 'skipped_rules' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
@@ -2582,6 +2584,7 @@ class CoreMatchResults:
         res['matches'] = _atd_write_list((lambda x: x.to_json()))(self.matches)
         res['errors'] = _atd_write_list((lambda x: x.to_json()))(self.errors)
         res['stats'] = (lambda x: x.to_json())(self.stats)
+        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.skipped_targets is not None:
             res['skipped'] = _atd_write_list((lambda x: x.to_json()))(self.skipped_targets)
         if self.skipped_rules is not None:

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2755,18 +2755,18 @@ class CliOutputExtra:
     """Original type: cli_output_extra = { ... }"""
 
     paths: CliPaths
-    max_ocaml_heap_words: int
     time: Optional[CliTiming] = None
     explanations: Optional[List[MatchingExplanation]] = None
+    max_ocaml_heap_words: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliOutputExtra':
         if isinstance(x, dict):
             return cls(
                 paths=CliPaths.from_json(x['paths']) if 'paths' in x else _atd_missing_json_field('CliOutputExtra', 'paths'),
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CliOutputExtra', 'max_ocaml_heap_words'),
                 time=CliTiming.from_json(x['time']) if 'time' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else None,
             )
         else:
             _atd_bad_json('CliOutputExtra', x)
@@ -2774,11 +2774,12 @@ class CliOutputExtra:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['paths'] = (lambda x: x.to_json())(self.paths)
-        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.time is not None:
             res['time'] = (lambda x: x.to_json())(self.time)
         if self.explanations is not None:
             res['explanations'] = _atd_write_list((lambda x: x.to_json()))(self.explanations)
+        if self.max_ocaml_heap_words is not None:
+            res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         return res
 
     @classmethod
@@ -2966,10 +2967,10 @@ class CliOutput:
     errors: List[CliError]
     results: List[CliMatch]
     paths: CliPaths
-    max_ocaml_heap_words: int
     version: Optional[Version] = None
     time: Optional[CliTiming] = None
     explanations: Optional[List[MatchingExplanation]] = None
+    max_ocaml_heap_words: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliOutput':
@@ -2978,10 +2979,10 @@ class CliOutput:
                 errors=_atd_read_list(CliError.from_json)(x['errors']) if 'errors' in x else _atd_missing_json_field('CliOutput', 'errors'),
                 results=_atd_read_list(CliMatch.from_json)(x['results']) if 'results' in x else _atd_missing_json_field('CliOutput', 'results'),
                 paths=CliPaths.from_json(x['paths']) if 'paths' in x else _atd_missing_json_field('CliOutput', 'paths'),
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CliOutput', 'max_ocaml_heap_words'),
                 version=Version.from_json(x['version']) if 'version' in x else None,
                 time=CliTiming.from_json(x['time']) if 'time' in x else None,
                 explanations=_atd_read_list(MatchingExplanation.from_json)(x['explanations']) if 'explanations' in x else None,
+                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else None,
             )
         else:
             _atd_bad_json('CliOutput', x)
@@ -2991,13 +2992,14 @@ class CliOutput:
         res['errors'] = _atd_write_list((lambda x: x.to_json()))(self.errors)
         res['results'] = _atd_write_list((lambda x: x.to_json()))(self.results)
         res['paths'] = (lambda x: x.to_json())(self.paths)
-        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         if self.version is not None:
             res['version'] = (lambda x: x.to_json())(self.version)
         if self.time is not None:
             res['time'] = (lambda x: x.to_json())(self.time)
         if self.explanations is not None:
             res['explanations'] = _atd_write_list((lambda x: x.to_json()))(self.explanations)
+        if self.max_ocaml_heap_words is not None:
+            res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
         return res
 
     @classmethod

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2080,7 +2080,7 @@ class CoreTiming:
 
     targets: List[TargetTime]
     rules: List[RuleId]
-    max_ocaml_heap_words: int
+    max_memory_bytes: int
     rules_parse_time: Optional[float] = None
 
     @classmethod
@@ -2089,7 +2089,7 @@ class CoreTiming:
             return cls(
                 targets=_atd_read_list(TargetTime.from_json)(x['targets']) if 'targets' in x else _atd_missing_json_field('CoreTiming', 'targets'),
                 rules=_atd_read_list(RuleId.from_json)(x['rules']) if 'rules' in x else _atd_missing_json_field('CoreTiming', 'rules'),
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else _atd_missing_json_field('CoreTiming', 'max_ocaml_heap_words'),
+                max_memory_bytes=_atd_read_int(x['max_memory_bytes']) if 'max_memory_bytes' in x else _atd_missing_json_field('CoreTiming', 'max_memory_bytes'),
                 rules_parse_time=_atd_read_float(x['rules_parse_time']) if 'rules_parse_time' in x else None,
             )
         else:
@@ -2099,7 +2099,7 @@ class CoreTiming:
         res: Dict[str, Any] = {}
         res['targets'] = _atd_write_list((lambda x: x.to_json()))(self.targets)
         res['rules'] = _atd_write_list((lambda x: x.to_json()))(self.rules)
-        res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
+        res['max_memory_bytes'] = _atd_write_int(self.max_memory_bytes)
         if self.rules_parse_time is not None:
             res['rules_parse_time'] = _atd_write_float(self.rules_parse_time)
         return res
@@ -2652,7 +2652,7 @@ class CliTiming:
     profiling_times: Dict[str, float]
     targets: List[CliTargetTimes]
     total_bytes: int
-    max_ocaml_heap_words: Optional[int] = None
+    max_memory_bytes: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CliTiming':
@@ -2663,7 +2663,7 @@ class CliTiming:
                 profiling_times=_atd_read_assoc_object_into_dict(_atd_read_float)(x['profiling_times']) if 'profiling_times' in x else _atd_missing_json_field('CliTiming', 'profiling_times'),
                 targets=_atd_read_list(CliTargetTimes.from_json)(x['targets']) if 'targets' in x else _atd_missing_json_field('CliTiming', 'targets'),
                 total_bytes=_atd_read_int(x['total_bytes']) if 'total_bytes' in x else _atd_missing_json_field('CliTiming', 'total_bytes'),
-                max_ocaml_heap_words=_atd_read_int(x['max_ocaml_heap_words']) if 'max_ocaml_heap_words' in x else None,
+                max_memory_bytes=_atd_read_int(x['max_memory_bytes']) if 'max_memory_bytes' in x else None,
             )
         else:
             _atd_bad_json('CliTiming', x)
@@ -2675,8 +2675,8 @@ class CliTiming:
         res['profiling_times'] = _atd_write_assoc_dict_to_object(_atd_write_float)(self.profiling_times)
         res['targets'] = _atd_write_list((lambda x: x.to_json()))(self.targets)
         res['total_bytes'] = _atd_write_int(self.total_bytes)
-        if self.max_ocaml_heap_words is not None:
-            res['max_ocaml_heap_words'] = _atd_write_int(self.max_ocaml_heap_words)
+        if self.max_memory_bytes is not None:
+            res['max_memory_bytes'] = _atd_write_int(self.max_memory_bytes)
         return res
 
     @classmethod

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -128,6 +128,7 @@ export type CoreTiming = {
   targets: TargetTime[];
   rules: RuleId[];
   rules_parse_time?: number;
+  max_ocaml_heap_words: Int;
 }
 
 export type TargetTime = {
@@ -179,7 +180,6 @@ export type CoreMatchResults = {
   explanations?: MatchingExplanation[];
   stats: CoreStats;
   time?: CoreTiming;
-  max_ocaml_heap_words: Int;
 }
 
 export type CliError = {
@@ -268,14 +268,12 @@ export type CliOutput = {
   paths: CliPaths;
   time?: CliTiming;
   explanations?: MatchingExplanation[];
-  max_ocaml_heap_words?: Int;
 }
 
 export type CliOutputExtra = {
   paths: CliPaths;
   time?: CliTiming;
   explanations?: MatchingExplanation[];
-  max_ocaml_heap_words?: Int;
 }
 
 export type CliPaths = {
@@ -295,6 +293,7 @@ export type CliTiming = {
   profiling_times: [string, number][];
   targets: CliTargetTimes[];
   total_bytes: Int;
+  max_ocaml_heap_words?: Int;
 }
 
 export type RuleIdDict = {
@@ -778,6 +777,7 @@ export function writeCoreTiming(x: CoreTiming, context: any = x): any {
     'targets': _atd_write_required_field('CoreTiming', 'targets', _atd_write_array(writeTargetTime), x.targets, x),
     'rules': _atd_write_required_field('CoreTiming', 'rules', _atd_write_array(writeRuleId), x.rules, x),
     'rules_parse_time': _atd_write_optional_field(_atd_write_float, x.rules_parse_time, x),
+    'max_ocaml_heap_words': _atd_write_required_field('CoreTiming', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -786,6 +786,7 @@ export function readCoreTiming(x: any, context: any = x): CoreTiming {
     targets: _atd_read_required_field('CoreTiming', 'targets', _atd_read_array(readTargetTime), x['targets'], x),
     rules: _atd_read_required_field('CoreTiming', 'rules', _atd_read_array(readRuleId), x['rules'], x),
     rules_parse_time: _atd_read_optional_field(_atd_read_float, x['rules_parse_time'], x),
+    max_ocaml_heap_words: _atd_read_required_field('CoreTiming', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 
@@ -943,7 +944,6 @@ export function writeCoreMatchResults(x: CoreMatchResults, context: any = x): an
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
     'stats': _atd_write_required_field('CoreMatchResults', 'stats', writeCoreStats, x.stats, x),
     'time': _atd_write_optional_field(writeCoreTiming, x.time, x),
-    'max_ocaml_heap_words': _atd_write_required_field('CoreMatchResults', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -956,7 +956,6 @@ export function readCoreMatchResults(x: any, context: any = x): CoreMatchResults
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
     stats: _atd_read_required_field('CoreMatchResults', 'stats', readCoreStats, x['stats'], x),
     time: _atd_read_optional_field(readCoreTiming, x['time'], x),
-    max_ocaml_heap_words: _atd_read_required_field('CoreMatchResults', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 
@@ -1176,7 +1175,6 @@ export function writeCliOutput(x: CliOutput, context: any = x): any {
     'paths': _atd_write_required_field('CliOutput', 'paths', writeCliPaths, x.paths, x),
     'time': _atd_write_optional_field(writeCliTiming, x.time, x),
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
-    'max_ocaml_heap_words': _atd_write_optional_field(_atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1188,7 +1186,6 @@ export function readCliOutput(x: any, context: any = x): CliOutput {
     paths: _atd_read_required_field('CliOutput', 'paths', readCliPaths, x['paths'], x),
     time: _atd_read_optional_field(readCliTiming, x['time'], x),
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
-    max_ocaml_heap_words: _atd_read_optional_field(_atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 
@@ -1197,7 +1194,6 @@ export function writeCliOutputExtra(x: CliOutputExtra, context: any = x): any {
     'paths': _atd_write_required_field('CliOutputExtra', 'paths', writeCliPaths, x.paths, x),
     'time': _atd_write_optional_field(writeCliTiming, x.time, x),
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
-    'max_ocaml_heap_words': _atd_write_optional_field(_atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1206,7 +1202,6 @@ export function readCliOutputExtra(x: any, context: any = x): CliOutputExtra {
     paths: _atd_read_required_field('CliOutputExtra', 'paths', readCliPaths, x['paths'], x),
     time: _atd_read_optional_field(readCliTiming, x['time'], x),
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
-    max_ocaml_heap_words: _atd_read_optional_field(_atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 
@@ -1247,6 +1242,7 @@ export function writeCliTiming(x: CliTiming, context: any = x): any {
     'profiling_times': _atd_write_required_field('CliTiming', 'profiling_times', _atd_write_assoc_array_to_object(_atd_write_float), x.profiling_times, x),
     'targets': _atd_write_required_field('CliTiming', 'targets', _atd_write_array(writeCliTargetTimes), x.targets, x),
     'total_bytes': _atd_write_required_field('CliTiming', 'total_bytes', _atd_write_int, x.total_bytes, x),
+    'max_ocaml_heap_words': _atd_write_optional_field(_atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1257,6 +1253,7 @@ export function readCliTiming(x: any, context: any = x): CliTiming {
     profiling_times: _atd_read_required_field('CliTiming', 'profiling_times', _atd_read_assoc_object_into_array(_atd_read_float), x['profiling_times'], x),
     targets: _atd_read_required_field('CliTiming', 'targets', _atd_read_array(readCliTargetTimes), x['targets'], x),
     total_bytes: _atd_read_required_field('CliTiming', 'total_bytes', _atd_read_int, x['total_bytes'], x),
+    max_ocaml_heap_words: _atd_read_optional_field(_atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -268,12 +268,14 @@ export type CliOutput = {
   paths: CliPaths;
   time?: CliTiming;
   explanations?: MatchingExplanation[];
+  max_ocaml_heap_words: Int;
 }
 
 export type CliOutputExtra = {
   paths: CliPaths;
   time?: CliTiming;
   explanations?: MatchingExplanation[];
+  max_ocaml_heap_words: Int;
 }
 
 export type CliPaths = {
@@ -1174,6 +1176,7 @@ export function writeCliOutput(x: CliOutput, context: any = x): any {
     'paths': _atd_write_required_field('CliOutput', 'paths', writeCliPaths, x.paths, x),
     'time': _atd_write_optional_field(writeCliTiming, x.time, x),
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
+    'max_ocaml_heap_words': _atd_write_required_field('CliOutput', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1185,6 +1188,7 @@ export function readCliOutput(x: any, context: any = x): CliOutput {
     paths: _atd_read_required_field('CliOutput', 'paths', readCliPaths, x['paths'], x),
     time: _atd_read_optional_field(readCliTiming, x['time'], x),
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
+    max_ocaml_heap_words: _atd_read_required_field('CliOutput', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 
@@ -1193,6 +1197,7 @@ export function writeCliOutputExtra(x: CliOutputExtra, context: any = x): any {
     'paths': _atd_write_required_field('CliOutputExtra', 'paths', writeCliPaths, x.paths, x),
     'time': _atd_write_optional_field(writeCliTiming, x.time, x),
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
+    'max_ocaml_heap_words': _atd_write_required_field('CliOutputExtra', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1201,6 +1206,7 @@ export function readCliOutputExtra(x: any, context: any = x): CliOutputExtra {
     paths: _atd_read_required_field('CliOutputExtra', 'paths', readCliPaths, x['paths'], x),
     time: _atd_read_optional_field(readCliTiming, x['time'], x),
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
+    max_ocaml_heap_words: _atd_read_required_field('CliOutputExtra', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -179,6 +179,7 @@ export type CoreMatchResults = {
   explanations?: MatchingExplanation[];
   stats: CoreStats;
   time?: CoreTiming;
+  max_ocaml_heap_words: Int;
 }
 
 export type CliError = {
@@ -940,6 +941,7 @@ export function writeCoreMatchResults(x: CoreMatchResults, context: any = x): an
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
     'stats': _atd_write_required_field('CoreMatchResults', 'stats', writeCoreStats, x.stats, x),
     'time': _atd_write_optional_field(writeCoreTiming, x.time, x),
+    'max_ocaml_heap_words': _atd_write_required_field('CoreMatchResults', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -952,6 +954,7 @@ export function readCoreMatchResults(x: any, context: any = x): CoreMatchResults
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
     stats: _atd_read_required_field('CoreMatchResults', 'stats', readCoreStats, x['stats'], x),
     time: _atd_read_optional_field(readCoreTiming, x['time'], x),
+    max_ocaml_heap_words: _atd_read_required_field('CoreMatchResults', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -128,7 +128,7 @@ export type CoreTiming = {
   targets: TargetTime[];
   rules: RuleId[];
   rules_parse_time?: number;
-  max_ocaml_heap_words: Int;
+  max_memory_bytes: Int;
 }
 
 export type TargetTime = {
@@ -293,7 +293,7 @@ export type CliTiming = {
   profiling_times: [string, number][];
   targets: CliTargetTimes[];
   total_bytes: Int;
-  max_ocaml_heap_words?: Int;
+  max_memory_bytes?: Int;
 }
 
 export type RuleIdDict = {
@@ -777,7 +777,7 @@ export function writeCoreTiming(x: CoreTiming, context: any = x): any {
     'targets': _atd_write_required_field('CoreTiming', 'targets', _atd_write_array(writeTargetTime), x.targets, x),
     'rules': _atd_write_required_field('CoreTiming', 'rules', _atd_write_array(writeRuleId), x.rules, x),
     'rules_parse_time': _atd_write_optional_field(_atd_write_float, x.rules_parse_time, x),
-    'max_ocaml_heap_words': _atd_write_required_field('CoreTiming', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
+    'max_memory_bytes': _atd_write_required_field('CoreTiming', 'max_memory_bytes', _atd_write_int, x.max_memory_bytes, x),
   };
 }
 
@@ -786,7 +786,7 @@ export function readCoreTiming(x: any, context: any = x): CoreTiming {
     targets: _atd_read_required_field('CoreTiming', 'targets', _atd_read_array(readTargetTime), x['targets'], x),
     rules: _atd_read_required_field('CoreTiming', 'rules', _atd_read_array(readRuleId), x['rules'], x),
     rules_parse_time: _atd_read_optional_field(_atd_read_float, x['rules_parse_time'], x),
-    max_ocaml_heap_words: _atd_read_required_field('CoreTiming', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
+    max_memory_bytes: _atd_read_required_field('CoreTiming', 'max_memory_bytes', _atd_read_int, x['max_memory_bytes'], x),
   };
 }
 
@@ -1242,7 +1242,7 @@ export function writeCliTiming(x: CliTiming, context: any = x): any {
     'profiling_times': _atd_write_required_field('CliTiming', 'profiling_times', _atd_write_assoc_array_to_object(_atd_write_float), x.profiling_times, x),
     'targets': _atd_write_required_field('CliTiming', 'targets', _atd_write_array(writeCliTargetTimes), x.targets, x),
     'total_bytes': _atd_write_required_field('CliTiming', 'total_bytes', _atd_write_int, x.total_bytes, x),
-    'max_ocaml_heap_words': _atd_write_optional_field(_atd_write_int, x.max_ocaml_heap_words, x),
+    'max_memory_bytes': _atd_write_optional_field(_atd_write_int, x.max_memory_bytes, x),
   };
 }
 
@@ -1253,7 +1253,7 @@ export function readCliTiming(x: any, context: any = x): CliTiming {
     profiling_times: _atd_read_required_field('CliTiming', 'profiling_times', _atd_read_assoc_object_into_array(_atd_read_float), x['profiling_times'], x),
     targets: _atd_read_required_field('CliTiming', 'targets', _atd_read_array(readCliTargetTimes), x['targets'], x),
     total_bytes: _atd_read_required_field('CliTiming', 'total_bytes', _atd_read_int, x['total_bytes'], x),
-    max_ocaml_heap_words: _atd_read_optional_field(_atd_read_int, x['max_ocaml_heap_words'], x),
+    max_memory_bytes: _atd_read_optional_field(_atd_read_int, x['max_memory_bytes'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -268,14 +268,14 @@ export type CliOutput = {
   paths: CliPaths;
   time?: CliTiming;
   explanations?: MatchingExplanation[];
-  max_ocaml_heap_words: Int;
+  max_ocaml_heap_words?: Int;
 }
 
 export type CliOutputExtra = {
   paths: CliPaths;
   time?: CliTiming;
   explanations?: MatchingExplanation[];
-  max_ocaml_heap_words: Int;
+  max_ocaml_heap_words?: Int;
 }
 
 export type CliPaths = {
@@ -1176,7 +1176,7 @@ export function writeCliOutput(x: CliOutput, context: any = x): any {
     'paths': _atd_write_required_field('CliOutput', 'paths', writeCliPaths, x.paths, x),
     'time': _atd_write_optional_field(writeCliTiming, x.time, x),
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
-    'max_ocaml_heap_words': _atd_write_required_field('CliOutput', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
+    'max_ocaml_heap_words': _atd_write_optional_field(_atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1188,7 +1188,7 @@ export function readCliOutput(x: any, context: any = x): CliOutput {
     paths: _atd_read_required_field('CliOutput', 'paths', readCliPaths, x['paths'], x),
     time: _atd_read_optional_field(readCliTiming, x['time'], x),
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
-    max_ocaml_heap_words: _atd_read_required_field('CliOutput', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
+    max_ocaml_heap_words: _atd_read_optional_field(_atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 
@@ -1197,7 +1197,7 @@ export function writeCliOutputExtra(x: CliOutputExtra, context: any = x): any {
     'paths': _atd_write_required_field('CliOutputExtra', 'paths', writeCliPaths, x.paths, x),
     'time': _atd_write_optional_field(writeCliTiming, x.time, x),
     'explanations': _atd_write_optional_field(_atd_write_array(writeMatchingExplanation), x.explanations, x),
-    'max_ocaml_heap_words': _atd_write_required_field('CliOutputExtra', 'max_ocaml_heap_words', _atd_write_int, x.max_ocaml_heap_words, x),
+    'max_ocaml_heap_words': _atd_write_optional_field(_atd_write_int, x.max_ocaml_heap_words, x),
   };
 }
 
@@ -1206,7 +1206,7 @@ export function readCliOutputExtra(x: any, context: any = x): CliOutputExtra {
     paths: _atd_read_required_field('CliOutputExtra', 'paths', readCliPaths, x['paths'], x),
     time: _atd_read_optional_field(readCliTiming, x['time'], x),
     explanations: _atd_read_optional_field(_atd_read_array(readMatchingExplanation), x['explanations'], x),
-    max_ocaml_heap_words: _atd_read_required_field('CliOutputExtra', 'max_ocaml_heap_words', _atd_read_int, x['max_ocaml_heap_words'], x),
+    max_ocaml_heap_words: _atd_read_optional_field(_atd_read_int, x['max_ocaml_heap_words'], x),
   };
 }
 

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -350,7 +350,7 @@ type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: cli_paths;
   time: cli_timing option;
   explanations: matching_explanation list option;
-  max_ocaml_heap_words: int
+  max_ocaml_heap_words: int option
 }
   [@@deriving show]
 
@@ -400,7 +400,7 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   paths: cli_paths;
   time: cli_timing option;
   explanations: matching_explanation list option;
-  max_ocaml_heap_words: int
+  max_ocaml_heap_words: int option
 }
   [@@deriving show]
 
@@ -11624,15 +11624,17 @@ let write_cli_output_extra : _ -> cli_output_extra -> _ = (
       )
         ob x;
     );
-    if !is_first then
-      is_first := false
-    else
-      Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
-    (
-      Yojson.Safe.write_int
-    )
-      ob x.max_ocaml_heap_words;
+    (match x.max_ocaml_heap_words with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_output_extra ?(len = 1024) x =
@@ -11725,13 +11727,15 @@ let read_cli_output_extra = (
               );
             )
           | 3 ->
-            field_max_ocaml_heap_words := (
-              Some (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              )
-            );
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -11814,13 +11818,15 @@ let read_cli_output_extra = (
                 );
               )
             | 3 ->
-              field_max_ocaml_heap_words := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_int
-                  ) p lb
-                )
-              );
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_max_ocaml_heap_words := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -11833,7 +11839,7 @@ let read_cli_output_extra = (
             paths = (match !field_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "paths");
             time = !field_time;
             explanations = !field_explanations;
-            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
+            max_ocaml_heap_words = !field_max_ocaml_heap_words;
           }
          : cli_output_extra)
       )
@@ -13799,15 +13805,17 @@ let write_cli_output : _ -> cli_output -> _ = (
       )
         ob x;
     );
-    if !is_first then
-      is_first := false
-    else
-      Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
-    (
-      Yojson.Safe.write_int
-    )
-      ob x.max_ocaml_heap_words;
+    (match x.max_ocaml_heap_words with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_output ?(len = 1024) x =
@@ -13959,13 +13967,15 @@ let read_cli_output = (
               );
             )
           | 6 ->
-            field_max_ocaml_heap_words := (
-              Some (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              )
-            );
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -14104,13 +14114,15 @@ let read_cli_output = (
                 );
               )
             | 6 ->
-              field_max_ocaml_heap_words := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_int
-                  ) p lb
-                )
-              );
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_max_ocaml_heap_words := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -14126,7 +14138,7 @@ let read_cli_output = (
             paths = (match !field_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "paths");
             time = !field_time;
             explanations = !field_explanations;
-            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
+            max_ocaml_heap_words = !field_max_ocaml_heap_words;
           }
          : cli_output)
       )

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -349,7 +349,8 @@ type cli_paths = Semgrep_output_v1_t.cli_paths = {
 type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option
+  explanations: matching_explanation list option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -398,7 +399,8 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   results: cli_match list;
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option
+  explanations: matching_explanation list option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -11622,6 +11624,15 @@ let write_cli_output_extra : _ -> cli_output_extra -> _ = (
       )
         ob x;
     );
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.max_ocaml_heap_words;
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_output_extra ?(len = 1024) x =
@@ -11635,6 +11646,7 @@ let read_cli_output_extra = (
     let field_paths = ref (None) in
     let field_time = ref (None) in
     let field_explanations = ref (None) in
+    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -11663,6 +11675,14 @@ let read_cli_output_extra = (
             | 12 -> (
                 if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'n' && String.unsafe_get s (pos+11) = 's' then (
                   2
+                )
+                else (
+                  -1
+                )
+              )
+            | 20 -> (
+                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                  3
                 )
                 else (
                   -1
@@ -11704,6 +11724,14 @@ let read_cli_output_extra = (
                 )
               );
             )
+          | 3 ->
+            field_max_ocaml_heap_words := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -11736,6 +11764,14 @@ let read_cli_output_extra = (
               | 12 -> (
                   if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'n' && String.unsafe_get s (pos+11) = 's' then (
                     2
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 20 -> (
+                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                    3
                   )
                   else (
                     -1
@@ -11777,6 +11813,14 @@ let read_cli_output_extra = (
                   )
                 );
               )
+            | 3 ->
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -11789,6 +11833,7 @@ let read_cli_output_extra = (
             paths = (match !field_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "paths");
             time = !field_time;
             explanations = !field_explanations;
+            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
           }
          : cli_output_extra)
       )
@@ -13754,6 +13799,15 @@ let write_cli_output : _ -> cli_output -> _ = (
       )
         ob x;
     );
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.max_ocaml_heap_words;
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_output ?(len = 1024) x =
@@ -13770,6 +13824,7 @@ let read_cli_output = (
     let field_paths = ref (None) in
     let field_time = ref (None) in
     let field_explanations = ref (None) in
+    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -13828,6 +13883,14 @@ let read_cli_output = (
             | 12 -> (
                 if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'n' && String.unsafe_get s (pos+11) = 's' then (
                   5
+                )
+                else (
+                  -1
+                )
+              )
+            | 20 -> (
+                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                  6
                 )
                 else (
                   -1
@@ -13895,6 +13958,14 @@ let read_cli_output = (
                 )
               );
             )
+          | 6 ->
+            field_max_ocaml_heap_words := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -13962,6 +14033,14 @@ let read_cli_output = (
                     -1
                   )
                 )
+              | 20 -> (
+                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                    6
+                  )
+                  else (
+                    -1
+                  )
+                )
               | _ -> (
                   -1
                 )
@@ -14024,6 +14103,14 @@ let read_cli_output = (
                   )
                 );
               )
+            | 6 ->
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -14039,6 +14126,7 @@ let read_cli_output = (
             paths = (match !field_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "paths");
             time = !field_time;
             explanations = !field_explanations;
+            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
           }
          : cli_output)
       )

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -262,7 +262,8 @@ type cve_results = Semgrep_output_v1_t.cve_results [@@deriving show]
 type core_timing = Semgrep_output_v1_t.core_timing = {
   targets: target_time list;
   rules: rule_id list;
-  rules_parse_time: float option
+  rules_parse_time: float option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -310,8 +311,7 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
   skipped_rules: skipped_rule list option;
   explanations: matching_explanation list option;
   stats: core_stats;
-  time: core_timing option;
-  max_ocaml_heap_words: int
+  time: core_timing option
 }
   [@@deriving show]
 
@@ -329,7 +329,8 @@ type cli_timing = Semgrep_output_v1_t.cli_timing = {
   rules_parse_time: float;
   profiling_times: (string * float) list;
   targets: cli_target_times list;
-  total_bytes: int
+  total_bytes: int;
+  max_ocaml_heap_words: int option
 }
   [@@deriving show]
 
@@ -349,8 +350,7 @@ type cli_paths = Semgrep_output_v1_t.cli_paths = {
 type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option;
-  max_ocaml_heap_words: int option
+  explanations: matching_explanation list option
 }
   [@@deriving show]
 
@@ -399,8 +399,7 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   results: cli_match list;
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option;
-  max_ocaml_heap_words: int option
+  explanations: matching_explanation list option
 }
   [@@deriving show]
 
@@ -8800,6 +8799,15 @@ let write_core_timing : _ -> core_timing -> _ = (
       )
         ob x;
     );
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.max_ocaml_heap_words;
     Bi_outbuf.add_char ob '}';
 )
 let string_of_core_timing ?(len = 1024) x =
@@ -8813,6 +8821,7 @@ let read_core_timing = (
     let field_targets = ref (None) in
     let field_rules = ref (None) in
     let field_rules_parse_time = ref (None) in
+    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -8841,6 +8850,14 @@ let read_core_timing = (
             | 16 -> (
                 if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
                   2
+                )
+                else (
+                  -1
+                )
+              )
+            | 20 -> (
+                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                  3
                 )
                 else (
                   -1
@@ -8880,6 +8897,14 @@ let read_core_timing = (
                 )
               );
             )
+          | 3 ->
+            field_max_ocaml_heap_words := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -8912,6 +8937,14 @@ let read_core_timing = (
               | 16 -> (
                   if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
                     2
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 20 -> (
+                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                    3
                   )
                   else (
                     -1
@@ -8951,6 +8984,14 @@ let read_core_timing = (
                   )
                 );
               )
+            | 3 ->
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -8963,6 +9004,7 @@ let read_core_timing = (
             targets = (match !field_targets with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "targets");
             rules = (match !field_rules with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "rules");
             rules_parse_time = !field_rules_parse_time;
+            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
           }
          : core_timing)
       )
@@ -10060,15 +10102,6 @@ let write_core_match_results : _ -> core_match_results -> _ = (
       )
         ob x;
     );
-    if !is_first then
-      is_first := false
-    else
-      Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
-    (
-      Yojson.Safe.write_int
-    )
-      ob x.max_ocaml_heap_words;
     Bi_outbuf.add_char ob '}';
 )
 let string_of_core_match_results ?(len = 1024) x =
@@ -10086,7 +10119,6 @@ let read_core_match_results = (
     let field_explanations = ref (None) in
     let field_stats = ref (None) in
     let field_time = ref (None) in
-    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -10153,14 +10185,6 @@ let read_core_match_results = (
             | 13 -> (
                 if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 'k' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'p' && String.unsafe_get s (pos+4) = 'p' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'l' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 's' then (
                   3
-                )
-                else (
-                  -1
-                )
-              )
-            | 20 -> (
-                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                  7
                 )
                 else (
                   -1
@@ -10238,14 +10262,6 @@ let read_core_match_results = (
                 )
               );
             )
-          | 7 ->
-            field_max_ocaml_heap_words := (
-              Some (
-                (
-                  Atdgen_runtime.Oj_run.read_int
-                ) p lb
-              )
-            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -10316,14 +10332,6 @@ let read_core_match_results = (
               | 13 -> (
                   if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 'k' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'p' && String.unsafe_get s (pos+4) = 'p' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'l' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 's' then (
                     3
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 20 -> (
-                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                    7
                   )
                   else (
                     -1
@@ -10401,14 +10409,6 @@ let read_core_match_results = (
                   )
                 );
               )
-            | 7 ->
-              field_max_ocaml_heap_words := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_int
-                  ) p lb
-                )
-              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -10425,7 +10425,6 @@ let read_core_match_results = (
             explanations = !field_explanations;
             stats = (match !field_stats with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "stats");
             time = !field_time;
-            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
           }
          : core_match_results)
       )
@@ -10843,6 +10842,17 @@ let write_cli_timing : _ -> cli_timing -> _ = (
       Yojson.Safe.write_int
     )
       ob x.total_bytes;
+    (match x.max_ocaml_heap_words with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Bi_outbuf.add_char ob ',';
+      Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_timing ?(len = 1024) x =
@@ -10858,6 +10868,7 @@ let read_cli_timing = (
     let field_profiling_times = ref (None) in
     let field_targets = ref (None) in
     let field_total_bytes = ref (None) in
+    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -10902,6 +10913,14 @@ let read_cli_timing = (
             | 16 -> (
                 if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
                   1
+                )
+                else (
+                  -1
+                )
+              )
+            | 20 -> (
+                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                  5
                 )
                 else (
                   -1
@@ -10955,6 +10974,16 @@ let read_cli_timing = (
                 ) p lb
               )
             );
+          | 5 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -11008,6 +11037,14 @@ let read_cli_timing = (
                     -1
                   )
                 )
+              | 20 -> (
+                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                    5
+                  )
+                  else (
+                    -1
+                  )
+                )
               | _ -> (
                   -1
                 )
@@ -11056,6 +11093,16 @@ let read_cli_timing = (
                   ) p lb
                 )
               );
+            | 5 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_max_ocaml_heap_words := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -11070,6 +11117,7 @@ let read_cli_timing = (
             profiling_times = (match !field_profiling_times with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "profiling_times");
             targets = (match !field_targets with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "targets");
             total_bytes = (match !field_total_bytes with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "total_bytes");
+            max_ocaml_heap_words = !field_max_ocaml_heap_words;
           }
          : cli_timing)
       )
@@ -11624,17 +11672,6 @@ let write_cli_output_extra : _ -> cli_output_extra -> _ = (
       )
         ob x;
     );
-    (match x.max_ocaml_heap_words with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Bi_outbuf.add_char ob ',';
-      Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
-      (
-        Yojson.Safe.write_int
-      )
-        ob x;
-    );
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_output_extra ?(len = 1024) x =
@@ -11648,7 +11685,6 @@ let read_cli_output_extra = (
     let field_paths = ref (None) in
     let field_time = ref (None) in
     let field_explanations = ref (None) in
-    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -11677,14 +11713,6 @@ let read_cli_output_extra = (
             | 12 -> (
                 if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'n' && String.unsafe_get s (pos+11) = 's' then (
                   2
-                )
-                else (
-                  -1
-                )
-              )
-            | 20 -> (
-                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                  3
                 )
                 else (
                   -1
@@ -11726,16 +11754,6 @@ let read_cli_output_extra = (
                 )
               );
             )
-          | 3 ->
-            if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_max_ocaml_heap_words := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_int
-                  ) p lb
-                )
-              );
-            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -11768,14 +11786,6 @@ let read_cli_output_extra = (
               | 12 -> (
                   if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'n' && String.unsafe_get s (pos+11) = 's' then (
                     2
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 20 -> (
-                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                    3
                   )
                   else (
                     -1
@@ -11817,16 +11827,6 @@ let read_cli_output_extra = (
                   )
                 );
               )
-            | 3 ->
-              if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_max_ocaml_heap_words := (
-                  Some (
-                    (
-                      Atdgen_runtime.Oj_run.read_int
-                    ) p lb
-                  )
-                );
-              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -11839,7 +11839,6 @@ let read_cli_output_extra = (
             paths = (match !field_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "paths");
             time = !field_time;
             explanations = !field_explanations;
-            max_ocaml_heap_words = !field_max_ocaml_heap_words;
           }
          : cli_output_extra)
       )
@@ -13805,17 +13804,6 @@ let write_cli_output : _ -> cli_output -> _ = (
       )
         ob x;
     );
-    (match x.max_ocaml_heap_words with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Bi_outbuf.add_char ob ',';
-      Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
-      (
-        Yojson.Safe.write_int
-      )
-        ob x;
-    );
     Bi_outbuf.add_char ob '}';
 )
 let string_of_cli_output ?(len = 1024) x =
@@ -13832,7 +13820,6 @@ let read_cli_output = (
     let field_paths = ref (None) in
     let field_time = ref (None) in
     let field_explanations = ref (None) in
-    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -13896,14 +13883,6 @@ let read_cli_output = (
                   -1
                 )
               )
-            | 20 -> (
-                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                  6
-                )
-                else (
-                  -1
-                )
-              )
             | _ -> (
                 -1
               )
@@ -13962,16 +13941,6 @@ let read_cli_output = (
                 Some (
                   (
                     read__16
-                  ) p lb
-                )
-              );
-            )
-          | 6 ->
-            if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_max_ocaml_heap_words := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_int
                   ) p lb
                 )
               );
@@ -14043,14 +14012,6 @@ let read_cli_output = (
                     -1
                   )
                 )
-              | 20 -> (
-                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                    6
-                  )
-                  else (
-                    -1
-                  )
-                )
               | _ -> (
                   -1
                 )
@@ -14113,16 +14074,6 @@ let read_cli_output = (
                   )
                 );
               )
-            | 6 ->
-              if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_max_ocaml_heap_words := (
-                  Some (
-                    (
-                      Atdgen_runtime.Oj_run.read_int
-                    ) p lb
-                  )
-                );
-              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -14138,7 +14089,6 @@ let read_cli_output = (
             paths = (match !field_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "paths");
             time = !field_time;
             explanations = !field_explanations;
-            max_ocaml_heap_words = !field_max_ocaml_heap_words;
           }
          : cli_output)
       )

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -105,9 +105,6 @@ type matching_explanation = Semgrep_output_v1_t.matching_explanation = {
 }
   [@@deriving show]
 
-<<<<<<< HEAD
-type version = Semgrep_output_v1_t.version [@@deriving show]
-=======
 type cli_match_call_trace = Semgrep_output_v1_t.cli_match_call_trace = 
     CliLoc of (location * string)
   | CliCall
@@ -118,7 +115,8 @@ type cli_match_call_trace = Semgrep_output_v1_t.cli_match_call_trace =
       )
 
   [@@deriving show]
->>>>>>> b20637e (change and update atd)
+
+type version = Semgrep_output_v1_t.version [@@deriving show]
 
 type transitivity = Semgrep_output_v1_t.transitivity [@@deriving show]
 
@@ -312,7 +310,8 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
   skipped_rules: skipped_rule list option;
   explanations: matching_explanation list option;
   stats: core_stats;
-  time: core_timing option
+  time: core_timing option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -10059,6 +10058,15 @@ let write_core_match_results : _ -> core_match_results -> _ = (
       )
         ob x;
     );
+    if !is_first then
+      is_first := false
+    else
+      Bi_outbuf.add_char ob ',';
+    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.max_ocaml_heap_words;
     Bi_outbuf.add_char ob '}';
 )
 let string_of_core_match_results ?(len = 1024) x =
@@ -10076,6 +10084,7 @@ let read_core_match_results = (
     let field_explanations = ref (None) in
     let field_stats = ref (None) in
     let field_time = ref (None) in
+    let field_max_ocaml_heap_words = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -10142,6 +10151,14 @@ let read_core_match_results = (
             | 13 -> (
                 if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 'k' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'p' && String.unsafe_get s (pos+4) = 'p' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'l' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 's' then (
                   3
+                )
+                else (
+                  -1
+                )
+              )
+            | 20 -> (
+                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                  7
                 )
                 else (
                   -1
@@ -10219,6 +10236,14 @@ let read_core_match_results = (
                 )
               );
             )
+          | 7 ->
+            field_max_ocaml_heap_words := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -10289,6 +10314,14 @@ let read_core_match_results = (
               | 13 -> (
                   if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 'k' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'p' && String.unsafe_get s (pos+4) = 'p' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'u' && String.unsafe_get s (pos+10) = 'l' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 's' then (
                     3
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 20 -> (
+                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
+                    7
                   )
                   else (
                     -1
@@ -10366,6 +10399,14 @@ let read_core_match_results = (
                   )
                 );
               )
+            | 7 ->
+              field_max_ocaml_heap_words := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -10382,6 +10423,7 @@ let read_core_match_results = (
             explanations = !field_explanations;
             stats = (match !field_stats with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "stats");
             time = !field_time;
+            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
           }
          : core_match_results)
       )

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -263,7 +263,7 @@ type core_timing = Semgrep_output_v1_t.core_timing = {
   targets: target_time list;
   rules: rule_id list;
   rules_parse_time: float option;
-  max_ocaml_heap_words: int
+  max_memory_bytes: int
 }
   [@@deriving show]
 
@@ -330,7 +330,7 @@ type cli_timing = Semgrep_output_v1_t.cli_timing = {
   profiling_times: (string * float) list;
   targets: cli_target_times list;
   total_bytes: int;
-  max_ocaml_heap_words: int option
+  max_memory_bytes: int option
 }
   [@@deriving show]
 
@@ -8803,11 +8803,11 @@ let write_core_timing : _ -> core_timing -> _ = (
       is_first := false
     else
       Bi_outbuf.add_char ob ',';
-    Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+    Bi_outbuf.add_string ob "\"max_memory_bytes\":";
     (
       Yojson.Safe.write_int
     )
-      ob x.max_ocaml_heap_words;
+      ob x.max_memory_bytes;
     Bi_outbuf.add_char ob '}';
 )
 let string_of_core_timing ?(len = 1024) x =
@@ -8821,7 +8821,7 @@ let read_core_timing = (
     let field_targets = ref (None) in
     let field_rules = ref (None) in
     let field_rules_parse_time = ref (None) in
-    let field_max_ocaml_heap_words = ref (None) in
+    let field_max_memory_bytes = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -8848,20 +8848,26 @@ let read_core_timing = (
                 )
               )
             | 16 -> (
-                if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
-                  2
-                )
-                else (
-                  -1
-                )
-              )
-            | 20 -> (
-                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                  3
-                )
-                else (
-                  -1
-                )
+                match String.unsafe_get s pos with
+                  | 'm' -> (
+                      if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'm' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'm' && String.unsafe_get s (pos+7) = 'o' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'y' && String.unsafe_get s (pos+10) = '_' && String.unsafe_get s (pos+11) = 'b' && String.unsafe_get s (pos+12) = 'y' && String.unsafe_get s (pos+13) = 't' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 's' then (
+                        3
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 'r' -> (
+                      if String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
+                        2
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | _ -> (
+                      -1
+                    )
               )
             | _ -> (
                 -1
@@ -8898,7 +8904,7 @@ let read_core_timing = (
               );
             )
           | 3 ->
-            field_max_ocaml_heap_words := (
+            field_max_memory_bytes := (
               Some (
                 (
                   Atdgen_runtime.Oj_run.read_int
@@ -8935,20 +8941,26 @@ let read_core_timing = (
                   )
                 )
               | 16 -> (
-                  if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
-                    2
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 20 -> (
-                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                    3
-                  )
-                  else (
-                    -1
-                  )
+                  match String.unsafe_get s pos with
+                    | 'm' -> (
+                        if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'm' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'm' && String.unsafe_get s (pos+7) = 'o' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'y' && String.unsafe_get s (pos+10) = '_' && String.unsafe_get s (pos+11) = 'b' && String.unsafe_get s (pos+12) = 'y' && String.unsafe_get s (pos+13) = 't' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 's' then (
+                          3
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 'r' -> (
+                        if String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
+                          2
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
                 )
               | _ -> (
                   -1
@@ -8985,7 +8997,7 @@ let read_core_timing = (
                 );
               )
             | 3 ->
-              field_max_ocaml_heap_words := (
+              field_max_memory_bytes := (
                 Some (
                   (
                     Atdgen_runtime.Oj_run.read_int
@@ -9004,7 +9016,7 @@ let read_core_timing = (
             targets = (match !field_targets with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "targets");
             rules = (match !field_rules with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "rules");
             rules_parse_time = !field_rules_parse_time;
-            max_ocaml_heap_words = (match !field_max_ocaml_heap_words with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_ocaml_heap_words");
+            max_memory_bytes = (match !field_max_memory_bytes with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "max_memory_bytes");
           }
          : core_timing)
       )
@@ -10842,12 +10854,12 @@ let write_cli_timing : _ -> cli_timing -> _ = (
       Yojson.Safe.write_int
     )
       ob x.total_bytes;
-    (match x.max_ocaml_heap_words with None -> () | Some x ->
+    (match x.max_memory_bytes with None -> () | Some x ->
       if !is_first then
         is_first := false
       else
         Bi_outbuf.add_char ob ',';
-      Bi_outbuf.add_string ob "\"max_ocaml_heap_words\":";
+      Bi_outbuf.add_string ob "\"max_memory_bytes\":";
       (
         Yojson.Safe.write_int
       )
@@ -10868,7 +10880,7 @@ let read_cli_timing = (
     let field_profiling_times = ref (None) in
     let field_targets = ref (None) in
     let field_total_bytes = ref (None) in
-    let field_max_ocaml_heap_words = ref (None) in
+    let field_max_memory_bytes = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -10911,20 +10923,26 @@ let read_cli_timing = (
                 )
               )
             | 16 -> (
-                if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
-                  1
-                )
-                else (
-                  -1
-                )
-              )
-            | 20 -> (
-                if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                  5
-                )
-                else (
-                  -1
-                )
+                match String.unsafe_get s pos with
+                  | 'm' -> (
+                      if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'm' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'm' && String.unsafe_get s (pos+7) = 'o' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'y' && String.unsafe_get s (pos+10) = '_' && String.unsafe_get s (pos+11) = 'b' && String.unsafe_get s (pos+12) = 'y' && String.unsafe_get s (pos+13) = 't' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 's' then (
+                        5
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 'r' -> (
+                      if String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
+                        1
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | _ -> (
+                      -1
+                    )
               )
             | _ -> (
                 -1
@@ -10976,7 +10994,7 @@ let read_cli_timing = (
             );
           | 5 ->
             if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_max_ocaml_heap_words := (
+              field_max_memory_bytes := (
                 Some (
                   (
                     Atdgen_runtime.Oj_run.read_int
@@ -11030,20 +11048,26 @@ let read_cli_timing = (
                   )
                 )
               | 16 -> (
-                  if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
-                    1
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 20 -> (
-                  if String.unsafe_get s pos = 'm' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'a' && String.unsafe_get s (pos+7) = 'm' && String.unsafe_get s (pos+8) = 'l' && String.unsafe_get s (pos+9) = '_' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'p' && String.unsafe_get s (pos+14) = '_' && String.unsafe_get s (pos+15) = 'w' && String.unsafe_get s (pos+16) = 'o' && String.unsafe_get s (pos+17) = 'r' && String.unsafe_get s (pos+18) = 'd' && String.unsafe_get s (pos+19) = 's' then (
-                    5
-                  )
-                  else (
-                    -1
-                  )
+                  match String.unsafe_get s pos with
+                    | 'm' -> (
+                        if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'm' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'm' && String.unsafe_get s (pos+7) = 'o' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 'y' && String.unsafe_get s (pos+10) = '_' && String.unsafe_get s (pos+11) = 'b' && String.unsafe_get s (pos+12) = 'y' && String.unsafe_get s (pos+13) = 't' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 's' then (
+                          5
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 'r' -> (
+                        if String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'i' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'e' then (
+                          1
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
                 )
               | _ -> (
                   -1
@@ -11095,7 +11119,7 @@ let read_cli_timing = (
               );
             | 5 ->
               if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_max_ocaml_heap_words := (
+                field_max_memory_bytes := (
                   Some (
                     (
                       Atdgen_runtime.Oj_run.read_int
@@ -11117,7 +11141,7 @@ let read_cli_timing = (
             profiling_times = (match !field_profiling_times with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "profiling_times");
             targets = (match !field_targets with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "targets");
             total_bytes = (match !field_total_bytes with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "total_bytes");
-            max_ocaml_heap_words = !field_max_ocaml_heap_words;
+            max_memory_bytes = !field_max_memory_bytes;
           }
          : cli_timing)
       )

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -105,9 +105,6 @@ type matching_explanation = Semgrep_output_v1_t.matching_explanation = {
 }
   [@@deriving show]
 
-<<<<<<< HEAD
-type version = Semgrep_output_v1_t.version [@@deriving show]
-=======
 type cli_match_call_trace = Semgrep_output_v1_t.cli_match_call_trace = 
     CliLoc of (location * string)
   | CliCall
@@ -118,7 +115,8 @@ type cli_match_call_trace = Semgrep_output_v1_t.cli_match_call_trace =
       )
 
   [@@deriving show]
->>>>>>> b20637e (change and update atd)
+
+type version = Semgrep_output_v1_t.version [@@deriving show]
 
 type transitivity = Semgrep_output_v1_t.transitivity [@@deriving show]
 
@@ -312,7 +310,8 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
   skipped_rules: skipped_rule list option;
   explanations: matching_explanation list option;
   stats: core_stats;
-  time: core_timing option
+  time: core_timing option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -699,15 +698,6 @@ val matching_explanation_of_string :
   string -> matching_explanation
   (** Deserialize JSON data of type {!type:matching_explanation}. *)
 
-<<<<<<< HEAD
-val write_version :
-  Bi_outbuf.t -> version -> unit
-  (** Output a JSON value of type {!type:version}. *)
-
-val string_of_version :
-  ?len:int -> version -> string
-  (** Serialize a value of type {!type:version}
-=======
 val write_cli_match_call_trace :
   Bi_outbuf.t -> cli_match_call_trace -> unit
   (** Output a JSON value of type {!type:cli_match_call_trace}. *)
@@ -715,21 +705,11 @@ val write_cli_match_call_trace :
 val string_of_cli_match_call_trace :
   ?len:int -> cli_match_call_trace -> string
   (** Serialize a value of type {!type:cli_match_call_trace}
->>>>>>> b20637e (change and update atd)
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
                  Default: 1024. *)
 
-<<<<<<< HEAD
-val read_version :
-  Yojson.Safe.lexer_state -> Lexing.lexbuf -> version
-  (** Input JSON data of type {!type:version}. *)
-
-val version_of_string :
-  string -> version
-  (** Deserialize JSON data of type {!type:version}. *)
-=======
 val read_cli_match_call_trace :
   Yojson.Safe.lexer_state -> Lexing.lexbuf -> cli_match_call_trace
   (** Input JSON data of type {!type:cli_match_call_trace}. *)
@@ -737,7 +717,26 @@ val read_cli_match_call_trace :
 val cli_match_call_trace_of_string :
   string -> cli_match_call_trace
   (** Deserialize JSON data of type {!type:cli_match_call_trace}. *)
->>>>>>> b20637e (change and update atd)
+
+val write_version :
+  Bi_outbuf.t -> version -> unit
+  (** Output a JSON value of type {!type:version}. *)
+
+val string_of_version :
+  ?len:int -> version -> string
+  (** Serialize a value of type {!type:version}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_version :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> version
+  (** Input JSON data of type {!type:version}. *)
+
+val version_of_string :
+  string -> version
+  (** Deserialize JSON data of type {!type:version}. *)
 
 val write_transitivity :
   Bi_outbuf.t -> transitivity -> unit

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -349,7 +349,8 @@ type cli_paths = Semgrep_output_v1_t.cli_paths = {
 type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option
+  explanations: matching_explanation list option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -398,7 +399,8 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   results: cli_match list;
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option
+  explanations: matching_explanation list option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -350,7 +350,7 @@ type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: cli_paths;
   time: cli_timing option;
   explanations: matching_explanation list option;
-  max_ocaml_heap_words: int
+  max_ocaml_heap_words: int option
 }
   [@@deriving show]
 
@@ -400,7 +400,7 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   paths: cli_paths;
   time: cli_timing option;
   explanations: matching_explanation list option;
-  max_ocaml_heap_words: int
+  max_ocaml_heap_words: int option
 }
   [@@deriving show]
 

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -263,7 +263,7 @@ type core_timing = Semgrep_output_v1_t.core_timing = {
   targets: target_time list;
   rules: rule_id list;
   rules_parse_time: float option;
-  max_ocaml_heap_words: int
+  max_memory_bytes: int
 }
   [@@deriving show]
 
@@ -330,7 +330,7 @@ type cli_timing = Semgrep_output_v1_t.cli_timing = {
   profiling_times: (string * float) list;
   targets: cli_target_times list;
   total_bytes: int;
-  max_ocaml_heap_words: int option
+  max_memory_bytes: int option
 }
   [@@deriving show]
 

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -262,7 +262,8 @@ type cve_results = Semgrep_output_v1_t.cve_results [@@deriving show]
 type core_timing = Semgrep_output_v1_t.core_timing = {
   targets: target_time list;
   rules: rule_id list;
-  rules_parse_time: float option
+  rules_parse_time: float option;
+  max_ocaml_heap_words: int
 }
   [@@deriving show]
 
@@ -310,8 +311,7 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
   skipped_rules: skipped_rule list option;
   explanations: matching_explanation list option;
   stats: core_stats;
-  time: core_timing option;
-  max_ocaml_heap_words: int
+  time: core_timing option
 }
   [@@deriving show]
 
@@ -329,7 +329,8 @@ type cli_timing = Semgrep_output_v1_t.cli_timing = {
   rules_parse_time: float;
   profiling_times: (string * float) list;
   targets: cli_target_times list;
-  total_bytes: int
+  total_bytes: int;
+  max_ocaml_heap_words: int option
 }
   [@@deriving show]
 
@@ -349,8 +350,7 @@ type cli_paths = Semgrep_output_v1_t.cli_paths = {
 type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option;
-  max_ocaml_heap_words: int option
+  explanations: matching_explanation list option
 }
   [@@deriving show]
 
@@ -399,8 +399,7 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   results: cli_match list;
   paths: cli_paths;
   time: cli_timing option;
-  explanations: matching_explanation list option;
-  max_ocaml_heap_words: int option
+  explanations: matching_explanation list option
 }
   [@@deriving show]
 


### PR DESCRIPTION
Added an `ocaml_max_heap_words` field to the JSON output which denotes the maximum amount of words used by the OCaml process during execution. This will be useful for Metabase scanning, so we can plot this against the repository size and get memory benchmarks over time.