### PR TITLE
Fix error message in 'make test'

### DIFF
--- a/tests/test-ast
+++ b/tests/test-ast
@@ -17,6 +17,6 @@ fi
 echo "semgrep-core is: $(which semgrep-core)"
 for javafile in data/*.java; do
   echo "### Dump JSON AST, read it from Python program: $javafile"
-  "$SEMGREP_CORE" -lang java -generate_ast_json "$javafile"
+  "$semgrep_core" -lang java -generate_ast_json "$javafile"
   python3 read-ast.py < "$javafile".ast.json
 done


### PR DESCRIPTION
We were using the wrong variable in `make test`, which isn't called by anything at the moment.

This is what happens when `semgrep-core` isn't found in PATH:
```
~/semgrep-interfaces $ make test
make -C tests
make[1]: Entering directory '/home/martin/semgrep-interfaces/tests'
./test-ast
semgrep-core is: 
### Dump JSON AST, read it from Python program: data/hello.java
./test-ast: line 20: semgrep-core: command not found
make[1]: *** [Makefile:4: test] Error 127
make[1]: Leaving directory '/home/martin/semgrep-interfaces/tests'
make: *** [Makefile:48: test] Error 2
```
This is what happens when the environment variable is set incorrectly:
```
$ SEMGREP_CORE=id-dont-exist make test
make -C tests
make[1]: Entering directory '/home/martin/semgrep-interfaces/tests'
./test-ast
semgrep-core is: /home/martin/semgrep/bin/semgrep-core
### Dump JSON AST, read it from Python program: data/hello.java
./test-ast: line 20: id-dont-exist: command not found
make[1]: *** [Makefile:4: test] Error 127
make[1]: Leaving directory '/home/martin/semgrep-interfaces/tests'
make: *** [Makefile:48: test] Error 2
```

This is successful output:
```
~/semgrep-interfaces $ make test
make -C tests
make[1]: Entering directory '/home/martin/semgrep-interfaces/tests'
./test-ast
semgrep-core is: /home/martin/semgrep/bin/semgrep-core
### Dump JSON AST, read it from Python program: data/hello.java
saved JSON output in data/hello.java.ast.json
### Dump JSON AST, read it from Python program: data/MainActivity.java
saved JSON output in data/MainActivity.java.ast.json
make[1]: Leaving directory '/home/martin/semgrep-interfaces/tests'
```