### PR TITLE
Update Cairo support to alpha

### DIFF
--- a/lang.json
+++ b/lang.json
@@ -63,7 +63,7 @@
     "keys": [
       "cairo"
     ],
-    "maturity": "develop",
+    "maturity": "alpha",
     "exts": [
       ".cairo"
     ],


### PR DESCRIPTION
This PR is a reaction to: https://semgrep.dev/blog/2023/semgrep-now-supports-cairo-1-0

- [ ] I ran `make` to update the generated code (TODO: have a CI check)
