### PR TITLE
enable the migration of severity from int to string

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -105,7 +105,7 @@ type rule_id
 
 type rule_id_and_engine_kind
   <ocaml attr="deriving show">
-  <python decorator="dataclass(frozen=True)"> = (rule_id * engine_kind) 
+  <python decorator="dataclass(frozen=True)"> = (rule_id * engine_kind)
 
 (*****************************************************************************)
 (* Core Match result *)
@@ -117,7 +117,7 @@ type engine_kind
   <python decorator="dataclass(frozen=True)"> = [
   | OSS
   | PRO
-] 
+]
 
 type core_match
   <ocaml attr="deriving show">
@@ -150,7 +150,7 @@ type core_match_call_trace
   <ocaml attr="deriving show">
   <python decorator="dataclass(frozen=True, order=True)"> = [
   | CoreLoc of location
-  | CoreCall of (location * core_match_intermediate_var list * core_match_call_trace) 
+  | CoreCall of (location * core_match_intermediate_var list * core_match_call_trace)
 ] <ocaml repr="classic">
 
 (* Provides information about dataflow that leads to a finding. For now, just
@@ -547,7 +547,7 @@ type cli_match_call_trace
   <ocaml attr="deriving show">
   <python decorator="dataclass(frozen=True, order=True)"> = [
   | CliLoc of (location * string)
-  | CliCall of ((location * string) * cli_match_intermediate_var list * cli_match_call_trace) 
+  | CliCall of ((location * string) * cli_match_intermediate_var list * cli_match_call_trace)
 ] <ocaml repr="classic">
 
 (* from rule_lang.py in the Span class
@@ -762,7 +762,7 @@ type dependency_match <ocaml attr="deriving show"> = {
   lockfile: string;
 }
 
-type ecosystem 
+type ecosystem
   <ocaml attr="deriving show">
   <python decorator="dataclass(frozen=True)"> = [
   | Npm <json name="npm">
@@ -774,7 +774,7 @@ type ecosystem
   | Composer <json name="composer">
 ]
 
-type transitivity 
+type transitivity
   <ocaml attr="deriving show">
   <python decorator="dataclass(frozen=True)"> = [
     | Direct <json name="direct">
@@ -827,6 +827,7 @@ type finding_hashes <ocaml attr="deriving show"> = {
   pattern_hash: string;
 }
 
+
 (* TODO: rewrite rule_matches.to_app_finding_format() *)
 type finding <ocaml attr="deriving show"> = {
   check_id: rule_id;
@@ -836,8 +837,7 @@ type finding <ocaml attr="deriving show"> = {
   end_line: int;
   end_column: int;
   message: string;
-  (* TODO: use variant *)
-  severity: int;
+  severity: abstract; (* int|string until minimum version exceeds 1.32.0, then string *)
   (* ?? *)
   index: int;
   commit_date: string;

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -827,7 +827,6 @@ type finding_hashes <ocaml attr="deriving show"> = {
   pattern_hash: string;
 }
 
-
 (* TODO: rewrite rule_matches.to_app_finding_format() *)
 type finding <ocaml attr="deriving show"> = {
   check_id: rule_id;

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -743,7 +743,7 @@
         "end_line": { "type": "integer" },
         "end_column": { "type": "integer" },
         "message": { "type": "string" },
-        "severity": { "type": "integer" },
+        "severity": {},
         "index": { "type": "integer" },
         "commit_date": { "type": "string" },
         "syntactic_id": { "type": "string" },

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2219,7 +2219,7 @@ class Finding:
     end_line: int
     end_column: int
     message: str
-    severity: int
+    severity: Any
     index: int
     commit_date: str
     syntactic_id: str
@@ -2242,7 +2242,7 @@ class Finding:
                 end_line=_atd_read_int(x['end_line']) if 'end_line' in x else _atd_missing_json_field('Finding', 'end_line'),
                 end_column=_atd_read_int(x['end_column']) if 'end_column' in x else _atd_missing_json_field('Finding', 'end_column'),
                 message=_atd_read_string(x['message']) if 'message' in x else _atd_missing_json_field('Finding', 'message'),
-                severity=_atd_read_int(x['severity']) if 'severity' in x else _atd_missing_json_field('Finding', 'severity'),
+                severity=(lambda x: x)(x['severity']) if 'severity' in x else _atd_missing_json_field('Finding', 'severity'),
                 index=_atd_read_int(x['index']) if 'index' in x else _atd_missing_json_field('Finding', 'index'),
                 commit_date=_atd_read_string(x['commit_date']) if 'commit_date' in x else _atd_missing_json_field('Finding', 'commit_date'),
                 syntactic_id=_atd_read_string(x['syntactic_id']) if 'syntactic_id' in x else _atd_missing_json_field('Finding', 'syntactic_id'),
@@ -2266,7 +2266,7 @@ class Finding:
         res['end_line'] = _atd_write_int(self.end_line)
         res['end_column'] = _atd_write_int(self.end_column)
         res['message'] = _atd_write_string(self.message)
-        res['severity'] = _atd_write_int(self.severity)
+        res['severity'] = (lambda x: x)(self.severity)
         res['index'] = _atd_write_int(self.index)
         res['commit_date'] = _atd_write_string(self.commit_date)
         res['syntactic_id'] = _atd_write_string(self.syntactic_id)

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -405,7 +405,7 @@ export type Finding = {
   end_line: number /*int*/;
   end_column: number /*int*/;
   message: string;
-  severity: number /*int*/;
+  severity: any;
   index: number /*int*/;
   commit_date: string;
   syntactic_id: string;
@@ -1608,7 +1608,7 @@ export function writeFinding(x: Finding, context: any = x): any {
     'end_line': _atd_write_required_field('Finding', 'end_line', _atd_write_int, x.end_line, x),
     'end_column': _atd_write_required_field('Finding', 'end_column', _atd_write_int, x.end_column, x),
     'message': _atd_write_required_field('Finding', 'message', _atd_write_string, x.message, x),
-    'severity': _atd_write_required_field('Finding', 'severity', _atd_write_int, x.severity, x),
+    'severity': _atd_write_required_field('Finding', 'severity', ((x: any, context): any => x), x.severity, x),
     'index': _atd_write_required_field('Finding', 'index', _atd_write_int, x.index, x),
     'commit_date': _atd_write_required_field('Finding', 'commit_date', _atd_write_string, x.commit_date, x),
     'syntactic_id': _atd_write_required_field('Finding', 'syntactic_id', _atd_write_string, x.syntactic_id, x),
@@ -1631,7 +1631,7 @@ export function readFinding(x: any, context: any = x): Finding {
     end_line: _atd_read_required_field('Finding', 'end_line', _atd_read_int, x['end_line'], x),
     end_column: _atd_read_required_field('Finding', 'end_column', _atd_read_int, x['end_column'], x),
     message: _atd_read_required_field('Finding', 'message', _atd_read_string, x['message'], x),
-    severity: _atd_read_required_field('Finding', 'severity', _atd_read_int, x['severity'], x),
+    severity: _atd_read_required_field('Finding', 'severity', ((x: any, context): any => x), x['severity'], x),
     index: _atd_read_required_field('Finding', 'index', _atd_read_int, x['index'], x),
     commit_date: _atd_read_required_field('Finding', 'commit_date', _atd_read_string, x['commit_date'], x),
     syntactic_id: _atd_read_required_field('Finding', 'syntactic_id', _atd_read_string, x['syntactic_id'], x),

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -244,7 +244,7 @@ type finding = Semgrep_output_v1_t.finding = {
   end_line: int;
   end_column: int;
   message: string;
-  severity: int;
+  severity: Yojson.Safe.t;
   index: int;
   commit_date: string;
   syntactic_id: string;
@@ -563,7 +563,7 @@ let read_fpath = (
 let fpath_of_string s =
   read_fpath (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_matching_operation : _ -> matching_operation -> _ = (
-  fun ob x ->
+  fun ob (x : matching_operation) ->
     match x with
       | And -> Buffer.add_string ob "\"And\""
       | Or -> Buffer.add_string ob "\"Or\""
@@ -2139,7 +2139,7 @@ let read_metavars = (
 let metavars_of_string s =
   read_metavars (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_cli_match_call_trace : _ -> cli_match_call_trace -> _ = (
-  fun ob x ->
+  fun ob (x : cli_match_call_trace) ->
     match x with
       | CliLoc x ->
         Buffer.add_string ob "[\"CliLoc\",";
@@ -2534,7 +2534,7 @@ let rec read_cli_match_call_trace = (
 and cli_match_call_trace_of_string s =
   read_cli_match_call_trace (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_core_match_call_trace : _ -> core_match_call_trace -> _ = (
-  fun ob x ->
+  fun ob (x : core_match_call_trace) ->
     match x with
       | CoreLoc x ->
         Buffer.add_string ob "[\"CoreLoc\",";
@@ -4388,7 +4388,7 @@ let read_target_time = (
 let target_time_of_string s =
   read_target_time (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_skip_reason : _ -> skip_reason -> _ = (
-  fun ob x ->
+  fun ob (x : skip_reason) ->
     match x with
       | Gitignore_patterns_match -> Buffer.add_string ob "\"gitignore_patterns_match\""
       | Always_skipped -> Buffer.add_string ob "\"always_skipped\""
@@ -7643,7 +7643,7 @@ let write_finding : _ -> finding -> _ = (
       Buffer.add_char ob ',';
       Buffer.add_string ob "\"severity\":";
     (
-      Yojson.Safe.write_int
+      Yojson.Safe.write_json
     )
       ob x.severity;
     if !is_first then
@@ -8031,7 +8031,7 @@ let read_finding = (
             field_severity := (
               Some (
                 (
-                  Atdgen_runtime.Oj_run.read_int
+                  Atdgen_runtime.Oj_run.read_json
                 ) p lb
               )
             );
@@ -8386,7 +8386,7 @@ let read_finding = (
               field_severity := (
                 Some (
                   (
-                    Atdgen_runtime.Oj_run.read_int
+                    Atdgen_runtime.Oj_run.read_json
                   ) p lb
                 )
               );
@@ -9913,7 +9913,7 @@ let read_core_stats = (
 let core_stats_of_string s =
   read_core_stats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_severity : _ -> core_severity -> _ = (
-  fun ob x ->
+  fun ob (x : core_severity) ->
     match x with
       | Error -> Buffer.add_string ob "\"error\""
       | Warning -> Buffer.add_string ob "\"warning\""
@@ -9973,7 +9973,7 @@ let read__location_list = (
 let _location_list_of_string s =
   read__location_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_error_kind : _ -> core_error_kind -> _ = (
-  fun ob x ->
+  fun ob (x : core_error_kind) ->
     match x with
       | LexicalError -> Buffer.add_string ob "\"Lexical error\""
       | ParseError -> Buffer.add_string ob "\"Syntax error\""

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -244,7 +244,7 @@ type finding = Semgrep_output_v1_t.finding = {
   end_line: int;
   end_column: int;
   message: string;
-  severity: int;
+  severity: Yojson.Safe.t;
   index: int;
   commit_date: string;
   syntactic_id: string;


### PR DESCRIPTION
This should be an string enum rather than some int representation that approximates it.
To migrate we need the typing to allow for both string and int, which we can do by pushing the typing up a layer until the CLI versions using int are deprecated.

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)

Closes APP-4267