### PR TITLE
fix: `focus` operator type

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -98,7 +98,11 @@ $defs:
               - required: [ focus ]
                 properties:
                   focus:
-                    type: string
+                    oneOf:
+                      - type: string
+                      - type: array
+                        items:
+                          type: string
               - required: [ comparison ]
                 properties:
                   comparison:


### PR DESCRIPTION
This PR just changes the `focus` operator's type in the rule schema to reflect @enncoded's excellent work!

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
