### PR TITLE
update api_scans_findings to match current usage

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -811,12 +811,14 @@ type found_dependency <ocaml attr="deriving show"> = {
 type api_scans_findings <ocaml attr="deriving show"> = {
   (* TODO: ?version: version option; *)
    findings: finding list;
+   ignores: finding list;   
    token: string nullable;
-   gitlab_token: string nullable;
    searched_paths: string list;
-   (* TODO: rule_id list *)
+   renamed_paths: string list;
    rule_ids: string list;
 }
+
+
 
 type finding_hashes <ocaml attr="deriving show"> = {
   start_line_hash: string;

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -703,16 +703,21 @@
     "api_scans_findings": {
       "type": "object",
       "required": [
-        "findings", "token", "gitlab_token", "searched_paths", "rule_ids"
+        "findings", "ignores", "token", "searched_paths", "renamed_paths",
+        "rule_ids"
       ],
       "properties": {
         "findings": {
           "type": "array",
           "items": { "$ref": "#/definitions/finding" }
         },
+        "ignores": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/finding" }
+        },
         "token": { "type": [ "string", "null" ] },
-        "gitlab_token": { "type": [ "string", "null" ] },
         "searched_paths": { "type": "array", "items": { "type": "string" } },
+        "renamed_paths": { "type": "array", "items": { "type": "string" } },
         "rule_ids": { "type": "array", "items": { "type": "string" } }
       }
     },

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -3441,9 +3441,10 @@ class ApiScansFindings:
     """Original type: api_scans_findings = { ... }"""
 
     findings: List[Finding]
+    ignores: List[Finding]
     token: Optional[str]
-    gitlab_token: Optional[str]
     searched_paths: List[str]
+    renamed_paths: List[str]
     rule_ids: List[str]
 
     @classmethod
@@ -3451,9 +3452,10 @@ class ApiScansFindings:
         if isinstance(x, dict):
             return cls(
                 findings=_atd_read_list(Finding.from_json)(x['findings']) if 'findings' in x else _atd_missing_json_field('ApiScansFindings', 'findings'),
+                ignores=_atd_read_list(Finding.from_json)(x['ignores']) if 'ignores' in x else _atd_missing_json_field('ApiScansFindings', 'ignores'),
                 token=_atd_read_nullable(_atd_read_string)(x['token']) if 'token' in x else _atd_missing_json_field('ApiScansFindings', 'token'),
-                gitlab_token=_atd_read_nullable(_atd_read_string)(x['gitlab_token']) if 'gitlab_token' in x else _atd_missing_json_field('ApiScansFindings', 'gitlab_token'),
                 searched_paths=_atd_read_list(_atd_read_string)(x['searched_paths']) if 'searched_paths' in x else _atd_missing_json_field('ApiScansFindings', 'searched_paths'),
+                renamed_paths=_atd_read_list(_atd_read_string)(x['renamed_paths']) if 'renamed_paths' in x else _atd_missing_json_field('ApiScansFindings', 'renamed_paths'),
                 rule_ids=_atd_read_list(_atd_read_string)(x['rule_ids']) if 'rule_ids' in x else _atd_missing_json_field('ApiScansFindings', 'rule_ids'),
             )
         else:
@@ -3462,9 +3464,10 @@ class ApiScansFindings:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['findings'] = _atd_write_list((lambda x: x.to_json()))(self.findings)
+        res['ignores'] = _atd_write_list((lambda x: x.to_json()))(self.ignores)
         res['token'] = _atd_write_nullable(_atd_write_string)(self.token)
-        res['gitlab_token'] = _atd_write_nullable(_atd_write_string)(self.gitlab_token)
         res['searched_paths'] = _atd_write_list(_atd_write_string)(self.searched_paths)
+        res['renamed_paths'] = _atd_write_list(_atd_write_string)(self.renamed_paths)
         res['rule_ids'] = _atd_write_list(_atd_write_string)(self.rule_ids)
         return res
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -384,9 +384,10 @@ export type FoundDependency = {
 
 export type ApiScansFindings = {
   findings: Finding[];
+  ignores: Finding[];
   token: (string | null);
-  gitlab_token: (string | null);
   searched_paths: string[];
+  renamed_paths: string[];
   rule_ids: string[];
 }
 
@@ -1564,9 +1565,10 @@ export function readFoundDependency(x: any, context: any = x): FoundDependency {
 export function writeApiScansFindings(x: ApiScansFindings, context: any = x): any {
   return {
     'findings': _atd_write_required_field('ApiScansFindings', 'findings', _atd_write_array(writeFinding), x.findings, x),
+    'ignores': _atd_write_required_field('ApiScansFindings', 'ignores', _atd_write_array(writeFinding), x.ignores, x),
     'token': _atd_write_required_field('ApiScansFindings', 'token', _atd_write_nullable(_atd_write_string), x.token, x),
-    'gitlab_token': _atd_write_required_field('ApiScansFindings', 'gitlab_token', _atd_write_nullable(_atd_write_string), x.gitlab_token, x),
     'searched_paths': _atd_write_required_field('ApiScansFindings', 'searched_paths', _atd_write_array(_atd_write_string), x.searched_paths, x),
+    'renamed_paths': _atd_write_required_field('ApiScansFindings', 'renamed_paths', _atd_write_array(_atd_write_string), x.renamed_paths, x),
     'rule_ids': _atd_write_required_field('ApiScansFindings', 'rule_ids', _atd_write_array(_atd_write_string), x.rule_ids, x),
   };
 }
@@ -1574,9 +1576,10 @@ export function writeApiScansFindings(x: ApiScansFindings, context: any = x): an
 export function readApiScansFindings(x: any, context: any = x): ApiScansFindings {
   return {
     findings: _atd_read_required_field('ApiScansFindings', 'findings', _atd_read_array(readFinding), x['findings'], x),
+    ignores: _atd_read_required_field('ApiScansFindings', 'ignores', _atd_read_array(readFinding), x['ignores'], x),
     token: _atd_read_required_field('ApiScansFindings', 'token', _atd_read_nullable(_atd_read_string), x['token'], x),
-    gitlab_token: _atd_read_required_field('ApiScansFindings', 'gitlab_token', _atd_read_nullable(_atd_read_string), x['gitlab_token'], x),
     searched_paths: _atd_read_required_field('ApiScansFindings', 'searched_paths', _atd_read_array(_atd_read_string), x['searched_paths'], x),
+    renamed_paths: _atd_read_required_field('ApiScansFindings', 'renamed_paths', _atd_read_array(_atd_read_string), x['renamed_paths'], x),
     rule_ids: _atd_read_required_field('ApiScansFindings', 'rule_ids', _atd_read_array(_atd_read_string), x['rule_ids'], x),
   };
 }

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -442,9 +442,10 @@ type cli_match_taint_source = Semgrep_output_v1_t.cli_match_taint_source = {
 
 type api_scans_findings = Semgrep_output_v1_t.api_scans_findings = {
   findings: finding list;
+  ignores: finding list;
   token: string option;
-  gitlab_token: string option;
   searched_paths: string list;
+  renamed_paths: string list;
   rule_ids: string list
 }
   [@@deriving show]
@@ -15665,6 +15666,15 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       is_first := false
     else
       Buffer.add_char ob ',';
+      Buffer.add_string ob "\"ignores\":";
+    (
+      write__finding_list
+    )
+      ob x.ignores;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
       Buffer.add_string ob "\"token\":";
     (
       write__string_nullable
@@ -15674,20 +15684,20 @@ let write_api_scans_findings : _ -> api_scans_findings -> _ = (
       is_first := false
     else
       Buffer.add_char ob ',';
-      Buffer.add_string ob "\"gitlab_token\":";
-    (
-      write__string_nullable
-    )
-      ob x.gitlab_token;
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
       Buffer.add_string ob "\"searched_paths\":";
     (
       write__string_list
     )
       ob x.searched_paths;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"renamed_paths\":";
+    (
+      write__string_list
+    )
+      ob x.renamed_paths;
     if !is_first then
       is_first := false
     else
@@ -15708,9 +15718,10 @@ let read_api_scans_findings = (
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
     let field_findings = ref (None) in
+    let field_ignores = ref (None) in
     let field_token = ref (None) in
-    let field_gitlab_token = ref (None) in
     let field_searched_paths = ref (None) in
+    let field_renamed_paths = ref (None) in
     let field_rule_ids = ref (None) in
     try
       Yojson.Safe.read_space p lb;
@@ -15723,6 +15734,14 @@ let read_api_scans_findings = (
           match len with
             | 5 -> (
                 if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'k' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' then (
+                  2
+                )
+                else (
+                  -1
+                )
+              )
+            | 7 -> (
+                if String.unsafe_get s pos = 'i' && String.unsafe_get s (pos+1) = 'g' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'o' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 's' then (
                   1
                 )
                 else (
@@ -15741,7 +15760,7 @@ let read_api_scans_findings = (
                     )
                   | 'r' -> (
                       if String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = '_' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = 's' then (
-                        4
+                        5
                       )
                       else (
                         -1
@@ -15751,9 +15770,9 @@ let read_api_scans_findings = (
                       -1
                     )
               )
-            | 12 -> (
-                if String.unsafe_get s pos = 'g' && String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'b' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'o' && String.unsafe_get s (pos+9) = 'k' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 'n' then (
-                  2
+            | 13 -> (
+                if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'm' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'p' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 't' && String.unsafe_get s (pos+11) = 'h' && String.unsafe_get s (pos+12) = 's' then (
+                  4
                 )
                 else (
                   -1
@@ -15784,15 +15803,15 @@ let read_api_scans_findings = (
               )
             );
           | 1 ->
-            field_token := (
+            field_ignores := (
               Some (
                 (
-                  read__string_nullable
+                  read__finding_list
                 ) p lb
               )
             );
           | 2 ->
-            field_gitlab_token := (
+            field_token := (
               Some (
                 (
                   read__string_nullable
@@ -15808,6 +15827,14 @@ let read_api_scans_findings = (
               )
             );
           | 4 ->
+            field_renamed_paths := (
+              Some (
+                (
+                  read__string_list
+                ) p lb
+              )
+            );
+          | 5 ->
             field_rule_ids := (
               Some (
                 (
@@ -15830,6 +15857,14 @@ let read_api_scans_findings = (
             match len with
               | 5 -> (
                   if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'k' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' then (
+                    2
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 7 -> (
+                  if String.unsafe_get s pos = 'i' && String.unsafe_get s (pos+1) = 'g' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'o' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 's' then (
                     1
                   )
                   else (
@@ -15848,7 +15883,7 @@ let read_api_scans_findings = (
                       )
                     | 'r' -> (
                         if String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'l' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = '_' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = 's' then (
-                          4
+                          5
                         )
                         else (
                           -1
@@ -15858,9 +15893,9 @@ let read_api_scans_findings = (
                         -1
                       )
                 )
-              | 12 -> (
-                  if String.unsafe_get s pos = 'g' && String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'b' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'o' && String.unsafe_get s (pos+9) = 'k' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 'n' then (
-                    2
+              | 13 -> (
+                  if String.unsafe_get s pos = 'r' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'm' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = 'd' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'p' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 't' && String.unsafe_get s (pos+11) = 'h' && String.unsafe_get s (pos+12) = 's' then (
+                    4
                   )
                   else (
                     -1
@@ -15891,15 +15926,15 @@ let read_api_scans_findings = (
                 )
               );
             | 1 ->
-              field_token := (
+              field_ignores := (
                 Some (
                   (
-                    read__string_nullable
+                    read__finding_list
                   ) p lb
                 )
               );
             | 2 ->
-              field_gitlab_token := (
+              field_token := (
                 Some (
                   (
                     read__string_nullable
@@ -15915,6 +15950,14 @@ let read_api_scans_findings = (
                 )
               );
             | 4 ->
+              field_renamed_paths := (
+                Some (
+                  (
+                    read__string_list
+                  ) p lb
+                )
+              );
+            | 5 ->
               field_rule_ids := (
                 Some (
                   (
@@ -15932,9 +15975,10 @@ let read_api_scans_findings = (
         (
           {
             findings = (match !field_findings with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "findings");
+            ignores = (match !field_ignores with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "ignores");
             token = (match !field_token with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "token");
-            gitlab_token = (match !field_gitlab_token with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "gitlab_token");
             searched_paths = (match !field_searched_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "searched_paths");
+            renamed_paths = (match !field_renamed_paths with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "renamed_paths");
             rule_ids = (match !field_rule_ids with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "rule_ids");
           }
          : api_scans_findings)

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -442,9 +442,10 @@ type cli_match_taint_source = Semgrep_output_v1_t.cli_match_taint_source = {
 
 type api_scans_findings = Semgrep_output_v1_t.api_scans_findings = {
   findings: finding list;
+  ignores: finding list;
   token: string option;
-  gitlab_token: string option;
   searched_paths: string list;
+  renamed_paths: string list;
   rule_ids: string list
 }
   [@@deriving show]


### PR DESCRIPTION
This is needed so we can start strongly typing the messages between the CLI and semgrep.dev.

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
