### PR TITLE
fix: change strip type back to bool

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -107,10 +107,8 @@ $defs:
                     title: Integer base to parse metavariable contents as
                     type: integer
                   strip:
-                    title: Metavariable names to strip quotes from
-                    type: array
-                    items:
-                      type: string
+                    title: Whether to strip quotes from compared metavariables 
+                    type: boolean 
               - required: [ metavariable ]
                 $ref: "#/$defs/new-pattern"
                 properties:


### PR DESCRIPTION
Somehow, we changed `strip` to be an array of metavariable names which are meant to be rewritten, in the rule schema for the new syntax. Unfortunately, this is _not at all_ what `Parse_rule` does, so this was just a complete lie by the schema. https://github.com/returntocorp/semgrep/blob/20fa7210ed38eb48dce100687868b1bd1db6f5c4/src/parsing/Parse_rule.ml#L1079

So this just fixes that.

- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
