### PR TITLE
Add type for `/complete` data

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -801,6 +801,39 @@ type found_dependency <ocaml attr="deriving show"> = {
   ?line_number: int option;
 }
 
+
+
+type sca_parser_name = [
+  | Gemfile_lock <json name="gemfile_lock">
+  | Go_mod <json name="go_mod">
+  | Go_sum <json name="go_sum">
+  | Gradle_lockfile <json name="gradle_lockfile">
+  | Gradle_build <json name="gradle_build">
+  | Jsondoc <json name="jsondoc">
+  | Pipfile <json name="pipfile">
+  | Pnpm_lock <json name="pnpm_lock">
+  | Poetry_lock <json name="poetry_lock">
+  | Pyproject_toml <json name="pyproject_toml">
+  | Requirements <json name="requirements">
+  | Yarn_1 <json name="yarn_1">
+  | Yarn_2 <json name="yarn_2">
+  | Pomtree <json name="pomtree">
+  | Cargo_parser <json name="cargo">
+  | Composer_lock <json name="composer_lock">
+]
+
+
+
+type dependency_parser_error = {
+  path: string;
+  parser: sca_parser_name;
+  reason: string;
+  ?line: int option; 
+  ?col: int option; 
+  ?text: string option;
+}
+
+
 (*****************************************************************************)
 (* Semgrep CLI findings output for the App *)
 (*****************************************************************************)
@@ -808,6 +841,7 @@ type found_dependency <ocaml attr="deriving show"> = {
  * there is also api_scans_meta, api_scans_ignores, and api_scans_complete
  * EXPERIMENTAL
 *)
