### PR TITLE
chore: Add contribution model

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -464,7 +464,6 @@ type core_match_results
   (* since semgrep 0.109? *)
   ?explanations: matching_explanation list option;
 
-
   stats: core_stats;
   (* LATER: rename timing *)
   ?time: core_timing option;
@@ -713,6 +712,17 @@ type cli_timing <ocaml attr="deriving show"> = {
     ?max_memory_bytes : int option;
   }
 
+type contribution <ocaml attr="deriving show"> = {
+    commit_hash: string;
+    commit_timestamp: string;
+    commit_author_name: string;
+    commit_author_email: string;
+}
+
+type contributions <ocaml attr="deriving show"> = {
+    contributions: contribution list;
+}
+
 (* LATER: should just use rule_id *)
 type rule_id_dict <ocaml attr="deriving show"> = {
   id: rule_id;
@@ -816,6 +826,7 @@ type ci_scan_results <ocaml attr="deriving show"> = {
    searched_paths: string list;
    renamed_paths: string list;
    rule_ids: string list;
+   ?contributions: contributions option;
 }
 
 

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -712,11 +712,18 @@ type cli_timing <ocaml attr="deriving show"> = {
     ?max_memory_bytes : int option;
   }
 
+(* 
+ * https://semgrep.dev/docs/usage-limits
+ *)
+type contributor <ocaml attr="deriving show"> = {
+    commit_author_name: string;
+    commit_author_email: string;
+}
+
 type contribution <ocaml attr="deriving show"> = {
     commit_hash: string;
     commit_timestamp: string;
-    commit_author_name: string;
-    commit_author_email: string;
+    contributor: contributor;
 }
 
 type contributions <ocaml attr="deriving show"> = {
@@ -826,6 +833,7 @@ type ci_scan_results <ocaml attr="deriving show"> = {
    searched_paths: string list;
    renamed_paths: string list;
    rule_ids: string list;
+   (* since semgrep 1.34.0 *)
    ?contributions: contributions option;
 }
 

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -612,6 +612,29 @@
         "max_memory_bytes": { "type": "integer" }
       }
     },
+    "contribution": {
+      "type": "object",
+      "required": [
+        "commit_hash", "commit_timestamp", "commit_author_name",
+        "commit_author_email"
+      ],
+      "properties": {
+        "commit_hash": { "type": "string" },
+        "commit_timestamp": { "type": "string" },
+        "commit_author_name": { "type": "string" },
+        "commit_author_email": { "type": "string" }
+      }
+    },
+    "contributions": {
+      "type": "object",
+      "required": [ "contributions" ],
+      "properties": {
+        "contributions": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/contribution" }
+        }
+      }
+    },
     "rule_id_dict": {
       "type": "object",
       "required": [ "id" ],
@@ -718,7 +741,8 @@
         "token": { "type": [ "string", "null" ] },
         "searched_paths": { "type": "array", "items": { "type": "string" } },
         "renamed_paths": { "type": "array", "items": { "type": "string" } },
-        "rule_ids": { "type": "array", "items": { "type": "string" } }
+        "rule_ids": { "type": "array", "items": { "type": "string" } },
+        "contributions": { "$ref": "#/definitions/contributions" }
       }
     },
     "finding_hashes": {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -612,17 +612,21 @@
         "max_memory_bytes": { "type": "integer" }
       }
     },
