### PR TITLE
Add semgrep_metrics.py to the auto-generated targets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,2 +1,1 @@
-- [ ] I ran `make setup && make` to update the generated code after
-  editing a `.atd` file (TODO: have a CI check)
+- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,2 @@
-- [ ] I ran `make` to update the generated code (TODO: have a CI check)
+- [ ] I ran `make setup && make` to update the generated code after
+  editing a `.atd` file (TODO: have a CI check)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
-# If you want to modify the .atd, you will need to install via OPAM
-# 'atd', 'atdpy', and 'atdts' to regenerate the code. See the setup
-# target below.
+# Run 'make setup' to install the correct versions of the dependencies.
+# Run 'make' to regenerate all files.
+#
+# You must run 'make' after editing an atd file. This will update
+# other files that we keep under version control. Naturally, don't edit
+# generated files by hand.
 
 VER=v1
 
@@ -37,17 +40,13 @@ build: $(FILES)
 # need atdpy >= 2.11.0 to support parametrized types
 # need atdpy >= 2.12.0 for semgrep_metric.py
 %.py: %.atd
-	test `atdpy --version` = 2.12.0
 	atdpy $<
 
-# not sure about the minimum version of atdgen. Using safe settings.
 %_j.ml %_j.mli: %.atd
-	test `atdgen -version` = 2.12.0 || test `atdgen -version` = 2.11.0
 	atdgen -j -j-std $<
 
 # need atdts >= 2.11.0
 %.ts: %.atd
-	test `atdts --version` = 2.12.0 || test `atdts --version` = 2.11.0
 	atdts $<
 
 # need atdcat >= 2.6.0
@@ -64,8 +63,10 @@ Language.ml Language.mli lang.json: generate.py
 clean:
 	rm -f $(FILES) Language
 
+# This takes a while but ensures we use the correct versions of the atd tools.
 .PHONY: setup
 setup:
+	opam update
 	opam install --deps-only .
 
 # The tests require semgrep-core, among other things.

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,8 @@ FILES= \
   ast_generic_$(VER)_j.mli \
   Language.ml \
   Language.mli \
-  lang.json
-
-#TODO: pb with atdpy 2.11.0
-#  semgrep_metrics.py \
+  lang.json \
+  semgrep_metrics.py
 
 # Regenerate all files.
 #
@@ -37,14 +35,19 @@ force-build:
 build: $(FILES)
 
 # need atdpy >= 2.11.0 to support parametrized types
+# need atdpy >= 2.12.0 for semgrep_metric.py
 %.py: %.atd
+	test `atdpy --version` = 2.12.0
 	atdpy $<
 
+# not sure about the minimum version of atdgen. Using safe settings.
 %_j.ml %_j.mli: %.atd
+	test `atdgen -version` = 2.12.0 || test `atdgen -version` = 2.11.0
 	atdgen -j -j-std $<
 
 # need atdts >= 2.11.0
 %.ts: %.atd
+	test `atdts --version` = 2.12.0 || test `atdts --version` = 2.11.0
 	atdts $<
 
 # need atdcat >= 2.6.0

