### PR TITLE
chore: make cai_ids optonal list

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -816,7 +816,7 @@ type api_scans_findings <ocaml attr="deriving show"> = {
    searched_paths: string list;
    (* TODO: rule_id list *)
    rule_ids: string list;
-   cai_ids: string list;
+   cai_ids: string list option;
 }
 
 type finding_hashes <ocaml attr="deriving show"> = {

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -816,7 +816,6 @@ type api_scans_findings <ocaml attr="deriving show"> = {
    searched_paths: string list;
    (* TODO: rule_id list *)
    rule_ids: string list;
-   cai_ids: string list option;
 }
 
 type finding_hashes <ocaml attr="deriving show"> = {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -703,8 +703,7 @@
     "api_scans_findings": {
       "type": "object",
       "required": [
-        "findings", "token", "gitlab_token", "searched_paths", "rule_ids",
-        "cai_ids"
+        "findings", "token", "gitlab_token", "searched_paths", "rule_ids"
       ],
       "properties": {
         "findings": {
@@ -714,21 +713,7 @@
         "token": { "type": [ "string", "null" ] },
         "gitlab_token": { "type": [ "string", "null" ] },
         "searched_paths": { "type": "array", "items": { "type": "string" } },
-        "rule_ids": { "type": "array", "items": { "type": "string" } },
-        "cai_ids": {
-          "oneOf": [
-            {
-              "type": "array",
-              "minItems": 2,
-              "items": false,
-              "prefixItems": [
-                { "const": "Some" },
-                { "type": "array", "items": { "type": "string" } }
-              ]
-            },
-            { "const": "None" }
-          ]
-        }
+        "rule_ids": { "type": "array", "items": { "type": "string" } }
       }
     },
     "finding_hashes": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -715,7 +715,20 @@
         "gitlab_token": { "type": [ "string", "null" ] },
         "searched_paths": { "type": "array", "items": { "type": "string" } },
         "rule_ids": { "type": "array", "items": { "type": "string" } },
-        "cai_ids": { "type": "array", "items": { "type": "string" } }
+        "cai_ids": {
+          "oneOf": [
+            {
+              "type": "array",
+              "minItems": 2,
+              "items": false,
+              "prefixItems": [
+                { "const": "Some" },
+                { "type": "array", "items": { "type": "string" } }
+              ]
+            },
+            { "const": "None" }
+          ]
+        }
       }
     },
     "finding_hashes": {

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -3445,7 +3445,6 @@ class ApiScansFindings:
     gitlab_token: Optional[str]
     searched_paths: List[str]
     rule_ids: List[str]
-    cai_ids: Optional[List[str]]
 
     @classmethod
     def from_json(cls, x: Any) -> 'ApiScansFindings':
@@ -3456,7 +3455,6 @@ class ApiScansFindings:
                 gitlab_token=_atd_read_nullable(_atd_read_string)(x['gitlab_token']) if 'gitlab_token' in x else _atd_missing_json_field('ApiScansFindings', 'gitlab_token'),
                 searched_paths=_atd_read_list(_atd_read_string)(x['searched_paths']) if 'searched_paths' in x else _atd_missing_json_field('ApiScansFindings', 'searched_paths'),
                 rule_ids=_atd_read_list(_atd_read_string)(x['rule_ids']) if 'rule_ids' in x else _atd_missing_json_field('ApiScansFindings', 'rule_ids'),
-                cai_ids=_atd_read_option(_atd_read_list(_atd_read_string))(x['cai_ids']) if 'cai_ids' in x else _atd_missing_json_field('ApiScansFindings', 'cai_ids'),
             )
         else:
             _atd_bad_json('ApiScansFindings', x)
@@ -3468,7 +3466,6 @@ class ApiScansFindings:
         res['gitlab_token'] = _atd_write_nullable(_atd_write_string)(self.gitlab_token)
         res['searched_paths'] = _atd_write_list(_atd_write_string)(self.searched_paths)
         res['rule_ids'] = _atd_write_list(_atd_write_string)(self.rule_ids)
-        res['cai_ids'] = _atd_write_option(_atd_write_list(_atd_write_string))(self.cai_ids)
         return res
 
     @classmethod

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -3445,7 +3445,7 @@ class ApiScansFindings:
     gitlab_token: Optional[str]
     searched_paths: List[str]
     rule_ids: List[str]
-    cai_ids: List[str]
+    cai_ids: Optional[List[str]]
 
     @classmethod
     def from_json(cls, x: Any) -> 'ApiScansFindings':
@@ -3456,7 +3456,7 @@ class ApiScansFindings:
                 gitlab_token=_atd_read_nullable(_atd_read_string)(x['gitlab_token']) if 'gitlab_token' in x else _atd_missing_json_field('ApiScansFindings', 'gitlab_token'),
                 searched_paths=_atd_read_list(_atd_read_string)(x['searched_paths']) if 'searched_paths' in x else _atd_missing_json_field('ApiScansFindings', 'searched_paths'),
                 rule_ids=_atd_read_list(_atd_read_string)(x['rule_ids']) if 'rule_ids' in x else _atd_missing_json_field('ApiScansFindings', 'rule_ids'),
-                cai_ids=_atd_read_list(_atd_read_string)(x['cai_ids']) if 'cai_ids' in x else _atd_missing_json_field('ApiScansFindings', 'cai_ids'),
+                cai_ids=_atd_read_option(_atd_read_list(_atd_read_string))(x['cai_ids']) if 'cai_ids' in x else _atd_missing_json_field('ApiScansFindings', 'cai_ids'),
             )
         else:
             _atd_bad_json('ApiScansFindings', x)