+    "contributor": {
+      "type": "object",
+      "required": [ "commit_author_name", "commit_author_email" ],
+      "properties": {
+        "commit_author_name": { "type": "string" },
+        "commit_author_email": { "type": "string" }
+      }
+    },
     "contribution": {
       "type": "object",
-      "required": [
-        "commit_hash", "commit_timestamp", "commit_author_name",
-        "commit_author_email"
-      ],
+      "required": [ "commit_hash", "commit_timestamp", "contributor" ],
       "properties": {
         "commit_hash": { "type": "string" },
         "commit_timestamp": { "type": "string" },
-        "commit_author_name": { "type": "string" },
-        "commit_author_email": { "type": "string" }
+        "contributor": { "$ref": "#/definitions/contributor" }
       }
     },
     "contributions": {

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2979,6 +2979,71 @@ class CoreMatchResults:
 
 
 @dataclass
+class Contribution:
+    """Original type: contribution = { ... }"""
+
+    commit_hash: str
+    commit_timestamp: str
+    commit_author_name: str
+    commit_author_email: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Contribution':
+        if isinstance(x, dict):
+            return cls(
+                commit_hash=_atd_read_string(x['commit_hash']) if 'commit_hash' in x else _atd_missing_json_field('Contribution', 'commit_hash'),
+                commit_timestamp=_atd_read_string(x['commit_timestamp']) if 'commit_timestamp' in x else _atd_missing_json_field('Contribution', 'commit_timestamp'),
+                commit_author_name=_atd_read_string(x['commit_author_name']) if 'commit_author_name' in x else _atd_missing_json_field('Contribution', 'commit_author_name'),
+                commit_author_email=_atd_read_string(x['commit_author_email']) if 'commit_author_email' in x else _atd_missing_json_field('Contribution', 'commit_author_email'),
+            )
+        else:
+            _atd_bad_json('Contribution', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['commit_hash'] = _atd_write_string(self.commit_hash)
+        res['commit_timestamp'] = _atd_write_string(self.commit_timestamp)
+        res['commit_author_name'] = _atd_write_string(self.commit_author_name)
+        res['commit_author_email'] = _atd_write_string(self.commit_author_email)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Contribution':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Contributions:
+    """Original type: contributions = { ... }"""
+
+    contributions: List[Contribution]
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Contributions':
+        if isinstance(x, dict):
+            return cls(
+                contributions=_atd_read_list(Contribution.from_json)(x['contributions']) if 'contributions' in x else _atd_missing_json_field('Contributions', 'contributions'),
+            )
+        else:
+            _atd_bad_json('Contributions', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['contributions'] = _atd_write_list((lambda x: x.to_json()))(self.contributions)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Contributions':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class CliTargetTimes:
     """Original type: cli_target_times = { ... }"""
 
@@ -3446,6 +3511,7 @@ class CiScanResults:
     searched_paths: List[str]
     renamed_paths: List[str]
     rule_ids: List[str]
+    contributions: Optional[Contributions] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CiScanResults':
@@ -3457,6 +3523,7 @@ class CiScanResults:
                 searched_paths=_atd_read_list(_atd_read_string)(x['searched_paths']) if 'searched_paths' in x else _atd_missing_json_field('CiScanResults', 'searched_paths'),
                 renamed_paths=_atd_read_list(_atd_read_string)(x['renamed_paths']) if 'renamed_paths' in x else _atd_missing_json_field('CiScanResults', 'renamed_paths'),
                 rule_ids=_atd_read_list(_atd_read_string)(x['rule_ids']) if 'rule_ids' in x else _atd_missing_json_field('CiScanResults', 'rule_ids'),
+                contributions=Contributions.from_json(x['contributions']) if 'contributions' in x else None,
             )
         else:
             _atd_bad_json('CiScanResults', x)
@@ -3469,6 +3536,8 @@ class CiScanResults:
         res['searched_paths'] = _atd_write_list(_atd_write_string)(self.searched_paths)
         res['renamed_paths'] = _atd_write_list(_atd_write_string)(self.renamed_paths)
         res['rule_ids'] = _atd_write_list(_atd_write_string)(self.rule_ids)
+        if self.contributions is not None:
+            res['contributions'] = (lambda x: x.to_json())(self.contributions)
         return res
 
     @classmethod

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2979,13 +2979,43 @@ class CoreMatchResults:
 
 
 @dataclass
+class Contributor:
+    """Original type: contributor = { ... }"""
+
+    commit_author_name: str
+    commit_author_email: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Contributor':
+        if isinstance(x, dict):
+            return cls(
+                commit_author_name=_atd_read_string(x['commit_author_name']) if 'commit_author_name' in x else _atd_missing_json_field('Contributor', 'commit_author_name'),
+                commit_author_email=_atd_read_string(x['commit_author_email']) if 'commit_author_email' in x else _atd_missing_json_field('Contributor', 'commit_author_email'),
+            )
+        else:
+            _atd_bad_json('Contributor', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['commit_author_name'] = _atd_write_string(self.commit_author_name)
+        res['commit_author_email'] = _atd_write_string(self.commit_author_email)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Contributor':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class Contribution:
     """Original type: contribution = { ... }"""
 
     commit_hash: str
     commit_timestamp: str
-    commit_author_name: str
-    commit_author_email: str
+    contributor: Contributor
 
     @classmethod
     def from_json(cls, x: Any) -> 'Contribution':
@@ -2993,8 +3023,7 @@ class Contribution:
             return cls(
                 commit_hash=_atd_read_string(x['commit_hash']) if 'commit_hash' in x else _atd_missing_json_field('Contribution', 'commit_hash'),
                 commit_timestamp=_atd_read_string(x['commit_timestamp']) if 'commit_timestamp' in x else _atd_missing_json_field('Contribution', 'commit_timestamp'),
-                commit_author_name=_atd_read_string(x['commit_author_name']) if 'commit_author_name' in x else _atd_missing_json_field('Contribution', 'commit_author_name'),
-                commit_author_email=_atd_read_string(x['commit_author_email']) if 'commit_author_email' in x else _atd_missing_json_field('Contribution', 'commit_author_email'),
+                contributor=Contributor.from_json(x['contributor']) if 'contributor' in x else _atd_missing_json_field('Contribution', 'contributor'),
             )
         else:
             _atd_bad_json('Contribution', x)
@@ -3003,8 +3032,7 @@ class Contribution:
         res: Dict[str, Any] = {}
         res['commit_hash'] = _atd_write_string(self.commit_hash)
         res['commit_timestamp'] = _atd_write_string(self.commit_timestamp)
-        res['commit_author_name'] = _atd_write_string(self.commit_author_name)
-        res['commit_author_email'] = _atd_write_string(self.commit_author_email)
+        res['contributor'] = (lambda x: x.to_json())(self.contributor)
         return res
 
     @classmethod

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -327,6 +327,17 @@ export type CliTiming = {
   max_memory_bytes?: number /*int*/;
 }
 
+export type Contribution = {
+  commit_hash: string;
+  commit_timestamp: string;
+  commit_author_name: string;
+  commit_author_email: string;
+}
+
+export type Contributions = {
+  contributions: Contribution[];
+}
+
 export type RuleIdDict = {
   id: RuleId;
 }
@@ -389,6 +400,7 @@ export type CiScanResults = {
   searched_paths: string[];
   renamed_paths: string[];
   rule_ids: string[];
+  contributions?: Contributions;
 }
 
 export type FindingHashes = {
@@ -1390,6 +1402,36 @@ export function readCliTiming(x: any, context: any = x): CliTiming {
   };
 }
 
+export function writeContribution(x: Contribution, context: any = x): any {
+  return {
+    'commit_hash': _atd_write_required_field('Contribution', 'commit_hash', _atd_write_string, x.commit_hash, x),
+    'commit_timestamp': _atd_write_required_field('Contribution', 'commit_timestamp', _atd_write_string, x.commit_timestamp, x),
+    'commit_author_name': _atd_write_required_field('Contribution', 'commit_author_name', _atd_write_string, x.commit_author_name, x),
+    'commit_author_email': _atd_write_required_field('Contribution', 'commit_author_email', _atd_write_string, x.commit_author_email, x),
+  };
+}
+
+export function readContribution(x: any, context: any = x): Contribution {
+  return {
+    commit_hash: _atd_read_required_field('Contribution', 'commit_hash', _atd_read_string, x['commit_hash'], x),
+    commit_timestamp: _atd_read_required_field('Contribution', 'commit_timestamp', _atd_read_string, x['commit_timestamp'], x),
+    commit_author_name: _atd_read_required_field('Contribution', 'commit_author_name', _atd_read_string, x['commit_author_name'], x),
+    commit_author_email: _atd_read_required_field('Contribution', 'commit_author_email', _atd_read_string, x['commit_author_email'], x),
+  };
+}
+
+export function writeContributions(x: Contributions, context: any = x): any {
+  return {
+    'contributions': _atd_write_required_field('Contributions', 'contributions', _atd_write_array(writeContribution), x.contributions, x),
+  };
+}
+
+export function readContributions(x: any, context: any = x): Contributions {
+  return {
+    contributions: _atd_read_required_field('Contributions', 'contributions', _atd_read_array(readContribution), x['contributions'], x),
+  };
+}
+
 export function writeRuleIdDict(x: RuleIdDict, context: any = x): any {
   return {
     'id': _atd_write_required_field('RuleIdDict', 'id', writeRuleId, x.id, x),
@@ -1570,6 +1612,7 @@ export function writeCiScanResults(x: CiScanResults, context: any = x): any {
     'searched_paths': _atd_write_required_field('CiScanResults', 'searched_paths', _atd_write_array(_atd_write_string), x.searched_paths, x),
     'renamed_paths': _atd_write_required_field('CiScanResults', 'renamed_paths', _atd_write_array(_atd_write_string), x.renamed_paths, x),
     'rule_ids': _atd_write_required_field('CiScanResults', 'rule_ids', _atd_write_array(_atd_write_string), x.rule_ids, x),
+    'contributions': _atd_write_optional_field(writeContributions, x.contributions, x),
   };
 }
 
@@ -1581,6 +1624,7 @@ export function readCiScanResults(x: any, context: any = x): CiScanResults {
     searched_paths: _atd_read_required_field('CiScanResults', 'searched_paths', _atd_read_array(_atd_read_string), x['searched_paths'], x),
     renamed_paths: _atd_read_required_field('CiScanResults', 'renamed_paths', _atd_read_array(_atd_read_string), x['renamed_paths'], x),
     rule_ids: _atd_read_required_field('CiScanResults', 'rule_ids', _atd_read_array(_atd_read_string), x['rule_ids'], x),
+    contributions: _atd_read_optional_field(readContributions, x['contributions'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -327,11 +327,15 @@ export type CliTiming = {
   max_memory_bytes?: number /*int*/;
 }
 
+export type Contributor = {
+  commit_author_name: string;
+  commit_author_email: string;
+}
+
 export type Contribution = {
   commit_hash: string;
   commit_timestamp: string;
-  commit_author_name: string;
-  commit_author_email: string;
+  contributor: Contributor;
 }
 
 export type Contributions = {
@@ -1402,12 +1406,25 @@ export function readCliTiming(x: any, context: any = x): CliTiming {
   };
 }
 
+export function writeContributor(x: Contributor, context: any = x): any {
+  return {
+    'commit_author_name': _atd_write_required_field('Contributor', 'commit_author_name', _atd_write_string, x.commit_author_name, x),
+    'commit_author_email': _atd_write_required_field('Contributor', 'commit_author_email', _atd_write_string, x.commit_author_email, x),
+  };
+}
+
+export function readContributor(x: any, context: any = x): Contributor {
+  return {
+    commit_author_name: _atd_read_required_field('Contributor', 'commit_author_name', _atd_read_string, x['commit_author_name'], x),
+    commit_author_email: _atd_read_required_field('Contributor', 'commit_author_email', _atd_read_string, x['commit_author_email'], x),
+  };
+}
+
 export function writeContribution(x: Contribution, context: any = x): any {
   return {
     'commit_hash': _atd_write_required_field('Contribution', 'commit_hash', _atd_write_string, x.commit_hash, x),
     'commit_timestamp': _atd_write_required_field('Contribution', 'commit_timestamp', _atd_write_string, x.commit_timestamp, x),
-    'commit_author_name': _atd_write_required_field('Contribution', 'commit_author_name', _atd_write_string, x.commit_author_name, x),
-    'commit_author_email': _atd_write_required_field('Contribution', 'commit_author_email', _atd_write_string, x.commit_author_email, x),
+    'contributor': _atd_write_required_field('Contribution', 'contributor', writeContributor, x.contributor, x),
   };
 }
 
@@ -1415,8 +1432,7 @@ export function readContribution(x: any, context: any = x): Contribution {
   return {
     commit_hash: _atd_read_required_field('Contribution', 'commit_hash', _atd_read_string, x['commit_hash'], x),
     commit_timestamp: _atd_read_required_field('Contribution', 'commit_timestamp', _atd_read_string, x['commit_timestamp'], x),
-    commit_author_name: _atd_read_required_field('Contribution', 'commit_author_name', _atd_read_string, x['commit_author_name'], x),
-    commit_author_email: _atd_read_required_field('Contribution', 'commit_author_email', _atd_read_string, x['commit_author_email'], x),
+    contributor: _atd_read_required_field('Contribution', 'contributor', readContributor, x['contributor'], x),
   };
 }
 

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -340,11 +340,16 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
 }
   [@@deriving show]
 
+type contributor = Semgrep_output_v1_t.contributor = {
+  commit_author_name: string;
+  commit_author_email: string
+}
+  [@@deriving show]
+
 type contribution = Semgrep_output_v1_t.contribution = {
   commit_hash: string;
   commit_timestamp: string;
-  commit_author_name: string;
-  commit_author_email: string
+  contributor: contributor
 }
   [@@deriving show]
 
@@ -11310,6 +11315,159 @@ let read_core_match_results = (
 )
 let core_match_results_of_string s =
   read_core_match_results (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_contributor : _ -> contributor -> _ = (
+  fun ob (x : contributor) ->
+    Buffer.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"commit_author_name\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.commit_author_name;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"commit_author_email\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.commit_author_email;
+    Buffer.add_char ob '}';
+)
+let string_of_contributor ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_contributor ob x;
+  Buffer.contents ob
+let read_contributor = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_commit_author_name = ref (None) in
+    let field_commit_author_email = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+          match len with
+            | 18 -> (
+                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'n' && String.unsafe_get s (pos+15) = 'a' && String.unsafe_get s (pos+16) = 'm' && String.unsafe_get s (pos+17) = 'e' then (
+                  0
+                )
+                else (
+                  -1
+                )
+              )
+            | 19 -> (
+                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 'm' && String.unsafe_get s (pos+16) = 'a' && String.unsafe_get s (pos+17) = 'i' && String.unsafe_get s (pos+18) = 'l' then (
+                  1
+                )
+                else (
+                  -1
+                )
+              )
+            | _ -> (
+                -1
+              )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_commit_author_name := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_commit_author_email := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+            match len with
+              | 18 -> (
+                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'n' && String.unsafe_get s (pos+15) = 'a' && String.unsafe_get s (pos+16) = 'm' && String.unsafe_get s (pos+17) = 'e' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 19 -> (
+                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 'm' && String.unsafe_get s (pos+16) = 'a' && String.unsafe_get s (pos+17) = 'i' && String.unsafe_get s (pos+18) = 'l' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_commit_author_name := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_commit_author_email := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            commit_author_name = (match !field_commit_author_name with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "commit_author_name");
+            commit_author_email = (match !field_commit_author_email with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "commit_author_email");
+          }
+         : contributor)
+      )
+)
+let contributor_of_string s =
+  read_contributor (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_contribution : _ -> contribution -> _ = (
   fun ob (x : contribution) ->
     Buffer.add_char ob '{';
@@ -11336,20 +11494,11 @@ let write_contribution : _ -> contribution -> _ = (
       is_first := false
     else
       Buffer.add_char ob ',';
-      Buffer.add_string ob "\"commit_author_name\":";
+      Buffer.add_string ob "\"contributor\":";
     (
-      Yojson.Safe.write_string
+      write_contributor
     )
-      ob x.commit_author_name;
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
-      Buffer.add_string ob "\"commit_author_email\":";
-    (
-      Yojson.Safe.write_string
-    )
-      ob x.commit_author_email;
+      ob x.contributor;
     Buffer.add_char ob '}';
 )
 let string_of_contribution ?(len = 1024) x =
@@ -11362,8 +11511,7 @@ let read_contribution = (
     Yojson.Safe.read_lcurl p lb;
     let field_commit_hash = ref (None) in
     let field_commit_timestamp = ref (None) in
-    let field_commit_author_name = ref (None) in
-    let field_commit_author_email = ref (None) in
+    let field_contributor = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -11374,8 +11522,27 @@ let read_contribution = (
             invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
           match len with
             | 11 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'h' then (
-                  0
+                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' then (
+                  match String.unsafe_get s (pos+2) with
+                    | 'm' -> (
+                        if String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'h' then (
+                          0
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | 'n' -> (
+                        if String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'r' then (
+                          2
+                        )
+                        else (
+                          -1
+                        )
+                      )
+                    | _ -> (
+                        -1
+                      )
                 )
                 else (
                   -1
@@ -11384,22 +11551,6 @@ let read_contribution = (
             | 16 -> (
                 if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'm' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 's' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'a' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'p' then (
                   1
-                )
-                else (
-                  -1
-                )
-              )
-            | 18 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'n' && String.unsafe_get s (pos+15) = 'a' && String.unsafe_get s (pos+16) = 'm' && String.unsafe_get s (pos+17) = 'e' then (
-                  2
-                )
-                else (
-                  -1
-                )
-              )
-            | 19 -> (
-                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 'm' && String.unsafe_get s (pos+16) = 'a' && String.unsafe_get s (pos+17) = 'i' && String.unsafe_get s (pos+18) = 'l' then (
-                  3
                 )
                 else (
                   -1
@@ -11430,18 +11581,10 @@ let read_contribution = (
               )
             );
           | 2 ->
-            field_commit_author_name := (
+            field_contributor := (
               Some (
                 (
-                  Atdgen_runtime.Oj_run.read_string
-                ) p lb
-              )
-            );
-          | 3 ->
-            field_commit_author_email := (
-              Some (
-                (
-                  Atdgen_runtime.Oj_run.read_string
+                  read_contributor
                 ) p lb
               )
             );
@@ -11459,8 +11602,27 @@ let read_contribution = (
               invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
             match len with
               | 11 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'h' then (
-                    0
+                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' then (
+                    match String.unsafe_get s (pos+2) with
+                      | 'm' -> (
+                          if String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'h' && String.unsafe_get s (pos+8) = 'a' && String.unsafe_get s (pos+9) = 's' && String.unsafe_get s (pos+10) = 'h' then (
+                            0
+                          )
+                          else (
+                            -1
+                          )
+                        )
+                      | 'n' -> (
+                          if String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'o' && String.unsafe_get s (pos+10) = 'r' then (
+                            2
+                          )
+                          else (
+                            -1
+                          )
+                        )
+                      | _ -> (
+                          -1
+                        )
                   )
                   else (
                     -1
@@ -11469,22 +11631,6 @@ let read_contribution = (
               | 16 -> (
                   if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 't' && String.unsafe_get s (pos+8) = 'i' && String.unsafe_get s (pos+9) = 'm' && String.unsafe_get s (pos+10) = 'e' && String.unsafe_get s (pos+11) = 's' && String.unsafe_get s (pos+12) = 't' && String.unsafe_get s (pos+13) = 'a' && String.unsafe_get s (pos+14) = 'm' && String.unsafe_get s (pos+15) = 'p' then (
                     1
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 18 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'n' && String.unsafe_get s (pos+15) = 'a' && String.unsafe_get s (pos+16) = 'm' && String.unsafe_get s (pos+17) = 'e' then (
-                    2
-                  )
-                  else (
-                    -1
-                  )
-                )
-              | 19 -> (
-                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'm' && String.unsafe_get s (pos+3) = 'm' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 't' && String.unsafe_get s (pos+6) = '_' && String.unsafe_get s (pos+7) = 'a' && String.unsafe_get s (pos+8) = 'u' && String.unsafe_get s (pos+9) = 't' && String.unsafe_get s (pos+10) = 'h' && String.unsafe_get s (pos+11) = 'o' && String.unsafe_get s (pos+12) = 'r' && String.unsafe_get s (pos+13) = '_' && String.unsafe_get s (pos+14) = 'e' && String.unsafe_get s (pos+15) = 'm' && String.unsafe_get s (pos+16) = 'a' && String.unsafe_get s (pos+17) = 'i' && String.unsafe_get s (pos+18) = 'l' then (
-                    3
                   )
                   else (
                     -1
@@ -11515,18 +11661,10 @@ let read_contribution = (
                 )
               );
             | 2 ->
-              field_commit_author_name := (
+              field_contributor := (
                 Some (
                   (
-                    Atdgen_runtime.Oj_run.read_string
-                  ) p lb
-                )
-              );
-            | 3 ->
-              field_commit_author_email := (
-                Some (
-                  (
-                    Atdgen_runtime.Oj_run.read_string
+                    read_contributor
                   ) p lb
                 )
               );
@@ -11541,8 +11679,7 @@ let read_contribution = (
           {
             commit_hash = (match !field_commit_hash with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "commit_hash");
             commit_timestamp = (match !field_commit_timestamp with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "commit_timestamp");
-            commit_author_name = (match !field_commit_author_name with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "commit_author_name");
-            commit_author_email = (match !field_commit_author_email with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "commit_author_email");
+            contributor = (match !field_contributor with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "contributor");
           }
          : contribution)
       )

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -340,6 +340,19 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
 }
   [@@deriving show]
 
+type contribution = Semgrep_output_v1_t.contribution = {
+  commit_hash: string;
+  commit_timestamp: string;
+  commit_author_name: string;
+  commit_author_email: string
+}
+  [@@deriving show]
+
+type contributions = Semgrep_output_v1_t.contributions = {
+  contributions: contribution list
+}
+  [@@deriving show]
+
 type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   path: fpath;
   num_bytes: int;
@@ -446,7 +459,8 @@ type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   token: string option;
   searched_paths: string list;
   renamed_paths: string list;
-  rule_ids: string list
+  rule_ids: string list;
+  contributions: contributions option
 }
   [@@deriving show]
 
@@ -1369,6 +1383,46 @@ val read_core_match_results :
 val core_match_results_of_string :
   string -> core_match_results
   (** Deserialize JSON data of type {!type:core_match_results}. *)
+
+val write_contribution :
+  Buffer.t -> contribution -> unit
+  (** Output a JSON value of type {!type:contribution}. *)
+
+val string_of_contribution :
+  ?len:int -> contribution -> string
+  (** Serialize a value of type {!type:contribution}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_contribution :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> contribution
+  (** Input JSON data of type {!type:contribution}. *)
+
+val contribution_of_string :
+  string -> contribution
+  (** Deserialize JSON data of type {!type:contribution}. *)
+
+val write_contributions :
+  Buffer.t -> contributions -> unit
+  (** Output a JSON value of type {!type:contributions}. *)
+
+val string_of_contributions :
+  ?len:int -> contributions -> string
+  (** Serialize a value of type {!type:contributions}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_contributions :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> contributions
+  (** Input JSON data of type {!type:contributions}. *)
+
+val contributions_of_string :
+  string -> contributions
+  (** Deserialize JSON data of type {!type:contributions}. *)
 
 val write_cli_target_times :
   Buffer.t -> cli_target_times -> unit

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -340,11 +340,16 @@ type core_match_results = Semgrep_output_v1_t.core_match_results = {
 }
   [@@deriving show]
 
+type contributor = Semgrep_output_v1_t.contributor = {
+  commit_author_name: string;
+  commit_author_email: string
+}
+  [@@deriving show]
+
 type contribution = Semgrep_output_v1_t.contribution = {
   commit_hash: string;
   commit_timestamp: string;
-  commit_author_name: string;
-  commit_author_email: string
+  contributor: contributor
 }
   [@@deriving show]
 
@@ -1383,6 +1388,26 @@ val read_core_match_results :
 val core_match_results_of_string :
   string -> core_match_results
   (** Deserialize JSON data of type {!type:core_match_results}. *)
+
+val write_contributor :
+  Buffer.t -> contributor -> unit
+  (** Output a JSON value of type {!type:contributor}. *)
+
+val string_of_contributor :
+  ?len:int -> contributor -> string
+  (** Serialize a value of type {!type:contributor}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_contributor :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> contributor
+  (** Input JSON data of type {!type:contributor}. *)
+
+val contributor_of_string :
+  string -> contributor
+  (** Deserialize JSON data of type {!type:contributor}. *)
 
 val write_contribution :
   Buffer.t -> contribution -> unit


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)

For context, [this PR](https://github.com/returntocorp/semgrep/pull/7892) was created a while back to get the "contributions" in a CI scan and upload with the findings/ignores, but it was implemented in python.

I'm translating that logic to semgrep-core so it will be available to both pysemgrep and osemgrep.