--- a/dev.opam
+++ b/dev.opam
@@ -8,7 +8,7 @@ bug-reports: "n/a"
 synopsis: "OCaml development dependencies"
 
 depends: [
-  "atd" {= "2.6.0"}
+  "atd" {>= "2.6.0"}
   "atdpy" {>= "2.12.0"}
   "atdts" {>= "2.11.0"}
   "atdgen" {>= "2.10.0"}

--- a/dev.opam
+++ b/dev.opam
@@ -8,7 +8,8 @@ bug-reports: "n/a"
 synopsis: "OCaml development dependencies"
 
 depends: [
-  "atdpy" {>= "2.10.0"}
-  "atdts" {>= "2.10.0"}
+  "atd" {= "2.6.0"}
+  "atdpy" {>= "2.12.0"}
+  "atdts" {>= "2.11.0"}
   "atdgen" {>= "2.10.0"}
 ]

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -71,7 +71,7 @@ type performance = {
     ?fileStats : file_stats list option;
     ?ruleStats : rule_stats list option;
     ?profilingTimes : (string * float) list <json repr="object"> option;
-    maxMemoryBytes: int option;
+    ?maxMemoryBytes: int option;
   }
 
 type file_stats = {

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -516,32 +516,31 @@ class FileStats:
 class Performance:
     """Original type: performance = { ... }"""
 
-    maxMemoryBytes: Optional[int]
     numRules: Optional[int] = None
     numTargets: Optional[int] = None
     totalBytesScanned: Optional[int] = None
     fileStats: Optional[List[FileStats]] = None
     ruleStats: Optional[List[RuleStats]] = None
     profilingTimes: Optional[List[Tuple[str, float]]] = None
+    maxMemoryBytes: Optional[int] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'Performance':
         if isinstance(x, dict):
             return cls(
-                maxMemoryBytes=_atd_read_option(_atd_read_int)(x['maxMemoryBytes']) if 'maxMemoryBytes' in x else _atd_missing_json_field('Performance', 'maxMemoryBytes'),
                 numRules=_atd_read_int(x['numRules']) if 'numRules' in x else None,
                 numTargets=_atd_read_int(x['numTargets']) if 'numTargets' in x else None,
                 totalBytesScanned=_atd_read_int(x['totalBytesScanned']) if 'totalBytesScanned' in x else None,
                 fileStats=_atd_read_list(FileStats.from_json)(x['fileStats']) if 'fileStats' in x else None,
                 ruleStats=_atd_read_list(RuleStats.from_json)(x['ruleStats']) if 'ruleStats' in x else None,
                 profilingTimes=_atd_read_assoc_object_into_list(_atd_read_float)(x['profilingTimes']) if 'profilingTimes' in x else None,
+                maxMemoryBytes=_atd_read_int(x['maxMemoryBytes']) if 'maxMemoryBytes' in x else None,
             )
         else:
             _atd_bad_json('Performance', x)
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
-        res['maxMemoryBytes'] = _atd_write_option(_atd_write_int)(self.maxMemoryBytes)
         if self.numRules is not None:
             res['numRules'] = _atd_write_int(self.numRules)
         if self.numTargets is not None:
@@ -554,6 +553,8 @@ class Performance:
             res['ruleStats'] = _atd_write_list((lambda x: x.to_json()))(self.ruleStats)
         if self.profilingTimes is not None:
             res['profilingTimes'] = _atd_write_assoc_list_to_object(_atd_write_float)(self.profilingTimes)
+        if self.maxMemoryBytes is not None:
+            res['maxMemoryBytes'] = _atd_write_int(self.maxMemoryBytes)
         return res
 
     @classmethod

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -9,7 +9,7 @@ methods and functions to convert data from/to JSON.
 
 # Import annotations to allow forward references
 from __future__ import annotations
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Tuple, Union
 
 import json
@@ -137,6 +137,19 @@ def _atd_read_nullable(read_elt: Callable[[Any], Any]) \
     return read_nullable
 
 
+def _atd_read_option(read_elt: Callable[[Any], Any]) \
+        -> Callable[[Optional[Any]], Optional[Any]]:
+    def read_option(x: Any) -> Any:
+        if x == 'None':
+            return None
+        elif isinstance(x, List) and len(x) == 2 and x[0] == 'Some':
+            return read_elt(x[1])
+        else:
+            _atd_bad_json('option', x)
+            raise AssertionError('impossible')  # keep mypy happy
+    return read_option
+
+
 def _atd_write_unit(x: Any) -> None:
     if x is None:
         return x
@@ -232,6 +245,16 @@ def _atd_write_nullable(write_elt: Callable[[Any], Any]) \
     return write_nullable
 
 
+def _atd_write_option(write_elt: Callable[[Any], Any]) \
+        -> Callable[[Optional[Any]], Optional[Any]]:
+    def write_option(x: Any) -> Any:
+        if x is None:
+            return 'None'
+        else:
+            return ['Some', write_elt(x)]
+    return write_option
+
+
 ############################################################################
 # Public classes
 ############################################################################
@@ -276,7 +299,7 @@ class Value:
     numFindings: Optional[int] = None
     numIgnored: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
-    engineRequested: str = 'OSS'
+    engineRequested: str = field(default_factory=lambda: 'OSS')
 
     @classmethod
     def from_json(cls, x: Any) -> 'Value':
@@ -505,7 +528,7 @@ class Performance:
     def from_json(cls, x: Any) -> 'Performance':
         if isinstance(x, dict):
             return cls(
-                maxMemoryBytes=_atd_read_nullable(_atd_read_int)(x['maxMemoryBytes']) if 'maxMemoryBytes' in x else _atd_missing_json_field('Performance', 'maxMemoryBytes'),
+                maxMemoryBytes=_atd_read_option(_atd_read_int)(x['maxMemoryBytes']) if 'maxMemoryBytes' in x else _atd_missing_json_field('Performance', 'maxMemoryBytes'),
                 numRules=_atd_read_int(x['numRules']) if 'numRules' in x else None,
                 numTargets=_atd_read_int(x['numTargets']) if 'numTargets' in x else None,
                 totalBytesScanned=_atd_read_int(x['totalBytesScanned']) if 'totalBytesScanned' in x else None,
@@ -518,7 +541,7 @@ class Performance:
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
-        res['maxMemoryBytes'] = _atd_write_nullable(_atd_write_int)(self.maxMemoryBytes)
+        res['maxMemoryBytes'] = _atd_write_option(_atd_write_int)(self.maxMemoryBytes)
         if self.numRules is not None:
             res['numRules'] = _atd_write_int(self.numRules)
         if self.numTargets is not None:
@@ -666,16 +689,16 @@ class Environment:
     ci: Optional[str]
     rulesHash: Optional[Sha256hash] = None
     integrationName: Optional[str] = None
-    isAuthenticated: bool = False
+    isAuthenticated: bool = field(default_factory=lambda: False)
 
     @classmethod
     def from_json(cls, x: Any) -> 'Environment':
         if isinstance(x, dict):
             return cls(
                 version=_atd_read_string(x['version']) if 'version' in x else _atd_missing_json_field('Environment', 'version'),
-                projectHash=_atd_read_nullable(Sha256hash.from_json)(x['projectHash']) if 'projectHash' in x else _atd_missing_json_field('Environment', 'projectHash'),
+                projectHash=_atd_read_option(Sha256hash.from_json)(x['projectHash']) if 'projectHash' in x else _atd_missing_json_field('Environment', 'projectHash'),
                 configNamesHash=Sha256hash.from_json(x['configNamesHash']) if 'configNamesHash' in x else _atd_missing_json_field('Environment', 'configNamesHash'),
-                ci=_atd_read_nullable(_atd_read_string)(x['ci']) if 'ci' in x else _atd_missing_json_field('Environment', 'ci'),
+                ci=_atd_read_option(_atd_read_string)(x['ci']) if 'ci' in x else _atd_missing_json_field('Environment', 'ci'),
                 rulesHash=Sha256hash.from_json(x['rulesHash']) if 'rulesHash' in x else None,
                 integrationName=_atd_read_string(x['integrationName']) if 'integrationName' in x else None,
                 isAuthenticated=_atd_read_bool(x['isAuthenticated']) if 'isAuthenticated' in x else False,
@@ -686,9 +709,9 @@ class Environment:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['version'] = _atd_write_string(self.version)
-        res['projectHash'] = _atd_write_nullable((lambda x: x.to_json()))(self.projectHash)
+        res['projectHash'] = _atd_write_option((lambda x: x.to_json()))(self.projectHash)
         res['configNamesHash'] = (lambda x: x.to_json())(self.configNamesHash)
-        res['ci'] = _atd_write_nullable(_atd_write_string)(self.ci)
+        res['ci'] = _atd_write_option(_atd_write_string)(self.ci)
         if self.rulesHash is not None:
             res['rulesHash'] = (lambda x: x.to_json())(self.rulesHash)
         if self.integrationName is not None:
@@ -717,7 +740,7 @@ class Payload:
     extension: Extension
     errors: Errors
     value: Value
-    parse_rate: List[Tuple[str, ParseStat]]
+    parse_rate: List[Tuple[str, ParseStat]] = field(default_factory=lambda: [])
 
     @classmethod
     def from_json(cls, x: Any) -> 'Payload':


### PR DESCRIPTION
The atdpy bug was fixed in 2.12.0. I'm not sure how the previous version of this file was created. There's a nonempty diff.

Update: the field `maxMemoryBytes` was using `option` but was not optional. We should not use this. I made the field optional.

This updates the version constraints in `dev.opam` and stresses the importance of running `make setup`.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