@@ -3468,7 +3468,7 @@ class ApiScansFindings:
         res['gitlab_token'] = _atd_write_nullable(_atd_write_string)(self.gitlab_token)
         res['searched_paths'] = _atd_write_list(_atd_write_string)(self.searched_paths)
         res['rule_ids'] = _atd_write_list(_atd_write_string)(self.rule_ids)
-        res['cai_ids'] = _atd_write_list(_atd_write_string)(self.cai_ids)
+        res['cai_ids'] = _atd_write_option(_atd_write_list(_atd_write_string))(self.cai_ids)
         return res
 
     @classmethod

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -388,7 +388,7 @@ export type ApiScansFindings = {
   gitlab_token: (string | null);
   searched_paths: string[];
   rule_ids: string[];
-  cai_ids: string[];
+  cai_ids: Option<string[]>;
 }
 
 export type FindingHashes = {
@@ -1569,7 +1569,7 @@ export function writeApiScansFindings(x: ApiScansFindings, context: any = x): an
     'gitlab_token': _atd_write_required_field('ApiScansFindings', 'gitlab_token', _atd_write_nullable(_atd_write_string), x.gitlab_token, x),
     'searched_paths': _atd_write_required_field('ApiScansFindings', 'searched_paths', _atd_write_array(_atd_write_string), x.searched_paths, x),
     'rule_ids': _atd_write_required_field('ApiScansFindings', 'rule_ids', _atd_write_array(_atd_write_string), x.rule_ids, x),
-    'cai_ids': _atd_write_required_field('ApiScansFindings', 'cai_ids', _atd_write_array(_atd_write_string), x.cai_ids, x),
+    'cai_ids': _atd_write_required_field('ApiScansFindings', 'cai_ids', _atd_write_option(_atd_write_array(_atd_write_string)), x.cai_ids, x),
   };
 }
 
@@ -1580,7 +1580,7 @@ export function readApiScansFindings(x: any, context: any = x): ApiScansFindings
     gitlab_token: _atd_read_required_field('ApiScansFindings', 'gitlab_token', _atd_read_nullable(_atd_read_string), x['gitlab_token'], x),
     searched_paths: _atd_read_required_field('ApiScansFindings', 'searched_paths', _atd_read_array(_atd_read_string), x['searched_paths'], x),
     rule_ids: _atd_read_required_field('ApiScansFindings', 'rule_ids', _atd_read_array(_atd_read_string), x['rule_ids'], x),