+
 type ci_scan_results <ocaml attr="deriving show"> = {
   (* TODO: ?version: version option; *)
    findings: finding list;
@@ -818,6 +852,47 @@ type ci_scan_results <ocaml attr="deriving show"> = {
    rule_ids: string list;
 }
 
+
+
+type parsing_stats <ocaml attr="deriving show"> = {
+  targets_parsed: int;
+  num_targets: int;
+  bytes_parsed: int;
+  num_bytes: int;
+}
+
+type ci_scan_complete_stats <ocaml attr="deriving show"> = {
+  findings: int;
+  errors: cli_error list;
+  total_time: float;
+  unsupported_exts: (string * int) list
+    <json repr="object">
+    <python repr="dict">
+    <ts repr="map">;
+  lockfile_scan_info: (string * int) list
+    <json repr="object">
+    <python repr="dict">
+    <ts repr="map">;
+  parse_rate: (string * parsing_stats) list
+    <json repr="object">
+    <python repr="dict">
+    <ts repr="map">;
+  (* This is EngineType from python, which is different from engine_kind used in this file *)
+  ?engine_requested: string option;
+}
+
+type ci_scan_dependencies <ocaml attr="deriving show"> =  (string * found_dependency list) list
+    <json repr="object">
+    <python repr="dict">
+    <ts repr="map">
+
+type ci_scan_complete <ocaml attr="deriving show"> = {
+  exit_code: int;
+  stats: ci_scan_complete_stats;
+  ?dependencies: ci_scan_dependencies option;
+  ?dependency_parser_errors: dependency_parser_error list option;
+  ?task_id: string option;
+}
 
 
 type finding_hashes <ocaml attr="deriving show"> = {

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -802,7 +802,7 @@ type found_dependency <ocaml attr="deriving show"> = {
 }
 
 
-
+(* json names are to maintain backwards compatibility with the python enum it is replacing *)
 type sca_parser_name <ocaml attr="deriving show"> = [
   | Gemfile_lock <json name="gemfile_lock">
   | Go_mod <json name="go_mod">
@@ -828,8 +828,10 @@ type dependency_parser_error <ocaml attr="deriving show"> = {
   path: string;
   parser: sca_parser_name;
   reason: string;
-  ?position: position option;
-  ?text: string option;
+  (* Not using `position` because this type must be backwards compatible with the python class it is replacing *)
+  line: int nullable;
+  col: int nullable;
+  text: string nullable;
 }
 
 

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -803,7 +803,7 @@ type found_dependency <ocaml attr="deriving show"> = {
 
 
 
-type sca_parser_name = [
+type sca_parser_name <ocaml attr="deriving show"> = [
   | Gemfile_lock <json name="gemfile_lock">
   | Go_mod <json name="go_mod">
   | Go_sum <json name="go_sum">
@@ -824,7 +824,7 @@ type sca_parser_name = [
 
 
 
-type dependency_parser_error = {
+type dependency_parser_error <ocaml attr="deriving show"> = {
   path: string;
   parser: sca_parser_name;
   reason: string;

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -843,6 +843,7 @@ type dependency_parser_error <ocaml attr="deriving show"> = {
  * EXPERIMENTAL
 *)
 
+(* Sent by the CLI to /findings_and_ignores aka /results *)
 type ci_scan_results <ocaml attr="deriving show"> = {
   (* TODO: ?version: version option; *)
    findings: finding list;
@@ -887,6 +888,7 @@ type ci_scan_dependencies <ocaml attr="deriving show"> =  (string * found_depend
     <python repr="dict">
     <ts repr="map">
 
+(* Seny by the CLI to /complete *)
 type ci_scan_complete_response <ocaml attr="deriving show"> = {
   exit_code: int;
   stats: ci_scan_complete_stats;

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -829,9 +829,9 @@ type dependency_parser_error <ocaml attr="deriving show"> = {
   parser: sca_parser_name;
   reason: string;
   (* Not using `position` because this type must be backwards compatible with the python class it is replacing *)
-  line: int nullable;
-  col: int nullable;
-  text: string nullable;
+  ?line: int option;
+  ?col: int option;
+  ?text: string option;
 }
 
 

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -828,8 +828,7 @@ type dependency_parser_error = {
   path: string;
   parser: sca_parser_name;
   reason: string;
-  ?line: int option; 
-  ?col: int option; 
+  ?position: position option;
   ?text: string option;
 }
 
@@ -886,7 +885,7 @@ type ci_scan_dependencies <ocaml attr="deriving show"> =  (string * found_depend
     <python repr="dict">
     <ts repr="map">
 
-type ci_scan_complete <ocaml attr="deriving show"> = {
+type ci_scan_complete_response <ocaml attr="deriving show"> = {
   exit_code: int;
   stats: ci_scan_complete_stats;
   ?dependencies: ci_scan_dependencies option;

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -722,13 +722,14 @@
     },
     "dependency_parser_error": {
       "type": "object",
-      "required": [ "path", "parser", "reason" ],
+      "required": [ "path", "parser", "reason", "line", "col", "text" ],
       "properties": {
         "path": { "type": "string" },
         "parser": { "$ref": "#/definitions/sca_parser_name" },
         "reason": { "type": "string" },
-        "position": { "$ref": "#/definitions/position" },
-        "text": { "type": "string" }
+        "line": { "type": [ "integer", "null" ] },
+        "col": { "type": [ "integer", "null" ] },
+        "text": { "type": [ "string", "null" ] }
       }
     },
     "ci_scan_results": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -722,14 +722,14 @@
     },
     "dependency_parser_error": {
       "type": "object",
-      "required": [ "path", "parser", "reason", "line", "col", "text" ],
+      "required": [ "path", "parser", "reason" ],
       "properties": {
         "path": { "type": "string" },
         "parser": { "$ref": "#/definitions/sca_parser_name" },
         "reason": { "type": "string" },
-        "line": { "type": [ "integer", "null" ] },
-        "col": { "type": [ "integer", "null" ] },
-        "text": { "type": [ "string", "null" ] }
+        "line": { "type": "integer" },
+        "col": { "type": "integer" },
+        "text": { "type": "string" }
       }
     },
     "ci_scan_results": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -700,6 +700,38 @@
         "line_number": { "type": "integer" }
       }
     },
+    "sca_parser_name": {
+      "oneOf": [
+        { "const": "gemfile_lock" },
+        { "const": "go_mod" },
+        { "const": "go_sum" },
+        { "const": "gradle_lockfile" },
+        { "const": "gradle_build" },
+        { "const": "jsondoc" },
+        { "const": "pipfile" },
+        { "const": "pnpm_lock" },
+        { "const": "poetry_lock" },
+        { "const": "pyproject_toml" },
+        { "const": "requirements" },
+        { "const": "yarn_1" },
+        { "const": "yarn_2" },
+        { "const": "pomtree" },
+        { "const": "cargo" },
+        { "const": "composer_lock" }
+      ]
+    },
+    "dependency_parser_error": {
+      "type": "object",
+      "required": [ "path", "parser", "reason" ],
+      "properties": {
+        "path": { "type": "string" },
+        "parser": { "$ref": "#/definitions/sca_parser_name" },
+        "reason": { "type": "string" },
+        "line": { "type": "integer" },
+        "col": { "type": "integer" },
+        "text": { "type": "string" }
+      }
+    },
     "ci_scan_results": {
       "type": "object",
       "required": [
@@ -719,6 +751,67 @@
         "searched_paths": { "type": "array", "items": { "type": "string" } },
         "renamed_paths": { "type": "array", "items": { "type": "string" } },
         "rule_ids": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "parsing_stats": {
+      "type": "object",
+      "required": [
+        "targets_parsed", "num_targets", "bytes_parsed", "num_bytes"
+      ],
+      "properties": {
+        "targets_parsed": { "type": "integer" },
+        "num_targets": { "type": "integer" },
+        "bytes_parsed": { "type": "integer" },
+        "num_bytes": { "type": "integer" }
+      }
+    },
+    "ci_scan_complete_stats": {
+      "type": "object",
+      "required": [
+        "findings", "errors", "total_time", "unsupported_exts",
+        "lockfile_scan_info", "parse_rate"
+      ],
+      "properties": {
+        "findings": { "type": "integer" },
+        "errors": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/cli_error" }
+        },
+        "total_time": { "type": "number" },
+        "unsupported_exts": {
+          "type": "object",
+          "additionalProperties": { "type": "integer" }
+        },
+        "lockfile_scan_info": {
+          "type": "object",
+          "additionalProperties": { "type": "integer" }
+        },
+        "parse_rate": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/parsing_stats" }
+        },
+        "engine_requested": { "type": "string" }
+      }
+    },
+    "ci_scan_dependencies": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/definitions/found_dependency" }
+      }
+    },
+    "ci_scan_complete": {
+      "type": "object",
+      "required": [ "exit_code", "stats" ],
+      "properties": {
+        "exit_code": { "type": "integer" },
+        "stats": { "$ref": "#/definitions/ci_scan_complete_stats" },
+        "dependencies": { "$ref": "#/definitions/ci_scan_dependencies" },
+        "dependency_parser_errors": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/dependency_parser_error" }
+        },
+        "task_id": { "type": "string" }
       }
     },
     "finding_hashes": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -727,8 +727,7 @@
         "path": { "type": "string" },
         "parser": { "$ref": "#/definitions/sca_parser_name" },
         "reason": { "type": "string" },
-        "line": { "type": "integer" },
-        "col": { "type": "integer" },
+        "position": { "$ref": "#/definitions/position" },
         "text": { "type": "string" }
       }
     },
@@ -800,7 +799,7 @@
         "items": { "$ref": "#/definitions/found_dependency" }
       }
     },
-    "ci_scan_complete": {
+    "ci_scan_complete_response": {
       "type": "object",
       "required": [ "exit_code", "stats" ],
       "properties": {

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -1705,6 +1705,338 @@ class SkippedRule:
         return json.dumps(self.to_json(), **kw)
 
 
+@dataclass
+class GemfileLock:
+    """Original type: sca_parser_name = [ ... | Gemfile_lock | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'GemfileLock'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'gemfile_lock'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class GoMod:
+    """Original type: sca_parser_name = [ ... | Go_mod | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'GoMod'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'go_mod'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class GoSum:
+    """Original type: sca_parser_name = [ ... | Go_sum | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'GoSum'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'go_sum'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class GradleLockfile:
+    """Original type: sca_parser_name = [ ... | Gradle_lockfile | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'GradleLockfile'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'gradle_lockfile'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class GradleBuild:
+    """Original type: sca_parser_name = [ ... | Gradle_build | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'GradleBuild'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'gradle_build'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Jsondoc:
+    """Original type: sca_parser_name = [ ... | Jsondoc | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Jsondoc'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'jsondoc'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Pipfile:
+    """Original type: sca_parser_name = [ ... | Pipfile | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Pipfile'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'pipfile'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class PnpmLock:
+    """Original type: sca_parser_name = [ ... | Pnpm_lock | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'PnpmLock'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'pnpm_lock'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class PoetryLock:
+    """Original type: sca_parser_name = [ ... | Poetry_lock | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'PoetryLock'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'poetry_lock'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class PyprojectToml:
+    """Original type: sca_parser_name = [ ... | Pyproject_toml | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'PyprojectToml'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'pyproject_toml'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Requirements:
+    """Original type: sca_parser_name = [ ... | Requirements | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Requirements'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'requirements'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Yarn1:
+    """Original type: sca_parser_name = [ ... | Yarn_1 | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Yarn1'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'yarn_1'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Yarn2:
+    """Original type: sca_parser_name = [ ... | Yarn_2 | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Yarn2'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'yarn_2'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Pomtree:
+    """Original type: sca_parser_name = [ ... | Pomtree | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'Pomtree'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'pomtree'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class CargoParser:
+    """Original type: sca_parser_name = [ ... | Cargo_parser | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'CargoParser'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'cargo'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class ComposerLock:
+    """Original type: sca_parser_name = [ ... | Composer_lock | ... ]"""
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return 'ComposerLock'
+
+    @staticmethod
+    def to_json() -> Any:
+        return 'composer_lock'
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class ScaParserName:
+    """Original type: sca_parser_name = [ ... ]"""
+
+    value: Union[GemfileLock, GoMod, GoSum, GradleLockfile, GradleBuild, Jsondoc, Pipfile, PnpmLock, PoetryLock, PyprojectToml, Requirements, Yarn1, Yarn2, Pomtree, CargoParser, ComposerLock]
+
+    @property
+    def kind(self) -> str:
+        """Name of the class representing this variant."""
+        return self.value.kind
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'ScaParserName':
+        if isinstance(x, str):
+            if x == 'gemfile_lock':
+                return cls(GemfileLock())
+            if x == 'go_mod':
+                return cls(GoMod())
+            if x == 'go_sum':
+                return cls(GoSum())
+            if x == 'gradle_lockfile':
+                return cls(GradleLockfile())
+            if x == 'gradle_build':
+                return cls(GradleBuild())
+            if x == 'jsondoc':
+                return cls(Jsondoc())
+            if x == 'pipfile':
+                return cls(Pipfile())
+            if x == 'pnpm_lock':
+                return cls(PnpmLock())
+            if x == 'poetry_lock':
+                return cls(PoetryLock())
+            if x == 'pyproject_toml':
+                return cls(PyprojectToml())
+            if x == 'requirements':
+                return cls(Requirements())
+            if x == 'yarn_1':
+                return cls(Yarn1())
+            if x == 'yarn_2':
+                return cls(Yarn2())
+            if x == 'pomtree':
+                return cls(Pomtree())
+            if x == 'cargo':
+                return cls(CargoParser())
+            if x == 'composer_lock':
+                return cls(ComposerLock())
+            _atd_bad_json('ScaParserName', x)
+        _atd_bad_json('ScaParserName', x)
+
+    def to_json(self) -> Any:
+        return self.value.to_json()
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'ScaParserName':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
 @dataclass(frozen=True)
 class Npm:
     """Original type: ecosystem = [ ... | Npm | ... ]"""
@@ -2100,6 +2432,43 @@ class PositionBis:
 
 
 @dataclass
+class ParsingStats:
+    """Original type: parsing_stats = { ... }"""
+
+    targets_parsed: int
+    num_targets: int
+    bytes_parsed: int
+    num_bytes: int
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'ParsingStats':
+        if isinstance(x, dict):
+            return cls(
+                targets_parsed=_atd_read_int(x['targets_parsed']) if 'targets_parsed' in x else _atd_missing_json_field('ParsingStats', 'targets_parsed'),
+                num_targets=_atd_read_int(x['num_targets']) if 'num_targets' in x else _atd_missing_json_field('ParsingStats', 'num_targets'),
+                bytes_parsed=_atd_read_int(x['bytes_parsed']) if 'bytes_parsed' in x else _atd_missing_json_field('ParsingStats', 'bytes_parsed'),
+                num_bytes=_atd_read_int(x['num_bytes']) if 'num_bytes' in x else _atd_missing_json_field('ParsingStats', 'num_bytes'),
+            )
+        else:
+            _atd_bad_json('ParsingStats', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['targets_parsed'] = _atd_write_int(self.targets_parsed)
+        res['num_targets'] = _atd_write_int(self.num_targets)
+        res['bytes_parsed'] = _atd_write_int(self.bytes_parsed)
+        res['num_bytes'] = _atd_write_int(self.num_bytes)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'ParsingStats':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class FixRegex:
     """Original type: fix_regex = { ... }"""
 
@@ -2344,6 +2713,52 @@ class ErrorSpan:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'ErrorSpan':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class DependencyParserError:
+    """Original type: dependency_parser_error = { ... }"""
+
+    path: str
+    parser: ScaParserName
+    reason: str
+    line: Optional[int] = None
+    col: Optional[int] = None
+    text: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'DependencyParserError':
+        if isinstance(x, dict):
+            return cls(
+                path=_atd_read_string(x['path']) if 'path' in x else _atd_missing_json_field('DependencyParserError', 'path'),
+                parser=ScaParserName.from_json(x['parser']) if 'parser' in x else _atd_missing_json_field('DependencyParserError', 'parser'),
+                reason=_atd_read_string(x['reason']) if 'reason' in x else _atd_missing_json_field('DependencyParserError', 'reason'),
+                line=_atd_read_int(x['line']) if 'line' in x else None,
+                col=_atd_read_int(x['col']) if 'col' in x else None,
+                text=_atd_read_string(x['text']) if 'text' in x else None,
+            )
+        else:
+            _atd_bad_json('DependencyParserError', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['path'] = _atd_write_string(self.path)
+        res['parser'] = (lambda x: x.to_json())(self.parser)
+        res['reason'] = _atd_write_string(self.reason)
+        if self.line is not None:
+            res['line'] = _atd_write_int(self.line)
+        if self.col is not None:
+            res['col'] = _atd_write_int(self.col)
+        if self.text is not None:
+            res['text'] = _atd_write_string(self.text)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'DependencyParserError':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -3473,6 +3888,117 @@ class CiScanResults:
 
     @classmethod
     def from_json_string(cls, x: str) -> 'CiScanResults':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class CiScanDependencies:
+    """Original type: ci_scan_dependencies"""
+
+    value: Dict[str, List[FoundDependency]]
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'CiScanDependencies':
+        return cls(_atd_read_assoc_object_into_dict(_atd_read_list(FoundDependency.from_json))(x))
+
+    def to_json(self) -> Any:
+        return _atd_write_assoc_dict_to_object(_atd_write_list((lambda x: x.to_json())))(self.value)
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'CiScanDependencies':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class CiScanCompleteStats:
+    """Original type: ci_scan_complete_stats = { ... }"""
+
+    findings: int
+    errors: List[CliError]
+    total_time: float
+    unsupported_exts: Dict[str, int]
+    lockfile_scan_info: Dict[str, int]
+    parse_rate: Dict[str, ParsingStats]
+    engine_requested: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'CiScanCompleteStats':
+        if isinstance(x, dict):
+            return cls(
+                findings=_atd_read_int(x['findings']) if 'findings' in x else _atd_missing_json_field('CiScanCompleteStats', 'findings'),
+                errors=_atd_read_list(CliError.from_json)(x['errors']) if 'errors' in x else _atd_missing_json_field('CiScanCompleteStats', 'errors'),
+                total_time=_atd_read_float(x['total_time']) if 'total_time' in x else _atd_missing_json_field('CiScanCompleteStats', 'total_time'),
+                unsupported_exts=_atd_read_assoc_object_into_dict(_atd_read_int)(x['unsupported_exts']) if 'unsupported_exts' in x else _atd_missing_json_field('CiScanCompleteStats', 'unsupported_exts'),
+                lockfile_scan_info=_atd_read_assoc_object_into_dict(_atd_read_int)(x['lockfile_scan_info']) if 'lockfile_scan_info' in x else _atd_missing_json_field('CiScanCompleteStats', 'lockfile_scan_info'),
+                parse_rate=_atd_read_assoc_object_into_dict(ParsingStats.from_json)(x['parse_rate']) if 'parse_rate' in x else _atd_missing_json_field('CiScanCompleteStats', 'parse_rate'),
+                engine_requested=_atd_read_string(x['engine_requested']) if 'engine_requested' in x else None,
+            )
+        else:
+            _atd_bad_json('CiScanCompleteStats', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['findings'] = _atd_write_int(self.findings)
+        res['errors'] = _atd_write_list((lambda x: x.to_json()))(self.errors)
+        res['total_time'] = _atd_write_float(self.total_time)
+        res['unsupported_exts'] = _atd_write_assoc_dict_to_object(_atd_write_int)(self.unsupported_exts)
+        res['lockfile_scan_info'] = _atd_write_assoc_dict_to_object(_atd_write_int)(self.lockfile_scan_info)
+        res['parse_rate'] = _atd_write_assoc_dict_to_object((lambda x: x.to_json()))(self.parse_rate)
+        if self.engine_requested is not None:
+            res['engine_requested'] = _atd_write_string(self.engine_requested)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'CiScanCompleteStats':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class CiScanComplete:
+    """Original type: ci_scan_complete = { ... }"""
+
+    exit_code: int
+    stats: CiScanCompleteStats
+    dependencies: Optional[CiScanDependencies] = None
+    dependency_parser_errors: Optional[List[DependencyParserError]] = None
+    task_id: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'CiScanComplete':
+        if isinstance(x, dict):
+            return cls(
+                exit_code=_atd_read_int(x['exit_code']) if 'exit_code' in x else _atd_missing_json_field('CiScanComplete', 'exit_code'),
+                stats=CiScanCompleteStats.from_json(x['stats']) if 'stats' in x else _atd_missing_json_field('CiScanComplete', 'stats'),
+                dependencies=CiScanDependencies.from_json(x['dependencies']) if 'dependencies' in x else None,
+                dependency_parser_errors=_atd_read_list(DependencyParserError.from_json)(x['dependency_parser_errors']) if 'dependency_parser_errors' in x else None,
+                task_id=_atd_read_string(x['task_id']) if 'task_id' in x else None,
+            )
+        else:
+            _atd_bad_json('CiScanComplete', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['exit_code'] = _atd_write_int(self.exit_code)
+        res['stats'] = (lambda x: x.to_json())(self.stats)
+        if self.dependencies is not None:
+            res['dependencies'] = (lambda x: x.to_json())(self.dependencies)
+        if self.dependency_parser_errors is not None:
+            res['dependency_parser_errors'] = _atd_write_list((lambda x: x.to_json()))(self.dependency_parser_errors)
+        if self.task_id is not None:
+            res['task_id'] = _atd_write_string(self.task_id)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'CiScanComplete':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2726,9 +2726,9 @@ class DependencyParserError:
     path: str
     parser: ScaParserName
     reason: str
-    line: Optional[int]
-    col: Optional[int]
-    text: Optional[str]
+    line: Optional[int] = None
+    col: Optional[int] = None
+    text: Optional[str] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'DependencyParserError':
@@ -2737,9 +2737,9 @@ class DependencyParserError:
                 path=_atd_read_string(x['path']) if 'path' in x else _atd_missing_json_field('DependencyParserError', 'path'),
                 parser=ScaParserName.from_json(x['parser']) if 'parser' in x else _atd_missing_json_field('DependencyParserError', 'parser'),
                 reason=_atd_read_string(x['reason']) if 'reason' in x else _atd_missing_json_field('DependencyParserError', 'reason'),
-                line=_atd_read_nullable(_atd_read_int)(x['line']) if 'line' in x else _atd_missing_json_field('DependencyParserError', 'line'),
-                col=_atd_read_nullable(_atd_read_int)(x['col']) if 'col' in x else _atd_missing_json_field('DependencyParserError', 'col'),
-                text=_atd_read_nullable(_atd_read_string)(x['text']) if 'text' in x else _atd_missing_json_field('DependencyParserError', 'text'),
+                line=_atd_read_int(x['line']) if 'line' in x else None,
+                col=_atd_read_int(x['col']) if 'col' in x else None,
+                text=_atd_read_string(x['text']) if 'text' in x else None,
             )
         else:
             _atd_bad_json('DependencyParserError', x)
@@ -2749,9 +2749,12 @@ class DependencyParserError:
         res['path'] = _atd_write_string(self.path)
         res['parser'] = (lambda x: x.to_json())(self.parser)
         res['reason'] = _atd_write_string(self.reason)
-        res['line'] = _atd_write_nullable(_atd_write_int)(self.line)
-        res['col'] = _atd_write_nullable(_atd_write_int)(self.col)
-        res['text'] = _atd_write_nullable(_atd_write_string)(self.text)
+        if self.line is not None:
+            res['line'] = _atd_write_int(self.line)
+        if self.col is not None:
+            res['col'] = _atd_write_int(self.col)
+        if self.text is not None:
+            res['text'] = _atd_write_string(self.text)
         return res
 
     @classmethod

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2726,8 +2726,7 @@ class DependencyParserError:
     path: str
     parser: ScaParserName
     reason: str
-    line: Optional[int] = None
-    col: Optional[int] = None
+    position: Optional[Position] = None
     text: Optional[str] = None
 
     @classmethod
@@ -2737,8 +2736,7 @@ class DependencyParserError:
                 path=_atd_read_string(x['path']) if 'path' in x else _atd_missing_json_field('DependencyParserError', 'path'),
                 parser=ScaParserName.from_json(x['parser']) if 'parser' in x else _atd_missing_json_field('DependencyParserError', 'parser'),
                 reason=_atd_read_string(x['reason']) if 'reason' in x else _atd_missing_json_field('DependencyParserError', 'reason'),
-                line=_atd_read_int(x['line']) if 'line' in x else None,
-                col=_atd_read_int(x['col']) if 'col' in x else None,
+                position=Position.from_json(x['position']) if 'position' in x else None,
                 text=_atd_read_string(x['text']) if 'text' in x else None,
             )
         else:
@@ -2749,10 +2747,8 @@ class DependencyParserError:
         res['path'] = _atd_write_string(self.path)
         res['parser'] = (lambda x: x.to_json())(self.parser)
         res['reason'] = _atd_write_string(self.reason)
-        if self.line is not None:
-            res['line'] = _atd_write_int(self.line)
-        if self.col is not None:
-            res['col'] = _atd_write_int(self.col)
+        if self.position is not None:
+            res['position'] = (lambda x: x.to_json())(self.position)
         if self.text is not None:
             res['text'] = _atd_write_string(self.text)
         return res
@@ -3963,8 +3959,8 @@ class CiScanCompleteStats:
 
 
 @dataclass
-class CiScanComplete:
-    """Original type: ci_scan_complete = { ... }"""
+class CiScanCompleteResponse:
+    """Original type: ci_scan_complete_response = { ... }"""
 
     exit_code: int
     stats: CiScanCompleteStats
@@ -3973,17 +3969,17 @@ class CiScanComplete:
     task_id: Optional[str] = None
 
     @classmethod
-    def from_json(cls, x: Any) -> 'CiScanComplete':
+    def from_json(cls, x: Any) -> 'CiScanCompleteResponse':
         if isinstance(x, dict):
             return cls(
-                exit_code=_atd_read_int(x['exit_code']) if 'exit_code' in x else _atd_missing_json_field('CiScanComplete', 'exit_code'),
-                stats=CiScanCompleteStats.from_json(x['stats']) if 'stats' in x else _atd_missing_json_field('CiScanComplete', 'stats'),
+                exit_code=_atd_read_int(x['exit_code']) if 'exit_code' in x else _atd_missing_json_field('CiScanCompleteResponse', 'exit_code'),
+                stats=CiScanCompleteStats.from_json(x['stats']) if 'stats' in x else _atd_missing_json_field('CiScanCompleteResponse', 'stats'),
                 dependencies=CiScanDependencies.from_json(x['dependencies']) if 'dependencies' in x else None,
                 dependency_parser_errors=_atd_read_list(DependencyParserError.from_json)(x['dependency_parser_errors']) if 'dependency_parser_errors' in x else None,
                 task_id=_atd_read_string(x['task_id']) if 'task_id' in x else None,
             )
         else:
-            _atd_bad_json('CiScanComplete', x)
+            _atd_bad_json('CiScanCompleteResponse', x)
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
@@ -3998,7 +3994,7 @@ class CiScanComplete:
         return res
 
     @classmethod
-    def from_json_string(cls, x: str) -> 'CiScanComplete':
+    def from_json_string(cls, x: str) -> 'CiScanCompleteResponse':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2726,8 +2726,9 @@ class DependencyParserError:
     path: str
     parser: ScaParserName
     reason: str
-    position: Optional[Position] = None
-    text: Optional[str] = None
+    line: Optional[int]
+    col: Optional[int]
+    text: Optional[str]
 
     @classmethod
     def from_json(cls, x: Any) -> 'DependencyParserError':
@@ -2736,8 +2737,9 @@ class DependencyParserError:
                 path=_atd_read_string(x['path']) if 'path' in x else _atd_missing_json_field('DependencyParserError', 'path'),
                 parser=ScaParserName.from_json(x['parser']) if 'parser' in x else _atd_missing_json_field('DependencyParserError', 'parser'),
                 reason=_atd_read_string(x['reason']) if 'reason' in x else _atd_missing_json_field('DependencyParserError', 'reason'),
-                position=Position.from_json(x['position']) if 'position' in x else None,
-                text=_atd_read_string(x['text']) if 'text' in x else None,
+                line=_atd_read_nullable(_atd_read_int)(x['line']) if 'line' in x else _atd_missing_json_field('DependencyParserError', 'line'),
+                col=_atd_read_nullable(_atd_read_int)(x['col']) if 'col' in x else _atd_missing_json_field('DependencyParserError', 'col'),
+                text=_atd_read_nullable(_atd_read_string)(x['text']) if 'text' in x else _atd_missing_json_field('DependencyParserError', 'text'),
             )
         else:
             _atd_bad_json('DependencyParserError', x)
@@ -2747,10 +2749,9 @@ class DependencyParserError:
         res['path'] = _atd_write_string(self.path)
         res['parser'] = (lambda x: x.to_json())(self.parser)
         res['reason'] = _atd_write_string(self.reason)
-        if self.position is not None:
-            res['position'] = (lambda x: x.to_json())(self.position)
-        if self.text is not None:
-            res['text'] = _atd_write_string(self.text)
+        res['line'] = _atd_write_nullable(_atd_write_int)(self.line)
+        res['col'] = _atd_write_nullable(_atd_write_int)(self.col)
+        res['text'] = _atd_write_nullable(_atd_write_string)(self.text)
         return res
 
     @classmethod

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -404,9 +404,9 @@ export type DependencyParserError = {
   path: string;
   parser: ScaParserName;
   reason: string;
-  line: (number /*int*/ | null);
-  col: (number /*int*/ | null);
-  text: (string | null);
+  line?: number /*int*/;
+  col?: number /*int*/;
+  text?: string;
 }
 
 export type CiScanResults = {
@@ -1698,9 +1698,9 @@ export function writeDependencyParserError(x: DependencyParserError, context: an
     'path': _atd_write_required_field('DependencyParserError', 'path', _atd_write_string, x.path, x),
     'parser': _atd_write_required_field('DependencyParserError', 'parser', writeScaParserName, x.parser, x),
     'reason': _atd_write_required_field('DependencyParserError', 'reason', _atd_write_string, x.reason, x),
-    'line': _atd_write_required_field('DependencyParserError', 'line', _atd_write_nullable(_atd_write_int), x.line, x),
-    'col': _atd_write_required_field('DependencyParserError', 'col', _atd_write_nullable(_atd_write_int), x.col, x),
-    'text': _atd_write_required_field('DependencyParserError', 'text', _atd_write_nullable(_atd_write_string), x.text, x),
+    'line': _atd_write_optional_field(_atd_write_int, x.line, x),
+    'col': _atd_write_optional_field(_atd_write_int, x.col, x),
+    'text': _atd_write_optional_field(_atd_write_string, x.text, x),
   };
 }
 
@@ -1709,9 +1709,9 @@ export function readDependencyParserError(x: any, context: any = x): DependencyP
     path: _atd_read_required_field('DependencyParserError', 'path', _atd_read_string, x['path'], x),
     parser: _atd_read_required_field('DependencyParserError', 'parser', readScaParserName, x['parser'], x),
     reason: _atd_read_required_field('DependencyParserError', 'reason', _atd_read_string, x['reason'], x),
-    line: _atd_read_required_field('DependencyParserError', 'line', _atd_read_nullable(_atd_read_int), x['line'], x),
-    col: _atd_read_required_field('DependencyParserError', 'col', _atd_read_nullable(_atd_read_int), x['col'], x),
-    text: _atd_read_required_field('DependencyParserError', 'text', _atd_read_nullable(_atd_read_string), x['text'], x),
+    line: _atd_read_optional_field(_atd_read_int, x['line'], x),
+    col: _atd_read_optional_field(_atd_read_int, x['col'], x),
+    text: _atd_read_optional_field(_atd_read_string, x['text'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -404,8 +404,9 @@ export type DependencyParserError = {
   path: string;
   parser: ScaParserName;
   reason: string;
-  position?: Position;
-  text?: string;
+  line: (number /*int*/ | null);
+  col: (number /*int*/ | null);
+  text: (string | null);
 }
 
 export type CiScanResults = {
@@ -1697,8 +1698,9 @@ export function writeDependencyParserError(x: DependencyParserError, context: an
     'path': _atd_write_required_field('DependencyParserError', 'path', _atd_write_string, x.path, x),
     'parser': _atd_write_required_field('DependencyParserError', 'parser', writeScaParserName, x.parser, x),
     'reason': _atd_write_required_field('DependencyParserError', 'reason', _atd_write_string, x.reason, x),
-    'position': _atd_write_optional_field(writePosition, x.position, x),
-    'text': _atd_write_optional_field(_atd_write_string, x.text, x),
+    'line': _atd_write_required_field('DependencyParserError', 'line', _atd_write_nullable(_atd_write_int), x.line, x),
+    'col': _atd_write_required_field('DependencyParserError', 'col', _atd_write_nullable(_atd_write_int), x.col, x),
+    'text': _atd_write_required_field('DependencyParserError', 'text', _atd_write_nullable(_atd_write_string), x.text, x),
   };
 }
 
@@ -1707,8 +1709,9 @@ export function readDependencyParserError(x: any, context: any = x): DependencyP
     path: _atd_read_required_field('DependencyParserError', 'path', _atd_read_string, x['path'], x),
     parser: _atd_read_required_field('DependencyParserError', 'parser', readScaParserName, x['parser'], x),
     reason: _atd_read_required_field('DependencyParserError', 'reason', _atd_read_string, x['reason'], x),
-    position: _atd_read_optional_field(readPosition, x['position'], x),
-    text: _atd_read_optional_field(_atd_read_string, x['text'], x),
+    line: _atd_read_required_field('DependencyParserError', 'line', _atd_read_nullable(_atd_read_int), x['line'], x),
+    col: _atd_read_required_field('DependencyParserError', 'col', _atd_read_nullable(_atd_read_int), x['col'], x),
+    text: _atd_read_required_field('DependencyParserError', 'text', _atd_read_nullable(_atd_read_string), x['text'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -404,8 +404,7 @@ export type DependencyParserError = {
   path: string;
   parser: ScaParserName;
   reason: string;
-  line?: number /*int*/;
-  col?: number /*int*/;
+  position?: Position;
   text?: string;
 }
 
@@ -437,7 +436,7 @@ export type CiScanCompleteStats = {
 
 export type CiScanDependencies = Map<string, FoundDependency[]>
 
-export type CiScanComplete = {
+export type CiScanCompleteResponse = {
   exit_code: number /*int*/;
   stats: CiScanCompleteStats;
   dependencies?: CiScanDependencies;
@@ -1698,8 +1697,7 @@ export function writeDependencyParserError(x: DependencyParserError, context: an
     'path': _atd_write_required_field('DependencyParserError', 'path', _atd_write_string, x.path, x),
     'parser': _atd_write_required_field('DependencyParserError', 'parser', writeScaParserName, x.parser, x),
     'reason': _atd_write_required_field('DependencyParserError', 'reason', _atd_write_string, x.reason, x),
-    'line': _atd_write_optional_field(_atd_write_int, x.line, x),
-    'col': _atd_write_optional_field(_atd_write_int, x.col, x),
+    'position': _atd_write_optional_field(writePosition, x.position, x),
     'text': _atd_write_optional_field(_atd_write_string, x.text, x),
   };
 }
@@ -1709,8 +1707,7 @@ export function readDependencyParserError(x: any, context: any = x): DependencyP
     path: _atd_read_required_field('DependencyParserError', 'path', _atd_read_string, x['path'], x),
     parser: _atd_read_required_field('DependencyParserError', 'parser', readScaParserName, x['parser'], x),
     reason: _atd_read_required_field('DependencyParserError', 'reason', _atd_read_string, x['reason'], x),
-    line: _atd_read_optional_field(_atd_read_int, x['line'], x),
-    col: _atd_read_optional_field(_atd_read_int, x['col'], x),
+    position: _atd_read_optional_field(readPosition, x['position'], x),
     text: _atd_read_optional_field(_atd_read_string, x['text'], x),
   };
 }
@@ -1787,20 +1784,20 @@ export function readCiScanDependencies(x: any, context: any = x): CiScanDependen
   return _atd_read_assoc_object_into_map(_atd_read_array(readFoundDependency))(x, context);
 }
 
-export function writeCiScanComplete(x: CiScanComplete, context: any = x): any {
+export function writeCiScanCompleteResponse(x: CiScanCompleteResponse, context: any = x): any {
   return {
-    'exit_code': _atd_write_required_field('CiScanComplete', 'exit_code', _atd_write_int, x.exit_code, x),
-    'stats': _atd_write_required_field('CiScanComplete', 'stats', writeCiScanCompleteStats, x.stats, x),
+    'exit_code': _atd_write_required_field('CiScanCompleteResponse', 'exit_code', _atd_write_int, x.exit_code, x),
+    'stats': _atd_write_required_field('CiScanCompleteResponse', 'stats', writeCiScanCompleteStats, x.stats, x),
     'dependencies': _atd_write_optional_field(writeCiScanDependencies, x.dependencies, x),
     'dependency_parser_errors': _atd_write_optional_field(_atd_write_array(writeDependencyParserError), x.dependency_parser_errors, x),
     'task_id': _atd_write_optional_field(_atd_write_string, x.task_id, x),
   };
 }
 
-export function readCiScanComplete(x: any, context: any = x): CiScanComplete {
+export function readCiScanCompleteResponse(x: any, context: any = x): CiScanCompleteResponse {
   return {
-    exit_code: _atd_read_required_field('CiScanComplete', 'exit_code', _atd_read_int, x['exit_code'], x),
-    stats: _atd_read_required_field('CiScanComplete', 'stats', readCiScanCompleteStats, x['stats'], x),
+    exit_code: _atd_read_required_field('CiScanCompleteResponse', 'exit_code', _atd_read_int, x['exit_code'], x),
+    stats: _atd_read_required_field('CiScanCompleteResponse', 'stats', readCiScanCompleteStats, x['stats'], x),
     dependencies: _atd_read_optional_field(readCiScanDependencies, x['dependencies'], x),
     dependency_parser_errors: _atd_read_optional_field(_atd_read_array(readDependencyParserError), x['dependency_parser_errors'], x),
     task_id: _atd_read_optional_field(_atd_read_string, x['task_id'], x),

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -382,6 +382,33 @@ export type FoundDependency = {
   line_number?: number /*int*/;
 }
 
+export type ScaParserName =
+| { kind: 'Gemfile_lock' /* JSON: "gemfile_lock" */ }
+| { kind: 'Go_mod' /* JSON: "go_mod" */ }
+| { kind: 'Go_sum' /* JSON: "go_sum" */ }
+| { kind: 'Gradle_lockfile' /* JSON: "gradle_lockfile" */ }
+| { kind: 'Gradle_build' /* JSON: "gradle_build" */ }
+| { kind: 'Jsondoc' /* JSON: "jsondoc" */ }
+| { kind: 'Pipfile' /* JSON: "pipfile" */ }
+| { kind: 'Pnpm_lock' /* JSON: "pnpm_lock" */ }
+| { kind: 'Poetry_lock' /* JSON: "poetry_lock" */ }
+| { kind: 'Pyproject_toml' /* JSON: "pyproject_toml" */ }
+| { kind: 'Requirements' /* JSON: "requirements" */ }
+| { kind: 'Yarn_1' /* JSON: "yarn_1" */ }
+| { kind: 'Yarn_2' /* JSON: "yarn_2" */ }
+| { kind: 'Pomtree' /* JSON: "pomtree" */ }
+| { kind: 'Cargo_parser' /* JSON: "cargo" */ }
+| { kind: 'Composer_lock' /* JSON: "composer_lock" */ }
+
+export type DependencyParserError = {
+  path: string;
+  parser: ScaParserName;
+  reason: string;
+  line?: number /*int*/;
+  col?: number /*int*/;
+  text?: string;
+}
+
 export type CiScanResults = {
   findings: Finding[];
   ignores: Finding[];
@@ -389,6 +416,33 @@ export type CiScanResults = {
   searched_paths: string[];
   renamed_paths: string[];
   rule_ids: string[];
+}
+
+export type ParsingStats = {
+  targets_parsed: number /*int*/;
+  num_targets: number /*int*/;
+  bytes_parsed: number /*int*/;
+  num_bytes: number /*int*/;
+}
+
+export type CiScanCompleteStats = {
+  findings: number /*int*/;
+  errors: CliError[];
+  total_time: number;
+  unsupported_exts: Map<string, number /*int*/>;
+  lockfile_scan_info: Map<string, number /*int*/>;
+  parse_rate: Map<string, ParsingStats>;
+  engine_requested?: string;
+}
+
+export type CiScanDependencies = Map<string, FoundDependency[]>
+
+export type CiScanComplete = {
+  exit_code: number /*int*/;
+  stats: CiScanCompleteStats;
+  dependencies?: CiScanDependencies;
+  dependency_parser_errors?: DependencyParserError[];
+  task_id?: string;
 }
 
 export type FindingHashes = {
@@ -1562,6 +1616,105 @@ export function readFoundDependency(x: any, context: any = x): FoundDependency {
   };
 }
 
+export function writeScaParserName(x: ScaParserName, context: any = x): any {
+  switch (x.kind) {
+    case 'Gemfile_lock':
+      return 'gemfile_lock'
+    case 'Go_mod':
+      return 'go_mod'
+    case 'Go_sum':
+      return 'go_sum'
+    case 'Gradle_lockfile':
+      return 'gradle_lockfile'
+    case 'Gradle_build':
+      return 'gradle_build'
+    case 'Jsondoc':
+      return 'jsondoc'
+    case 'Pipfile':
+      return 'pipfile'
+    case 'Pnpm_lock':
+      return 'pnpm_lock'
+    case 'Poetry_lock':
+      return 'poetry_lock'
+    case 'Pyproject_toml':
+      return 'pyproject_toml'
+    case 'Requirements':
+      return 'requirements'
+    case 'Yarn_1':
+      return 'yarn_1'
+    case 'Yarn_2':
+      return 'yarn_2'
+    case 'Pomtree':
+      return 'pomtree'
+    case 'Cargo_parser':
+      return 'cargo'
+    case 'Composer_lock':
+      return 'composer_lock'
+  }
+}
+
+export function readScaParserName(x: any, context: any = x): ScaParserName {
+  switch (x) {
+    case 'gemfile_lock':
+      return { kind: 'Gemfile_lock' }
+    case 'go_mod':
+      return { kind: 'Go_mod' }
+    case 'go_sum':
+      return { kind: 'Go_sum' }
+    case 'gradle_lockfile':
+      return { kind: 'Gradle_lockfile' }
+    case 'gradle_build':
+      return { kind: 'Gradle_build' }
+    case 'jsondoc':
+      return { kind: 'Jsondoc' }
+    case 'pipfile':
+      return { kind: 'Pipfile' }
+    case 'pnpm_lock':
+      return { kind: 'Pnpm_lock' }
+    case 'poetry_lock':
+      return { kind: 'Poetry_lock' }
+    case 'pyproject_toml':
+      return { kind: 'Pyproject_toml' }
+    case 'requirements':
+      return { kind: 'Requirements' }
+    case 'yarn_1':
+      return { kind: 'Yarn_1' }
+    case 'yarn_2':
+      return { kind: 'Yarn_2' }
+    case 'pomtree':
+      return { kind: 'Pomtree' }
+    case 'cargo':
+      return { kind: 'Cargo_parser' }
+    case 'composer_lock':
+      return { kind: 'Composer_lock' }
+    default:
+      _atd_bad_json('ScaParserName', x, context)
+      throw new Error('impossible')
+  }
+}
+
+export function writeDependencyParserError(x: DependencyParserError, context: any = x): any {
+  return {
+    'path': _atd_write_required_field('DependencyParserError', 'path', _atd_write_string, x.path, x),
+    'parser': _atd_write_required_field('DependencyParserError', 'parser', writeScaParserName, x.parser, x),
+    'reason': _atd_write_required_field('DependencyParserError', 'reason', _atd_write_string, x.reason, x),
+    'line': _atd_write_optional_field(_atd_write_int, x.line, x),
+    'col': _atd_write_optional_field(_atd_write_int, x.col, x),
+    'text': _atd_write_optional_field(_atd_write_string, x.text, x),
+  };
+}
+
+export function readDependencyParserError(x: any, context: any = x): DependencyParserError {
+  return {
+    path: _atd_read_required_field('DependencyParserError', 'path', _atd_read_string, x['path'], x),
+    parser: _atd_read_required_field('DependencyParserError', 'parser', readScaParserName, x['parser'], x),
+    reason: _atd_read_required_field('DependencyParserError', 'reason', _atd_read_string, x['reason'], x),
+    line: _atd_read_optional_field(_atd_read_int, x['line'], x),
+    col: _atd_read_optional_field(_atd_read_int, x['col'], x),
+    text: _atd_read_optional_field(_atd_read_string, x['text'], x),
+  };
+}
+
 export function writeCiScanResults(x: CiScanResults, context: any = x): any {
   return {
     'findings': _atd_write_required_field('CiScanResults', 'findings', _atd_write_array(writeFinding), x.findings, x),
@@ -1581,6 +1734,76 @@ export function readCiScanResults(x: any, context: any = x): CiScanResults {
     searched_paths: _atd_read_required_field('CiScanResults', 'searched_paths', _atd_read_array(_atd_read_string), x['searched_paths'], x),
     renamed_paths: _atd_read_required_field('CiScanResults', 'renamed_paths', _atd_read_array(_atd_read_string), x['renamed_paths'], x),
     rule_ids: _atd_read_required_field('CiScanResults', 'rule_ids', _atd_read_array(_atd_read_string), x['rule_ids'], x),
+  };
+}
+
+export function writeParsingStats(x: ParsingStats, context: any = x): any {
+  return {
+    'targets_parsed': _atd_write_required_field('ParsingStats', 'targets_parsed', _atd_write_int, x.targets_parsed, x),
+    'num_targets': _atd_write_required_field('ParsingStats', 'num_targets', _atd_write_int, x.num_targets, x),
+    'bytes_parsed': _atd_write_required_field('ParsingStats', 'bytes_parsed', _atd_write_int, x.bytes_parsed, x),
+    'num_bytes': _atd_write_required_field('ParsingStats', 'num_bytes', _atd_write_int, x.num_bytes, x),
+  };
+}
+
+export function readParsingStats(x: any, context: any = x): ParsingStats {
+  return {
+    targets_parsed: _atd_read_required_field('ParsingStats', 'targets_parsed', _atd_read_int, x['targets_parsed'], x),
+    num_targets: _atd_read_required_field('ParsingStats', 'num_targets', _atd_read_int, x['num_targets'], x),
+    bytes_parsed: _atd_read_required_field('ParsingStats', 'bytes_parsed', _atd_read_int, x['bytes_parsed'], x),
+    num_bytes: _atd_read_required_field('ParsingStats', 'num_bytes', _atd_read_int, x['num_bytes'], x),
+  };
+}
+
+export function writeCiScanCompleteStats(x: CiScanCompleteStats, context: any = x): any {
+  return {
+    'findings': _atd_write_required_field('CiScanCompleteStats', 'findings', _atd_write_int, x.findings, x),
+    'errors': _atd_write_required_field('CiScanCompleteStats', 'errors', _atd_write_array(writeCliError), x.errors, x),
+    'total_time': _atd_write_required_field('CiScanCompleteStats', 'total_time', _atd_write_float, x.total_time, x),
+    'unsupported_exts': _atd_write_required_field('CiScanCompleteStats', 'unsupported_exts', _atd_write_assoc_map_to_object(_atd_write_int), x.unsupported_exts, x),
+    'lockfile_scan_info': _atd_write_required_field('CiScanCompleteStats', 'lockfile_scan_info', _atd_write_assoc_map_to_object(_atd_write_int), x.lockfile_scan_info, x),
+    'parse_rate': _atd_write_required_field('CiScanCompleteStats', 'parse_rate', _atd_write_assoc_map_to_object(writeParsingStats), x.parse_rate, x),
+    'engine_requested': _atd_write_optional_field(_atd_write_string, x.engine_requested, x),
+  };
+}
+
+export function readCiScanCompleteStats(x: any, context: any = x): CiScanCompleteStats {
+  return {
+    findings: _atd_read_required_field('CiScanCompleteStats', 'findings', _atd_read_int, x['findings'], x),
+    errors: _atd_read_required_field('CiScanCompleteStats', 'errors', _atd_read_array(readCliError), x['errors'], x),
+    total_time: _atd_read_required_field('CiScanCompleteStats', 'total_time', _atd_read_float, x['total_time'], x),
+    unsupported_exts: _atd_read_required_field('CiScanCompleteStats', 'unsupported_exts', _atd_read_assoc_object_into_map(_atd_read_int), x['unsupported_exts'], x),
+    lockfile_scan_info: _atd_read_required_field('CiScanCompleteStats', 'lockfile_scan_info', _atd_read_assoc_object_into_map(_atd_read_int), x['lockfile_scan_info'], x),
+    parse_rate: _atd_read_required_field('CiScanCompleteStats', 'parse_rate', _atd_read_assoc_object_into_map(readParsingStats), x['parse_rate'], x),
+    engine_requested: _atd_read_optional_field(_atd_read_string, x['engine_requested'], x),
+  };
+}
+
+export function writeCiScanDependencies(x: CiScanDependencies, context: any = x): any {
+  return _atd_write_assoc_map_to_object(_atd_write_array(writeFoundDependency))(x, context);
+}
+
+export function readCiScanDependencies(x: any, context: any = x): CiScanDependencies {
+  return _atd_read_assoc_object_into_map(_atd_read_array(readFoundDependency))(x, context);
+}
+
+export function writeCiScanComplete(x: CiScanComplete, context: any = x): any {
+  return {
+    'exit_code': _atd_write_required_field('CiScanComplete', 'exit_code', _atd_write_int, x.exit_code, x),
+    'stats': _atd_write_required_field('CiScanComplete', 'stats', writeCiScanCompleteStats, x.stats, x),
+    'dependencies': _atd_write_optional_field(writeCiScanDependencies, x.dependencies, x),
+    'dependency_parser_errors': _atd_write_optional_field(_atd_write_array(writeDependencyParserError), x.dependency_parser_errors, x),
+    'task_id': _atd_write_optional_field(_atd_write_string, x.task_id, x),
+  };
+}
+
+export function readCiScanComplete(x: any, context: any = x): CiScanComplete {
+  return {
+    exit_code: _atd_read_required_field('CiScanComplete', 'exit_code', _atd_read_int, x['exit_code'], x),
+    stats: _atd_read_required_field('CiScanComplete', 'stats', readCiScanCompleteStats, x['stats'], x),
+    dependencies: _atd_read_optional_field(readCiScanDependencies, x['dependencies'], x),
+    dependency_parser_errors: _atd_read_optional_field(_atd_read_array(readDependencyParserError), x['dependency_parser_errors'], x),
+    task_id: _atd_read_optional_field(_atd_read_string, x['task_id'], x),
   };
 }
 

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -285,7 +285,8 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   path: string;
   parser: sca_parser_name;
   reason: string;
-  position: position option;
+  line: int option;
+  col: int option;
   text: string option
 }
   [@@deriving show]
@@ -9614,6 +9615,44 @@ let read_error_span = (
 )
 let error_span_of_string s =
   read_error_span (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__string_nullable = (
+  Atdgen_runtime.Oj_run.write_nullable (
+    Yojson.Safe.write_string
+  )
+)
+let string_of__string_nullable ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__string_nullable ob x;
+  Buffer.contents ob
+let read__string_nullable = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    (if Yojson.Safe.read_null_if_possible p lb then None
+    else Some ((
+      Atdgen_runtime.Oj_run.read_string
+    ) p lb) : _ option)
+)
+let _string_nullable_of_string s =
+  read__string_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__int_nullable = (
+  Atdgen_runtime.Oj_run.write_nullable (
+    Yojson.Safe.write_int
+  )
+)
+let string_of__int_nullable ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__int_nullable ob x;
+  Buffer.contents ob
+let read__int_nullable = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    (if Yojson.Safe.read_null_if_possible p lb then None
+    else Some ((
+      Atdgen_runtime.Oj_run.read_int
+    ) p lb) : _ option)
+)
+let _int_nullable_of_string s =
+  read__int_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_dependency_parser_error : _ -> dependency_parser_error -> _ = (
   fun ob (x : dependency_parser_error) ->
     Buffer.add_char ob '{';
@@ -9645,28 +9684,33 @@ let write_dependency_parser_error : _ -> dependency_parser_error -> _ = (
       Yojson.Safe.write_string
     )
       ob x.reason;
-    (match x.position with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Buffer.add_char ob ',';
-        Buffer.add_string ob "\"position\":";
-      (
-        write_position
-      )
-        ob x;
-    );
-    (match x.text with None -> () | Some x ->
-      if !is_first then
-        is_first := false
-      else
-        Buffer.add_char ob ',';
-        Buffer.add_string ob "\"text\":";
-      (
-        Yojson.Safe.write_string
-      )
-        ob x;
-    );
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"line\":";
+    (
+      write__int_nullable
+    )
+      ob x.line;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"col\":";
+    (
+      write__int_nullable
+    )
+      ob x.col;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"text\":";
+    (
+      write__string_nullable
+    )
+      ob x.text;
     Buffer.add_char ob '}';
 )
 let string_of_dependency_parser_error ?(len = 1024) x =
@@ -9680,7 +9724,8 @@ let read_dependency_parser_error = (
     let field_path = ref (None) in
     let field_parser = ref (None) in
     let field_reason = ref (None) in
-    let field_position = ref (None) in
+    let field_line = ref (None) in
+    let field_col = ref (None) in
     let field_text = ref (None) in
     try
       Yojson.Safe.read_space p lb;
@@ -9691,8 +9736,24 @@ let read_dependency_parser_error = (
           if pos < 0 || len < 0 || pos + len > String.length s then
             invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
           match len with
+            | 3 -> (
+                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'l' then (
+                  4
+                )
+                else (
+                  -1
+                )
+              )
             | 4 -> (
                 match String.unsafe_get s pos with
+                  | 'l' -> (
+                      if String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'e' then (
+                        3
+                      )
+                      else (
+                        -1
+                      )
+                    )
                   | 'p' -> (
                       if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'h' then (
                         0
@@ -9703,7 +9764,7 @@ let read_dependency_parser_error = (
                     )
                   | 't' -> (
                       if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = 't' then (
-                        4
+                        5
                       )
                       else (
                         -1
@@ -9734,14 +9795,6 @@ let read_dependency_parser_error = (
                   | _ -> (
                       -1
                     )
-              )
-            | 8 -> (
-                if String.unsafe_get s pos = 'p' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 's' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 't' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'n' then (
-                  3
-                )
-                else (
-                  -1
-                )
               )
             | _ -> (
                 -1
@@ -9776,25 +9829,29 @@ let read_dependency_parser_error = (
               )
             );
           | 3 ->
-            if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_position := (
-                Some (
-                  (
-                    read_position
-                  ) p lb
-                )
-              );
-            )
+            field_line := (
+              Some (
+                (
+                  read__int_nullable
+                ) p lb
+              )
+            );
           | 4 ->
-            if not (Yojson.Safe.read_null_if_possible p lb) then (
-              field_text := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_string
-                  ) p lb
-                )
-              );
-            )
+            field_col := (
+              Some (
+                (
+                  read__int_nullable
+                ) p lb
+              )
+            );
+          | 5 ->
+            field_text := (
+              Some (
+                (
+                  read__string_nullable
+                ) p lb
+              )
+            );
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -9808,8 +9865,24 @@ let read_dependency_parser_error = (
             if pos < 0 || len < 0 || pos + len > String.length s then
               invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
             match len with
+              | 3 -> (
+                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'l' then (
+                    4
+                  )
+                  else (
+                    -1
+                  )
+                )
               | 4 -> (
                   match String.unsafe_get s pos with
+                    | 'l' -> (
+                        if String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'e' then (
+                          3
+                        )
+                        else (
+                          -1
+                        )
+                      )
                     | 'p' -> (
                         if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'h' then (
                           0
@@ -9820,7 +9893,7 @@ let read_dependency_parser_error = (
                       )
                     | 't' -> (
                         if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = 't' then (
-                          4
+                          5
                         )
                         else (
                           -1
@@ -9851,14 +9924,6 @@ let read_dependency_parser_error = (
                     | _ -> (
                         -1
                       )
-                )
-              | 8 -> (
-                  if String.unsafe_get s pos = 'p' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 's' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 't' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'n' then (
-                    3
-                  )
-                  else (
-                    -1
-                  )
                 )
               | _ -> (
                   -1
@@ -9893,25 +9958,29 @@ let read_dependency_parser_error = (
                 )
               );
             | 3 ->
-              if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_position := (
-                  Some (
-                    (
-                      read_position
-                    ) p lb
-                  )
-                );
-              )
+              field_line := (
+                Some (
+                  (
+                    read__int_nullable
+                  ) p lb
+                )
+              );
             | 4 ->
-              if not (Yojson.Safe.read_null_if_possible p lb) then (
-                field_text := (
-                  Some (
-                    (
-                      Atdgen_runtime.Oj_run.read_string
-                    ) p lb
-                  )
-                );
-              )
+              field_col := (
+                Some (
+                  (
+                    read__int_nullable
+                  ) p lb
+                )
+              );
+            | 5 ->
+              field_text := (
+                Some (
+                  (
+                    read__string_nullable
+                  ) p lb
+                )
+              );
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -9924,8 +9993,9 @@ let read_dependency_parser_error = (
             path = (match !field_path with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "path");
             parser = (match !field_parser with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "parser");
             reason = (match !field_reason with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "reason");
-            position = !field_position;
-            text = !field_text;
+            line = (match !field_line with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "line");
+            col = (match !field_col with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "col");
+            text = (match !field_text with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "text");
           }
          : dependency_parser_error)
       )
@@ -16356,25 +16426,6 @@ let read_cli_match_taint_source = (
 )
 let cli_match_taint_source_of_string s =
   read_cli_match_taint_source (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__string_nullable = (
-  Atdgen_runtime.Oj_run.write_nullable (
-    Yojson.Safe.write_string
-  )
-)
-let string_of__string_nullable ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__string_nullable ob x;
-  Buffer.contents ob
-let read__string_nullable = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    (if Yojson.Safe.read_null_if_possible p lb then None
-    else Some ((
-      Atdgen_runtime.Oj_run.read_string
-    ) p lb) : _ option)
-)
-let _string_nullable_of_string s =
-  read__string_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__finding_list = (
   Atdgen_runtime.Oj_run.write_list (
     write_finding

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -166,7 +166,7 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 }
   [@@deriving show]
 
-type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
+type sca_parser_name = Semgrep_output_v1_t.sca_parser_name [@@deriving show]
 
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
@@ -288,6 +288,7 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   position: position option;
   text: string option
 }
+  [@@deriving show]
 
 type cve_result = Semgrep_output_v1_t.cve_result = {
   url: string;

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -166,6 +166,8 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 }
   [@@deriving show]
 
+type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
+
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
@@ -210,6 +212,14 @@ type rule_id_and_engine_kind = Semgrep_output_v1_t.rule_id_and_engine_kind
 type position_bis = Semgrep_output_v1_t.position_bis = {
   line: int;
   col: int
+}
+  [@@deriving show]
+
+type parsing_stats = Semgrep_output_v1_t.parsing_stats = {
+  targets_parsed: int;
+  num_targets: int;
+  bytes_parsed: int;
+  num_bytes: int
 }
   [@@deriving show]
 
@@ -270,6 +280,15 @@ type error_span = Semgrep_output_v1_t.error_span = {
   context_end: position_bis option option
 }
   [@@deriving show]
+
+type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
+  path: string;
+  parser: sca_parser_name;
+  reason: string;
+  line: int option;
+  col: int option;
+  text: string option
+}
 
 type cve_result = Semgrep_output_v1_t.cve_result = {
   url: string;
@@ -447,6 +466,29 @@ type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   searched_paths: string list;
   renamed_paths: string list;
   rule_ids: string list
+}
+  [@@deriving show]
+
+type ci_scan_dependencies = Semgrep_output_v1_t.ci_scan_dependencies
+  [@@deriving show]
+
+type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
+  findings: int;
+  errors: cli_error list;
+  total_time: float;
+  unsupported_exts: (string * int) list;
+  lockfile_scan_info: (string * int) list;
+  parse_rate: (string * parsing_stats) list;
+  engine_requested: string option
+}
+  [@@deriving show]
+
+type ci_scan_complete = Semgrep_output_v1_t.ci_scan_complete = {
+  exit_code: int;
+  stats: ci_scan_complete_stats;
+  dependencies: ci_scan_dependencies option;
+  dependency_parser_errors: dependency_parser_error list option;
+  task_id: string option
 }
   [@@deriving show]
 
@@ -5038,6 +5080,148 @@ let read_skipped_rule = (
 )
 let skipped_rule_of_string s =
   read_skipped_rule (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_sca_parser_name = (
+  fun ob x ->
+    match x with
+      | `Gemfile_lock -> Buffer.add_string ob "\"gemfile_lock\""
+      | `Go_mod -> Buffer.add_string ob "\"go_mod\""
+      | `Go_sum -> Buffer.add_string ob "\"go_sum\""
+      | `Gradle_lockfile -> Buffer.add_string ob "\"gradle_lockfile\""
+      | `Gradle_build -> Buffer.add_string ob "\"gradle_build\""
+      | `Jsondoc -> Buffer.add_string ob "\"jsondoc\""
+      | `Pipfile -> Buffer.add_string ob "\"pipfile\""
+      | `Pnpm_lock -> Buffer.add_string ob "\"pnpm_lock\""
+      | `Poetry_lock -> Buffer.add_string ob "\"poetry_lock\""
+      | `Pyproject_toml -> Buffer.add_string ob "\"pyproject_toml\""
+      | `Requirements -> Buffer.add_string ob "\"requirements\""
+      | `Yarn_1 -> Buffer.add_string ob "\"yarn_1\""
+      | `Yarn_2 -> Buffer.add_string ob "\"yarn_2\""
+      | `Pomtree -> Buffer.add_string ob "\"pomtree\""
+      | `Cargo_parser -> Buffer.add_string ob "\"cargo\""
+      | `Composer_lock -> Buffer.add_string ob "\"composer_lock\""
+)
+let string_of_sca_parser_name ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_sca_parser_name ob x;
+  Buffer.contents ob
+let read_sca_parser_name = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "gemfile_lock" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Gemfile_lock
+            | "go_mod" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Go_mod
+            | "go_sum" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Go_sum
+            | "gradle_lockfile" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Gradle_lockfile
+            | "gradle_build" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Gradle_build
+            | "jsondoc" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Jsondoc
+            | "pipfile" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Pipfile
+            | "pnpm_lock" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Pnpm_lock
+            | "poetry_lock" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Poetry_lock
+            | "pyproject_toml" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Pyproject_toml
+            | "requirements" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Requirements
+            | "yarn_1" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Yarn_1
+            | "yarn_2" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Yarn_2
+            | "pomtree" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Pomtree
+            | "cargo" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Cargo_parser
+            | "composer_lock" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              `Composer_lock
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "gemfile_lock" ->
+              `Gemfile_lock
+            | "go_mod" ->
+              `Go_mod
+            | "go_sum" ->
+              `Go_sum
+            | "gradle_lockfile" ->
+              `Gradle_lockfile
+            | "gradle_build" ->
+              `Gradle_build
+            | "jsondoc" ->
+              `Jsondoc
+            | "pipfile" ->
+              `Pipfile
+            | "pnpm_lock" ->
+              `Pnpm_lock
+            | "poetry_lock" ->
+              `Poetry_lock
+            | "pyproject_toml" ->
+              `Pyproject_toml
+            | "requirements" ->
+              `Requirements
+            | "yarn_1" ->
+              `Yarn_1
+            | "yarn_2" ->
+              `Yarn_2
+            | "pomtree" ->
+              `Pomtree
+            | "cargo" ->
+              `Cargo_parser
+            | "composer_lock" ->
+              `Composer_lock
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let sca_parser_name_of_string s =
+  read_sca_parser_name (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_ecosystem = (
   fun ob x ->
     match x with
@@ -6562,6 +6746,245 @@ let read_position_bis = (
 )
 let position_bis_of_string s =
   read_position_bis (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_parsing_stats : _ -> parsing_stats -> _ = (
+  fun ob (x : parsing_stats) ->
+    Buffer.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"targets_parsed\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.targets_parsed;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"num_targets\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.num_targets;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"bytes_parsed\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.bytes_parsed;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"num_bytes\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.num_bytes;
+    Buffer.add_char ob '}';
+)
+let string_of_parsing_stats ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_parsing_stats ob x;
+  Buffer.contents ob
+let read_parsing_stats = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_targets_parsed = ref (None) in
+    let field_num_targets = ref (None) in
+    let field_bytes_parsed = ref (None) in
+    let field_num_bytes = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+          match len with
+            | 9 -> (
+                if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'b' && String.unsafe_get s (pos+5) = 'y' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 's' then (
+                  3
+                )
+                else (
+                  -1
+                )
+              )
+            | 11 -> (
+                if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 't' && String.unsafe_get s (pos+5) = 'a' && String.unsafe_get s (pos+6) = 'r' && String.unsafe_get s (pos+7) = 'g' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 's' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | 12 -> (
+                if String.unsafe_get s pos = 'b' && String.unsafe_get s (pos+1) = 'y' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 'd' then (
+                  2
+                )
+                else (
+                  -1
+                )
+              )
+            | 14 -> (
+                if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'g' && String.unsafe_get s (pos+4) = 'e' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = 's' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'p' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 's' && String.unsafe_get s (pos+12) = 'e' && String.unsafe_get s (pos+13) = 'd' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_targets_parsed := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_num_targets := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | 2 ->
+            field_bytes_parsed := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | 3 ->
+            field_num_bytes := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+            match len with
+              | 9 -> (
+                  if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 'b' && String.unsafe_get s (pos+5) = 'y' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 's' then (
+                    3
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 11 -> (
+                  if String.unsafe_get s pos = 'n' && String.unsafe_get s (pos+1) = 'u' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = '_' && String.unsafe_get s (pos+4) = 't' && String.unsafe_get s (pos+5) = 'a' && String.unsafe_get s (pos+6) = 'r' && String.unsafe_get s (pos+7) = 'g' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 's' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 12 -> (
+                  if String.unsafe_get s pos = 'b' && String.unsafe_get s (pos+1) = 'y' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 's' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'p' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'r' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 'd' then (
+                    2
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 14 -> (
+                  if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'g' && String.unsafe_get s (pos+4) = 'e' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = 's' && String.unsafe_get s (pos+7) = '_' && String.unsafe_get s (pos+8) = 'p' && String.unsafe_get s (pos+9) = 'a' && String.unsafe_get s (pos+10) = 'r' && String.unsafe_get s (pos+11) = 's' && String.unsafe_get s (pos+12) = 'e' && String.unsafe_get s (pos+13) = 'd' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_targets_parsed := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_num_targets := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | 2 ->
+              field_bytes_parsed := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | 3 ->
+              field_num_bytes := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            targets_parsed = (match !field_targets_parsed with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "targets_parsed");
+            num_targets = (match !field_num_targets with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "num_targets");
+            bytes_parsed = (match !field_bytes_parsed with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "bytes_parsed");
+            num_bytes = (match !field_num_bytes with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "num_bytes");
+          }
+         : parsing_stats)
+      )
+)
+let parsing_stats_of_string s =
+  read_parsing_stats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_fix_regex : _ -> fix_regex -> _ = (
   fun ob (x : fix_regex) ->
     Buffer.add_char ob '{';
@@ -9190,6 +9613,373 @@ let read_error_span = (
 )
 let error_span_of_string s =
   read_error_span (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_dependency_parser_error : _ -> dependency_parser_error -> _ = (
+  fun ob (x : dependency_parser_error) ->
+    Buffer.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"path\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.path;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"parser\":";
+    (
+      write_sca_parser_name
+    )
+      ob x.parser;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"reason\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.reason;
+    (match x.line with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"line\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
+    (match x.col with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"col\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
+    (match x.text with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"text\":";
+      (
+        Yojson.Safe.write_string
+      )
+        ob x;
+    );
+    Buffer.add_char ob '}';
+)
+let string_of_dependency_parser_error ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_dependency_parser_error ob x;
+  Buffer.contents ob
+let read_dependency_parser_error = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_path = ref (None) in
+    let field_parser = ref (None) in
+    let field_reason = ref (None) in
+    let field_line = ref (None) in
+    let field_col = ref (None) in
+    let field_text = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+          match len with
+            | 3 -> (
+                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'l' then (
+                  4
+                )
+                else (
+                  -1
+                )
+              )
+            | 4 -> (
+                match String.unsafe_get s pos with
+                  | 'l' -> (
+                      if String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'e' then (
+                        3
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 'p' -> (
+                      if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'h' then (
+                        0
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 't' -> (
+                      if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = 't' then (
+                        5
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | _ -> (
+                      -1
+                    )
+              )
+            | 6 -> (
+                match String.unsafe_get s pos with
+                  | 'p' -> (
+                      if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'e' && String.unsafe_get s (pos+5) = 'r' then (
+                        1
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 'r' -> (
+                      if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'a' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'n' then (
+                        2
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | _ -> (
+                      -1
+                    )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_path := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_parser := (
+              Some (
+                (
+                  read_sca_parser_name
+                ) p lb
+              )
+            );
+          | 2 ->
+            field_reason := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | 3 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_line := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
+          | 4 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_col := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
+          | 5 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_text := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            )
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+            match len with
+              | 3 -> (
+                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'l' then (
+                    4
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 4 -> (
+                  match String.unsafe_get s pos with
+                    | 'l' -> (
+                        if String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'e' then (
+                          3
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 'p' -> (
+                        if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'h' then (
+                          0
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 't' -> (
+                        if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'x' && String.unsafe_get s (pos+3) = 't' then (
+                          5
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
+                )
+              | 6 -> (
+                  match String.unsafe_get s pos with
+                    | 'p' -> (
+                        if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'e' && String.unsafe_get s (pos+5) = 'r' then (
+                          1
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 'r' -> (
+                        if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'a' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'o' && String.unsafe_get s (pos+5) = 'n' then (
+                          2
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_path := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_parser := (
+                Some (
+                  (
+                    read_sca_parser_name
+                  ) p lb
+                )
+              );
+            | 2 ->
+              field_reason := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 3 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_line := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
+            | 4 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_col := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
+            | 5 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_text := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
+                );
+              )
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            path = (match !field_path with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "path");
+            parser = (match !field_parser with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "parser");
+            reason = (match !field_reason with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "reason");
+            line = !field_line;
+            col = !field_col;
+            text = !field_text;
+          }
+         : dependency_parser_error)
+      )
+)
+let dependency_parser_error_of_string s =
+  read_dependency_parser_error (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_cve_result : _ -> cve_result -> _ = (
   fun ob (x : cve_result) ->
     Buffer.add_char ob '{';
@@ -15986,3 +16776,919 @@ let read_ci_scan_results = (
 )
 let ci_scan_results_of_string s =
   read_ci_scan_results (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__found_dependency_list = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_found_dependency
+  )
+)
+let string_of__found_dependency_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__found_dependency_list ob x;
+  Buffer.contents ob
+let read__found_dependency_list = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_found_dependency
+  )
+)
+let _found_dependency_list_of_string s =
+  read__found_dependency_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_a534bf0 = (
+  Atdgen_runtime.Oj_run.write_assoc_list (
+    Yojson.Safe.write_string
+  ) (
+    write__found_dependency_list
+  )
+)
+let string_of__x_a534bf0 ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__x_a534bf0 ob x;
+  Buffer.contents ob
+let read__x_a534bf0 = (
+  Atdgen_runtime.Oj_run.read_assoc_list (
+    Atdgen_runtime.Oj_run.read_string
+  ) (
+    read__found_dependency_list
+  )
+)
+let _x_a534bf0_of_string s =
+  read__x_a534bf0 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_ci_scan_dependencies = (
+  write__x_a534bf0
+)
+let string_of_ci_scan_dependencies ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_ci_scan_dependencies ob x;
+  Buffer.contents ob
+let read_ci_scan_dependencies = (
+  read__x_a534bf0
+)
+let ci_scan_dependencies_of_string s =
+  read_ci_scan_dependencies (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_a95369c = (
+  Atdgen_runtime.Oj_run.write_assoc_list (
+    Yojson.Safe.write_string
+  ) (
+    write_parsing_stats
+  )
+)
+let string_of__x_a95369c ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__x_a95369c ob x;
+  Buffer.contents ob
+let read__x_a95369c = (
+  Atdgen_runtime.Oj_run.read_assoc_list (
+    Atdgen_runtime.Oj_run.read_string
+  ) (
+    read_parsing_stats
+  )
+)
+let _x_a95369c_of_string s =
+  read__x_a95369c (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_852c7ec = (
+  Atdgen_runtime.Oj_run.write_assoc_list (
+    Yojson.Safe.write_string
+  ) (
+    Yojson.Safe.write_int
+  )
+)
+let string_of__x_852c7ec ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__x_852c7ec ob x;
+  Buffer.contents ob
+let read__x_852c7ec = (
+  Atdgen_runtime.Oj_run.read_assoc_list (
+    Atdgen_runtime.Oj_run.read_string
+  ) (
+    Atdgen_runtime.Oj_run.read_int
+  )
+)
+let _x_852c7ec_of_string s =
+  read__x_852c7ec (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_ci_scan_complete_stats : _ -> ci_scan_complete_stats -> _ = (
+  fun ob (x : ci_scan_complete_stats) ->
+    Buffer.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"findings\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.findings;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"errors\":";
+    (
+      write__cli_error_list
+    )
+      ob x.errors;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"total_time\":";
+    (
+      Yojson.Safe.write_std_float
+    )
+      ob x.total_time;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"unsupported_exts\":";
+    (
+      write__x_852c7ec
+    )
+      ob x.unsupported_exts;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"lockfile_scan_info\":";
+    (
+      write__x_852c7ec
+    )
+      ob x.lockfile_scan_info;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"parse_rate\":";
+    (
+      write__x_a95369c
+    )
+      ob x.parse_rate;
+    (match x.engine_requested with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"engine_requested\":";
+      (
+        Yojson.Safe.write_string
+      )
+        ob x;
+    );
+    Buffer.add_char ob '}';
+)
+let string_of_ci_scan_complete_stats ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_ci_scan_complete_stats ob x;
+  Buffer.contents ob
+let read_ci_scan_complete_stats = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_findings = ref (None) in
+    let field_errors = ref (None) in
+    let field_total_time = ref (None) in
+    let field_unsupported_exts = ref (None) in
+    let field_lockfile_scan_info = ref (None) in
+    let field_parse_rate = ref (None) in
+    let field_engine_requested = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+          match len with
+            | 6 -> (
+                if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'r' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'o' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 's' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | 8 -> (
+                if String.unsafe_get s pos = 'f' && String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'd' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'g' && String.unsafe_get s (pos+7) = 's' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | 10 -> (
+                match String.unsafe_get s pos with
+                  | 'p' -> (
+                      if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'e' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'r' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'e' then (
+                        5
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 't' -> (
+                      if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'l' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'i' && String.unsafe_get s (pos+8) = 'm' && String.unsafe_get s (pos+9) = 'e' then (
+                        2
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | _ -> (
+                      -1
+                    )
+              )
+            | 16 -> (
+                match String.unsafe_get s pos with
+                  | 'e' -> (
+                      if String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 'g' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 'n' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 'q' && String.unsafe_get s (pos+10) = 'u' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = 't' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 'd' then (
+                        6
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | 'u' -> (
+                      if String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 's' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'p' && String.unsafe_get s (pos+5) = 'p' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'e' && String.unsafe_get s (pos+10) = 'd' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 'e' && String.unsafe_get s (pos+13) = 'x' && String.unsafe_get s (pos+14) = 't' && String.unsafe_get s (pos+15) = 's' then (
+                        3
+                      )
+                      else (
+                        -1
+                      )
+                    )
+                  | _ -> (
+                      -1
+                    )
+              )
+            | 18 -> (
+                if String.unsafe_get s pos = 'l' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'c' && String.unsafe_get s (pos+3) = 'k' && String.unsafe_get s (pos+4) = 'f' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'l' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = '_' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'c' && String.unsafe_get s (pos+11) = 'a' && String.unsafe_get s (pos+12) = 'n' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'i' && String.unsafe_get s (pos+15) = 'n' && String.unsafe_get s (pos+16) = 'f' && String.unsafe_get s (pos+17) = 'o' then (
+                  4
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_findings := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_errors := (
+              Some (
+                (
+                  read__cli_error_list
+                ) p lb
+              )
+            );
+          | 2 ->
+            field_total_time := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_number
+                ) p lb
+              )
+            );
+          | 3 ->
+            field_unsupported_exts := (
+              Some (
+                (
+                  read__x_852c7ec
+                ) p lb
+              )
+            );
+          | 4 ->
+            field_lockfile_scan_info := (
+              Some (
+                (
+                  read__x_852c7ec
+                ) p lb
+              )
+            );
+          | 5 ->
+            field_parse_rate := (
+              Some (
+                (
+                  read__x_a95369c
+                ) p lb
+              )
+            );
+          | 6 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_engine_requested := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            )
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+            match len with
+              | 6 -> (
+                  if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'r' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 'o' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 's' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 8 -> (
+                  if String.unsafe_get s pos = 'f' && String.unsafe_get s (pos+1) = 'i' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 'd' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'n' && String.unsafe_get s (pos+6) = 'g' && String.unsafe_get s (pos+7) = 's' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 10 -> (
+                  match String.unsafe_get s pos with
+                    | 'p' -> (
+                        if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'e' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 'r' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'e' then (
+                          5
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 't' -> (
+                        if String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 't' && String.unsafe_get s (pos+3) = 'a' && String.unsafe_get s (pos+4) = 'l' && String.unsafe_get s (pos+5) = '_' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'i' && String.unsafe_get s (pos+8) = 'm' && String.unsafe_get s (pos+9) = 'e' then (
+                          2
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
+                )
+              | 16 -> (
+                  match String.unsafe_get s pos with
+                    | 'e' -> (
+                        if String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 'g' && String.unsafe_get s (pos+3) = 'i' && String.unsafe_get s (pos+4) = 'n' && String.unsafe_get s (pos+5) = 'e' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 'e' && String.unsafe_get s (pos+9) = 'q' && String.unsafe_get s (pos+10) = 'u' && String.unsafe_get s (pos+11) = 'e' && String.unsafe_get s (pos+12) = 's' && String.unsafe_get s (pos+13) = 't' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 'd' then (
+                          6
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 'u' -> (
+                        if String.unsafe_get s (pos+1) = 'n' && String.unsafe_get s (pos+2) = 's' && String.unsafe_get s (pos+3) = 'u' && String.unsafe_get s (pos+4) = 'p' && String.unsafe_get s (pos+5) = 'p' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'r' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'e' && String.unsafe_get s (pos+10) = 'd' && String.unsafe_get s (pos+11) = '_' && String.unsafe_get s (pos+12) = 'e' && String.unsafe_get s (pos+13) = 'x' && String.unsafe_get s (pos+14) = 't' && String.unsafe_get s (pos+15) = 's' then (
+                          3
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
+                )
+              | 18 -> (
+                  if String.unsafe_get s pos = 'l' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'c' && String.unsafe_get s (pos+3) = 'k' && String.unsafe_get s (pos+4) = 'f' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'l' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = '_' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'c' && String.unsafe_get s (pos+11) = 'a' && String.unsafe_get s (pos+12) = 'n' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'i' && String.unsafe_get s (pos+15) = 'n' && String.unsafe_get s (pos+16) = 'f' && String.unsafe_get s (pos+17) = 'o' then (
+                    4
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_findings := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_errors := (
+                Some (
+                  (
+                    read__cli_error_list
+                  ) p lb
+                )
+              );
+            | 2 ->
+              field_total_time := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_number
+                  ) p lb
+                )
+              );
+            | 3 ->
+              field_unsupported_exts := (
+                Some (
+                  (
+                    read__x_852c7ec
+                  ) p lb
+                )
+              );
+            | 4 ->
+              field_lockfile_scan_info := (
+                Some (
+                  (
+                    read__x_852c7ec
+                  ) p lb
+                )
+              );
+            | 5 ->
+              field_parse_rate := (
+                Some (
+                  (
+                    read__x_a95369c
+                  ) p lb
+                )
+              );
+            | 6 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_engine_requested := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
+                );
+              )
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            findings = (match !field_findings with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "findings");
+            errors = (match !field_errors with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "errors");
+            total_time = (match !field_total_time with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "total_time");
+            unsupported_exts = (match !field_unsupported_exts with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "unsupported_exts");
+            lockfile_scan_info = (match !field_lockfile_scan_info with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "lockfile_scan_info");
+            parse_rate = (match !field_parse_rate with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "parse_rate");
+            engine_requested = !field_engine_requested;
+          }
+         : ci_scan_complete_stats)
+      )
+)
+let ci_scan_complete_stats_of_string s =
+  read_ci_scan_complete_stats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__dependency_parser_error_list = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_dependency_parser_error
+  )
+)
+let string_of__dependency_parser_error_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__dependency_parser_error_list ob x;
+  Buffer.contents ob
+let read__dependency_parser_error_list = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_dependency_parser_error
+  )
+)
+let _dependency_parser_error_list_of_string s =
+  read__dependency_parser_error_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__dependency_parser_error_list_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__dependency_parser_error_list
+  )
+)
+let string_of__dependency_parser_error_list_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__dependency_parser_error_list_option ob x;
+  Buffer.contents ob
+let read__dependency_parser_error_list_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__dependency_parser_error_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__dependency_parser_error_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _dependency_parser_error_list_option_of_string s =
+  read__dependency_parser_error_list_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__ci_scan_dependencies_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write_ci_scan_dependencies
+  )
+)
+let string_of__ci_scan_dependencies_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__ci_scan_dependencies_option ob x;
+  Buffer.contents ob
+let read__ci_scan_dependencies_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read_ci_scan_dependencies
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read_ci_scan_dependencies
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _ci_scan_dependencies_option_of_string s =
+  read__ci_scan_dependencies_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_ci_scan_complete : _ -> ci_scan_complete -> _ = (
+  fun ob (x : ci_scan_complete) ->
+    Buffer.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"exit_code\":";
+    (
+      Yojson.Safe.write_int
+    )
+      ob x.exit_code;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"stats\":";
+    (
+      write_ci_scan_complete_stats
+    )
+      ob x.stats;
+    (match x.dependencies with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"dependencies\":";
+      (
+        write_ci_scan_dependencies
+      )
+        ob x;
+    );
+    (match x.dependency_parser_errors with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"dependency_parser_errors\":";
+      (
+        write__dependency_parser_error_list
+      )
+        ob x;
+    );
+    (match x.task_id with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"task_id\":";
+      (
+        Yojson.Safe.write_string
+      )
+        ob x;
+    );
+    Buffer.add_char ob '}';
+)
+let string_of_ci_scan_complete ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_ci_scan_complete ob x;
+  Buffer.contents ob
+let read_ci_scan_complete = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_exit_code = ref (None) in
+    let field_stats = ref (None) in
+    let field_dependencies = ref (None) in
+    let field_dependency_parser_errors = ref (None) in
+    let field_task_id = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+          match len with
+            | 5 -> (
+                if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 't' && String.unsafe_get s (pos+2) = 'a' && String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = 's' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | 7 -> (
+                if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 's' && String.unsafe_get s (pos+3) = 'k' && String.unsafe_get s (pos+4) = '_' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'd' then (
+                  4
+                )
+                else (
+                  -1
+                )
+              )
+            | 9 -> (
+                if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = '_' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'd' && String.unsafe_get s (pos+8) = 'e' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | 12 -> (
+                if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' && String.unsafe_get s (pos+5) = 'd' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'n' && String.unsafe_get s (pos+8) = 'c' && String.unsafe_get s (pos+9) = 'i' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 's' then (
+                  2
+                )
+                else (
+                  -1
+                )
+              )
+            | 24 -> (
+                if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' && String.unsafe_get s (pos+5) = 'd' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'n' && String.unsafe_get s (pos+8) = 'c' && String.unsafe_get s (pos+9) = 'y' && String.unsafe_get s (pos+10) = '_' && String.unsafe_get s (pos+11) = 'p' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'r' && String.unsafe_get s (pos+14) = 's' && String.unsafe_get s (pos+15) = 'e' && String.unsafe_get s (pos+16) = 'r' && String.unsafe_get s (pos+17) = '_' && String.unsafe_get s (pos+18) = 'e' && String.unsafe_get s (pos+19) = 'r' && String.unsafe_get s (pos+20) = 'r' && String.unsafe_get s (pos+21) = 'o' && String.unsafe_get s (pos+22) = 'r' && String.unsafe_get s (pos+23) = 's' then (
+                  3
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_exit_code := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_int
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_stats := (
+              Some (
+                (
+                  read_ci_scan_complete_stats
+                ) p lb
+              )
+            );
+          | 2 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_dependencies := (
+                Some (
+                  (
+                    read_ci_scan_dependencies
+                  ) p lb
+                )
+              );
+            )
+          | 3 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_dependency_parser_errors := (
+                Some (
+                  (
+                    read__dependency_parser_error_list
+                  ) p lb
+                )
+              );
+            )
+          | 4 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_task_id := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            )
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+            match len with
+              | 5 -> (
+                  if String.unsafe_get s pos = 's' && String.unsafe_get s (pos+1) = 't' && String.unsafe_get s (pos+2) = 'a' && String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = 's' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 7 -> (
+                  if String.unsafe_get s pos = 't' && String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 's' && String.unsafe_get s (pos+3) = 'k' && String.unsafe_get s (pos+4) = '_' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'd' then (
+                    4
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 9 -> (
+                  if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'x' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = '_' && String.unsafe_get s (pos+5) = 'c' && String.unsafe_get s (pos+6) = 'o' && String.unsafe_get s (pos+7) = 'd' && String.unsafe_get s (pos+8) = 'e' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 12 -> (
+                  if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' && String.unsafe_get s (pos+5) = 'd' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'n' && String.unsafe_get s (pos+8) = 'c' && String.unsafe_get s (pos+9) = 'i' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 's' then (
+                    2
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 24 -> (
+                  if String.unsafe_get s pos = 'd' && String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'p' && String.unsafe_get s (pos+3) = 'e' && String.unsafe_get s (pos+4) = 'n' && String.unsafe_get s (pos+5) = 'd' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'n' && String.unsafe_get s (pos+8) = 'c' && String.unsafe_get s (pos+9) = 'y' && String.unsafe_get s (pos+10) = '_' && String.unsafe_get s (pos+11) = 'p' && String.unsafe_get s (pos+12) = 'a' && String.unsafe_get s (pos+13) = 'r' && String.unsafe_get s (pos+14) = 's' && String.unsafe_get s (pos+15) = 'e' && String.unsafe_get s (pos+16) = 'r' && String.unsafe_get s (pos+17) = '_' && String.unsafe_get s (pos+18) = 'e' && String.unsafe_get s (pos+19) = 'r' && String.unsafe_get s (pos+20) = 'r' && String.unsafe_get s (pos+21) = 'o' && String.unsafe_get s (pos+22) = 'r' && String.unsafe_get s (pos+23) = 's' then (
+                    3
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_exit_code := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_stats := (
+                Some (
+                  (
+                    read_ci_scan_complete_stats
+                  ) p lb
+                )
+              );
+            | 2 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_dependencies := (
+                  Some (
+                    (
+                      read_ci_scan_dependencies
+                    ) p lb
+                  )
+                );
+              )
+            | 3 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_dependency_parser_errors := (
+                  Some (
+                    (
+                      read__dependency_parser_error_list
+                    ) p lb
+                  )
+                );
+              )
+            | 4 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_task_id := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
+                );
+              )
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            exit_code = (match !field_exit_code with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "exit_code");
+            stats = (match !field_stats with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "stats");
+            dependencies = !field_dependencies;
+            dependency_parser_errors = !field_dependency_parser_errors;
+            task_id = !field_task_id;
+          }
+         : ci_scan_complete)
+      )
+)
+let ci_scan_complete_of_string s =
+  read_ci_scan_complete (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -9615,44 +9615,6 @@ let read_error_span = (
 )
 let error_span_of_string s =
   read_error_span (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__string_nullable = (
-  Atdgen_runtime.Oj_run.write_nullable (
-    Yojson.Safe.write_string
-  )
-)
-let string_of__string_nullable ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__string_nullable ob x;
-  Buffer.contents ob
-let read__string_nullable = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    (if Yojson.Safe.read_null_if_possible p lb then None
-    else Some ((
-      Atdgen_runtime.Oj_run.read_string
-    ) p lb) : _ option)
-)
-let _string_nullable_of_string s =
-  read__string_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__int_nullable = (
-  Atdgen_runtime.Oj_run.write_nullable (
-    Yojson.Safe.write_int
-  )
-)
-let string_of__int_nullable ?(len = 1024) x =
-  let ob = Buffer.create len in
-  write__int_nullable ob x;
-  Buffer.contents ob
-let read__int_nullable = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    (if Yojson.Safe.read_null_if_possible p lb then None
-    else Some ((
-      Atdgen_runtime.Oj_run.read_int
-    ) p lb) : _ option)
-)
-let _int_nullable_of_string s =
-  read__int_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_dependency_parser_error : _ -> dependency_parser_error -> _ = (
   fun ob (x : dependency_parser_error) ->
     Buffer.add_char ob '{';
@@ -9684,33 +9646,39 @@ let write_dependency_parser_error : _ -> dependency_parser_error -> _ = (
       Yojson.Safe.write_string
     )
       ob x.reason;
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
-      Buffer.add_string ob "\"line\":";
-    (
-      write__int_nullable
-    )
-      ob x.line;
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
-      Buffer.add_string ob "\"col\":";
-    (
-      write__int_nullable
-    )
-      ob x.col;
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
-      Buffer.add_string ob "\"text\":";
-    (
-      write__string_nullable
-    )
-      ob x.text;
+    (match x.line with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"line\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
+    (match x.col with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"col\":";
+      (
+        Yojson.Safe.write_int
+      )
+        ob x;
+    );
+    (match x.text with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"text\":";
+      (
+        Yojson.Safe.write_string
+      )
+        ob x;
+    );
     Buffer.add_char ob '}';
 )
 let string_of_dependency_parser_error ?(len = 1024) x =
@@ -9829,29 +9797,35 @@ let read_dependency_parser_error = (
               )
             );
           | 3 ->
-            field_line := (
-              Some (
-                (
-                  read__int_nullable
-                ) p lb
-              )
-            );
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_line := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
           | 4 ->
-            field_col := (
-              Some (
-                (
-                  read__int_nullable
-                ) p lb
-              )
-            );
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_col := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_int
+                  ) p lb
+                )
+              );
+            )
           | 5 ->
-            field_text := (
-              Some (
-                (
-                  read__string_nullable
-                ) p lb
-              )
-            );
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_text := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -9958,29 +9932,35 @@ let read_dependency_parser_error = (
                 )
               );
             | 3 ->
-              field_line := (
-                Some (
-                  (
-                    read__int_nullable
-                  ) p lb
-                )
-              );
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_line := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
             | 4 ->
-              field_col := (
-                Some (
-                  (
-                    read__int_nullable
-                  ) p lb
-                )
-              );
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_col := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_int
+                    ) p lb
+                  )
+                );
+              )
             | 5 ->
-              field_text := (
-                Some (
-                  (
-                    read__string_nullable
-                  ) p lb
-                )
-              );
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_text := (
+                  Some (
+                    (
+                      Atdgen_runtime.Oj_run.read_string
+                    ) p lb
+                  )
+                );
+              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -9993,9 +9973,9 @@ let read_dependency_parser_error = (
             path = (match !field_path with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "path");
             parser = (match !field_parser with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "parser");
             reason = (match !field_reason with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "reason");
-            line = (match !field_line with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "line");
-            col = (match !field_col with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "col");
-            text = (match !field_text with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "text");
+            line = !field_line;
+            col = !field_col;
+            text = !field_text;
           }
          : dependency_parser_error)
       )
@@ -16426,6 +16406,25 @@ let read_cli_match_taint_source = (
 )
 let cli_match_taint_source_of_string s =
   read_cli_match_taint_source (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__string_nullable = (
+  Atdgen_runtime.Oj_run.write_nullable (
+    Yojson.Safe.write_string
+  )
+)
+let string_of__string_nullable ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__string_nullable ob x;
+  Buffer.contents ob
+let read__string_nullable = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    (if Yojson.Safe.read_null_if_possible p lb then None
+    else Some ((
+      Atdgen_runtime.Oj_run.read_string
+    ) p lb) : _ option)
+)
+let _string_nullable_of_string s =
+  read__string_nullable (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__finding_list = (
   Atdgen_runtime.Oj_run.write_list (
     write_finding

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -285,7 +285,8 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   path: string;
   parser: sca_parser_name;
   reason: string;
-  position: position option;
+  line: int option;
+  col: int option;
   text: string option
 }
   [@@deriving show]

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -166,7 +166,7 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 }
   [@@deriving show]
 
-type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
+type sca_parser_name = Semgrep_output_v1_t.sca_parser_name [@@deriving show]
 
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
@@ -288,6 +288,7 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   position: position option;
   text: string option
 }
+  [@@deriving show]
 
 type cve_result = Semgrep_output_v1_t.cve_result = {
   url: string;

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -285,8 +285,7 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   path: string;
   parser: sca_parser_name;
   reason: string;
-  line: int option;
-  col: int option;
+  position: position option;
   text: string option
 }
 
@@ -483,7 +482,8 @@ type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
 }
   [@@deriving show]
 
-type ci_scan_complete = Semgrep_output_v1_t.ci_scan_complete = {
+type ci_scan_complete_response =
+  Semgrep_output_v1_t.ci_scan_complete_response = {
   exit_code: int;
   stats: ci_scan_complete_stats;
   dependencies: ci_scan_dependencies option;
@@ -1732,23 +1732,23 @@ val ci_scan_complete_stats_of_string :
   string -> ci_scan_complete_stats
   (** Deserialize JSON data of type {!type:ci_scan_complete_stats}. *)
 
-val write_ci_scan_complete :
-  Buffer.t -> ci_scan_complete -> unit
-  (** Output a JSON value of type {!type:ci_scan_complete}. *)
+val write_ci_scan_complete_response :
+  Buffer.t -> ci_scan_complete_response -> unit
+  (** Output a JSON value of type {!type:ci_scan_complete_response}. *)
 
-val string_of_ci_scan_complete :
-  ?len:int -> ci_scan_complete -> string
-  (** Serialize a value of type {!type:ci_scan_complete}
+val string_of_ci_scan_complete_response :
+  ?len:int -> ci_scan_complete_response -> string
+  (** Serialize a value of type {!type:ci_scan_complete_response}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
                  Default: 1024. *)
 
-val read_ci_scan_complete :
-  Yojson.Safe.lexer_state -> Lexing.lexbuf -> ci_scan_complete
-  (** Input JSON data of type {!type:ci_scan_complete}. *)
+val read_ci_scan_complete_response :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> ci_scan_complete_response
+  (** Input JSON data of type {!type:ci_scan_complete_response}. *)
 
-val ci_scan_complete_of_string :
-  string -> ci_scan_complete
-  (** Deserialize JSON data of type {!type:ci_scan_complete}. *)
+val ci_scan_complete_response_of_string :
+  string -> ci_scan_complete_response
+  (** Deserialize JSON data of type {!type:ci_scan_complete_response}. *)
 

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -166,6 +166,8 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 }
   [@@deriving show]
 
+type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
+
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
@@ -210,6 +212,14 @@ type rule_id_and_engine_kind = Semgrep_output_v1_t.rule_id_and_engine_kind
 type position_bis = Semgrep_output_v1_t.position_bis = {
   line: int;
   col: int
+}
+  [@@deriving show]
+
+type parsing_stats = Semgrep_output_v1_t.parsing_stats = {
+  targets_parsed: int;
+  num_targets: int;
+  bytes_parsed: int;
+  num_bytes: int
 }
   [@@deriving show]
 
@@ -270,6 +280,15 @@ type error_span = Semgrep_output_v1_t.error_span = {
   context_end: position_bis option option
 }
   [@@deriving show]
+
+type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
+  path: string;
+  parser: sca_parser_name;
+  reason: string;
+  line: int option;
+  col: int option;
+  text: string option
+}
 
 type cve_result = Semgrep_output_v1_t.cve_result = {
   url: string;
@@ -447,6 +466,29 @@ type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   searched_paths: string list;
   renamed_paths: string list;
   rule_ids: string list
+}
+  [@@deriving show]
+
+type ci_scan_dependencies = Semgrep_output_v1_t.ci_scan_dependencies
+  [@@deriving show]
+
+type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
+  findings: int;
+  errors: cli_error list;
+  total_time: float;
+  unsupported_exts: (string * int) list;
+  lockfile_scan_info: (string * int) list;
+  parse_rate: (string * parsing_stats) list;
+  engine_requested: string option
+}
+  [@@deriving show]
+
+type ci_scan_complete = Semgrep_output_v1_t.ci_scan_complete = {
+  exit_code: int;
+  stats: ci_scan_complete_stats;
+  dependencies: ci_scan_dependencies option;
+  dependency_parser_errors: dependency_parser_error list option;
+  task_id: string option
 }
   [@@deriving show]
 
@@ -950,6 +992,26 @@ val skipped_rule_of_string :
   string -> skipped_rule
   (** Deserialize JSON data of type {!type:skipped_rule}. *)
 
+val write_sca_parser_name :
+  Buffer.t -> sca_parser_name -> unit
+  (** Output a JSON value of type {!type:sca_parser_name}. *)
+
+val string_of_sca_parser_name :
+  ?len:int -> sca_parser_name -> string
+  (** Serialize a value of type {!type:sca_parser_name}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_sca_parser_name :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> sca_parser_name
+  (** Input JSON data of type {!type:sca_parser_name}. *)
+
+val sca_parser_name_of_string :
+  string -> sca_parser_name
+  (** Deserialize JSON data of type {!type:sca_parser_name}. *)
+
 val write_ecosystem :
   Buffer.t -> ecosystem -> unit
   (** Output a JSON value of type {!type:ecosystem}. *)
@@ -1110,6 +1172,26 @@ val position_bis_of_string :
   string -> position_bis
   (** Deserialize JSON data of type {!type:position_bis}. *)
 
+val write_parsing_stats :
+  Buffer.t -> parsing_stats -> unit
+  (** Output a JSON value of type {!type:parsing_stats}. *)
+
+val string_of_parsing_stats :
+  ?len:int -> parsing_stats -> string
+  (** Serialize a value of type {!type:parsing_stats}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_parsing_stats :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> parsing_stats
+  (** Input JSON data of type {!type:parsing_stats}. *)
+
+val parsing_stats_of_string :
+  string -> parsing_stats
+  (** Deserialize JSON data of type {!type:parsing_stats}. *)
+
 val write_fix_regex :
   Buffer.t -> fix_regex -> unit
   (** Output a JSON value of type {!type:fix_regex}. *)
@@ -1209,6 +1291,26 @@ val read_error_span :
 val error_span_of_string :
   string -> error_span
   (** Deserialize JSON data of type {!type:error_span}. *)
+
+val write_dependency_parser_error :
+  Buffer.t -> dependency_parser_error -> unit
+  (** Output a JSON value of type {!type:dependency_parser_error}. *)
+
+val string_of_dependency_parser_error :
+  ?len:int -> dependency_parser_error -> string
+  (** Serialize a value of type {!type:dependency_parser_error}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_dependency_parser_error :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> dependency_parser_error
+  (** Input JSON data of type {!type:dependency_parser_error}. *)
+
+val dependency_parser_error_of_string :
+  string -> dependency_parser_error
+  (** Deserialize JSON data of type {!type:dependency_parser_error}. *)
 
 val write_cve_result :
   Buffer.t -> cve_result -> unit
@@ -1589,4 +1691,64 @@ val read_ci_scan_results :
 val ci_scan_results_of_string :
   string -> ci_scan_results
   (** Deserialize JSON data of type {!type:ci_scan_results}. *)
+
+val write_ci_scan_dependencies :
+  Buffer.t -> ci_scan_dependencies -> unit
+  (** Output a JSON value of type {!type:ci_scan_dependencies}. *)
+
+val string_of_ci_scan_dependencies :
+  ?len:int -> ci_scan_dependencies -> string
+  (** Serialize a value of type {!type:ci_scan_dependencies}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_ci_scan_dependencies :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> ci_scan_dependencies
+  (** Input JSON data of type {!type:ci_scan_dependencies}. *)
+
+val ci_scan_dependencies_of_string :
+  string -> ci_scan_dependencies
+  (** Deserialize JSON data of type {!type:ci_scan_dependencies}. *)
+
+val write_ci_scan_complete_stats :
+  Buffer.t -> ci_scan_complete_stats -> unit
+  (** Output a JSON value of type {!type:ci_scan_complete_stats}. *)
+
+val string_of_ci_scan_complete_stats :
+  ?len:int -> ci_scan_complete_stats -> string
+  (** Serialize a value of type {!type:ci_scan_complete_stats}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_ci_scan_complete_stats :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> ci_scan_complete_stats
+  (** Input JSON data of type {!type:ci_scan_complete_stats}. *)
+
+val ci_scan_complete_stats_of_string :
+  string -> ci_scan_complete_stats
+  (** Deserialize JSON data of type {!type:ci_scan_complete_stats}. *)
+
+val write_ci_scan_complete :
+  Buffer.t -> ci_scan_complete -> unit
+  (** Output a JSON value of type {!type:ci_scan_complete}. *)
+
+val string_of_ci_scan_complete :
+  ?len:int -> ci_scan_complete -> string
+  (** Serialize a value of type {!type:ci_scan_complete}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_ci_scan_complete :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> ci_scan_complete
+  (** Input JSON data of type {!type:ci_scan_complete}. *)
+
+val ci_scan_complete_of_string :
+  string -> ci_scan_complete
+  (** Deserialize JSON data of type {!type:ci_scan_complete}. *)
 


### PR DESCRIPTION
All the optional fields are new since `0.123.0`


0.123.0 data: https://github.com/returntocorp/semgrep/blob/084ff5f16866ab66337655dbc06672e05d3089dc/cli/src/semgrep/app/scans.py#L301

Current data: https://github.com/returntocorp/semgrep/blob/develop/cli/src/semgrep/app/scans.py#L320

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