-    cai_ids: _atd_read_required_field('ApiScansFindings', 'cai_ids', _atd_read_array(_atd_read_string), x['cai_ids'], x),
+    cai_ids: _atd_read_required_field('ApiScansFindings', 'cai_ids', _atd_read_option(_atd_read_array(_atd_read_string)), x['cai_ids'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -388,7 +388,6 @@ export type ApiScansFindings = {
   gitlab_token: (string | null);
   searched_paths: string[];
   rule_ids: string[];
-  cai_ids: Option<string[]>;
 }
 
 export type FindingHashes = {
@@ -1569,7 +1568,6 @@ export function writeApiScansFindings(x: ApiScansFindings, context: any = x): an
     'gitlab_token': _atd_write_required_field('ApiScansFindings', 'gitlab_token', _atd_write_nullable(_atd_write_string), x.gitlab_token, x),
     'searched_paths': _atd_write_required_field('ApiScansFindings', 'searched_paths', _atd_write_array(_atd_write_string), x.searched_paths, x),
     'rule_ids': _atd_write_required_field('ApiScansFindings', 'rule_ids', _atd_write_array(_atd_write_string), x.rule_ids, x),
-    'cai_ids': _atd_write_required_field('ApiScansFindings', 'cai_ids', _atd_write_option(_atd_write_array(_atd_write_string)), x.cai_ids, x),
   };
 }
 
@@ -1580,7 +1578,6 @@ export function readApiScansFindings(x: any, context: any = x): ApiScansFindings
     gitlab_token: _atd_read_required_field('ApiScansFindings', 'gitlab_token', _atd_read_nullable(_atd_read_string), x['gitlab_token'], x),
     searched_paths: _atd_read_required_field('ApiScansFindings', 'searched_paths', _atd_read_array(_atd_read_string), x['searched_paths'], x),
     rule_ids: _atd_read_required_field('ApiScansFindings', 'rule_ids', _atd_read_array(_atd_read_string), x['rule_ids'], x),
-    cai_ids: _atd_read_required_field('ApiScansFindings', 'cai_ids', _atd_read_option(_atd_read_array(_atd_read_string)), x['cai_ids'], x),
   };
 }
 

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -446,7 +446,7 @@ type api_scans_findings = Semgrep_output_v1_t.api_scans_findings = {
   gitlab_token: string option;
   searched_paths: string list;
   rule_ids: string list;
-  cai_ids: string list
+  cai_ids: string list option
 }
   [@@deriving show]
 
@@ -564,7 +564,7 @@ let read_fpath = (
 let fpath_of_string s =
   read_fpath (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_matching_operation : _ -> matching_operation -> _ = (
-  fun ob x ->
+  fun ob (x : matching_operation) ->
     match x with
       | And -> Buffer.add_string ob "\"And\""
       | Or -> Buffer.add_string ob "\"Or\""
@@ -2140,7 +2140,7 @@ let read_metavars = (
 let metavars_of_string s =
   read_metavars (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_cli_match_call_trace : _ -> cli_match_call_trace -> _ = (
-  fun ob x ->
+  fun ob (x : cli_match_call_trace) ->
     match x with
       | CliLoc x ->
         Buffer.add_string ob "[\"CliLoc\",";
@@ -2535,7 +2535,7 @@ let rec read_cli_match_call_trace = (
 and cli_match_call_trace_of_string s =
   read_cli_match_call_trace (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_core_match_call_trace : _ -> core_match_call_trace -> _ = (
-  fun ob x ->
+  fun ob (x : core_match_call_trace) ->
     match x with
       | CoreLoc x ->
         Buffer.add_string ob "[\"CoreLoc\",";
@@ -4389,7 +4389,7 @@ let read_target_time = (
 let target_time_of_string s =
   read_target_time (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_skip_reason : _ -> skip_reason -> _ = (
-  fun ob x ->
+  fun ob (x : skip_reason) ->
     match x with
       | Gitignore_patterns_match -> Buffer.add_string ob "\"gitignore_patterns_match\""
       | Always_skipped -> Buffer.add_string ob "\"always_skipped\""
@@ -9914,7 +9914,7 @@ let read_core_stats = (
 let core_stats_of_string s =
   read_core_stats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_severity : _ -> core_severity -> _ = (
-  fun ob x ->
+  fun ob (x : core_severity) ->
     match x with
       | Error -> Buffer.add_string ob "\"error\""
       | Warning -> Buffer.add_string ob "\"warning\""
@@ -9974,7 +9974,7 @@ let read__location_list = (
 let _location_list_of_string s =
   read__location_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_error_kind : _ -> core_error_kind -> _ = (
-  fun ob x ->
+  fun ob (x : core_error_kind) ->
     match x with
       | LexicalError -> Buffer.add_string ob "\"Lexical error\""
       | ParseError -> Buffer.add_string ob "\"Syntax error\""
@@ -15704,7 +15704,7 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"cai_ids\":";
     (
-      write__string_list
+      write__string_list_option
     )
       ob x.cai_ids;
     Buffer.add_char ob '}';
@@ -15838,7 +15838,7 @@ let read_api_scans_findings = (
             field_cai_ids := (
               Some (
                 (
-                  read__string_list
+                  read__string_list_option
                 ) p lb
               )
             );
@@ -15961,7 +15961,7 @@ let read_api_scans_findings = (
               field_cai_ids := (
                 Some (
                   (
-                    read__string_list
+                    read__string_list_option
                   ) p lb
                 )
               );

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -445,8 +445,7 @@ type api_scans_findings = Semgrep_output_v1_t.api_scans_findings = {
   token: string option;
   gitlab_token: string option;
   searched_paths: string list;
-  rule_ids: string list;
-  cai_ids: string list option
+  rule_ids: string list
 }
   [@@deriving show]
 
@@ -15698,15 +15697,6 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       write__string_list
     )
       ob x.rule_ids;
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
-      Buffer.add_string ob "\"cai_ids\":";
-    (
-      write__string_list_option
-    )
-      ob x.cai_ids;
     Buffer.add_char ob '}';
 )
 let string_of_api_scans_findings ?(len = 1024) x =
@@ -15722,7 +15712,6 @@ let read_api_scans_findings = (
     let field_gitlab_token = ref (None) in
     let field_searched_paths = ref (None) in
     let field_rule_ids = ref (None) in
-    let field_cai_ids = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -15735,14 +15724,6 @@ let read_api_scans_findings = (
             | 5 -> (
                 if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'k' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' then (
                   1
-                )
-                else (
-                  -1
-                )
-              )
-            | 7 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'd' && String.unsafe_get s (pos+6) = 's' then (
-                  5
                 )
                 else (
                   -1
@@ -15834,14 +15815,6 @@ let read_api_scans_findings = (
                 ) p lb
               )
             );
-          | 5 ->
-            field_cai_ids := (
-              Some (
-                (
-                  read__string_list_option
-                ) p lb
-              )
-            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -15858,14 +15831,6 @@ let read_api_scans_findings = (
               | 5 -> (
                   if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'k' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' then (
                     1
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 7 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'd' && String.unsafe_get s (pos+6) = 's' then (
-                    5
                   )
                   else (
                     -1
@@ -15957,14 +15922,6 @@ let read_api_scans_findings = (
                   ) p lb
                 )
               );
-            | 5 ->
-              field_cai_ids := (
-                Some (
-                  (
-                    read__string_list_option
-                  ) p lb
-                )
-              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -15979,7 +15936,6 @@ let read_api_scans_findings = (
             gitlab_token = (match !field_gitlab_token with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "gitlab_token");
             searched_paths = (match !field_searched_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "searched_paths");
             rule_ids = (match !field_rule_ids with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "rule_ids");
-            cai_ids = (match !field_cai_ids with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "cai_ids");
           }
          : api_scans_findings)
       )

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -445,8 +445,7 @@ type api_scans_findings = Semgrep_output_v1_t.api_scans_findings = {
   token: string option;
   gitlab_token: string option;
   searched_paths: string list;
-  rule_ids: string list;
-  cai_ids: string list option
+  rule_ids: string list
 }
   [@@deriving show]
 

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -446,7 +446,7 @@ type api_scans_findings = Semgrep_output_v1_t.api_scans_findings = {
   gitlab_token: string option;
   searched_paths: string list;
   rule_ids: string list;
-  cai_ids: string list
+  cai_ids: string list option
 }
   [@@deriving show]
 


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)

The cai_ids have not been used for quite some time. I am trying to finish removing them from the app and CLI to simplify the logic in both.

See https://github.com/returntocorp/semgrep-app/pull/8773
