### PR TITLE
fix: Change contributions type from struct to list

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -726,9 +726,8 @@ type contribution <ocaml attr="deriving show"> = {
     contributor: contributor;
 }
 
-type contributions <ocaml attr="deriving show"> = {
-    contributions: contribution list;
-}
+type contributions
+  <ocaml attr="deriving show"> = contribution list
 
 (* LATER: should just use rule_id *)
 type rule_id_dict <ocaml attr="deriving show"> = {

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -630,14 +630,8 @@
       }
     },
     "contributions": {
-      "type": "object",
-      "required": [ "contributions" ],
-      "properties": {
-        "contributions": {
-          "type": "array",
-          "items": { "$ref": "#/definitions/contribution" }
-        }
-      }
+      "type": "array",
+      "items": { "$ref": "#/definitions/contribution" }
     },
     "rule_id_dict": {
       "type": "object",

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -3045,23 +3045,16 @@ class Contribution:
 
 @dataclass
 class Contributions:
-    """Original type: contributions = { ... }"""
+    """Original type: contributions"""
 
-    contributions: List[Contribution]
+    value: List[Contribution]
 
     @classmethod
     def from_json(cls, x: Any) -> 'Contributions':
-        if isinstance(x, dict):
-            return cls(
-                contributions=_atd_read_list(Contribution.from_json)(x['contributions']) if 'contributions' in x else _atd_missing_json_field('Contributions', 'contributions'),
-            )
-        else:
-            _atd_bad_json('Contributions', x)
+        return cls(_atd_read_list(Contribution.from_json)(x))
 
     def to_json(self) -> Any:
-        res: Dict[str, Any] = {}
-        res['contributions'] = _atd_write_list((lambda x: x.to_json()))(self.contributions)
-        return res
+        return _atd_write_list((lambda x: x.to_json()))(self.value)
 
     @classmethod
     def from_json_string(cls, x: str) -> 'Contributions':

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -338,9 +338,7 @@ export type Contribution = {
   contributor: Contributor;
 }
 
-export type Contributions = {
-  contributions: Contribution[];
-}
+export type Contributions = Contribution[]
 
 export type RuleIdDict = {
   id: RuleId;
@@ -1437,15 +1435,11 @@ export function readContribution(x: any, context: any = x): Contribution {
 }
 
 export function writeContributions(x: Contributions, context: any = x): any {
-  return {
-    'contributions': _atd_write_required_field('Contributions', 'contributions', _atd_write_array(writeContribution), x.contributions, x),
-  };
+  return _atd_write_array(writeContribution)(x, context);
 }
 
 export function readContributions(x: any, context: any = x): Contributions {
-  return {
-    contributions: _atd_read_required_field('Contributions', 'contributions', _atd_read_array(readContribution), x['contributions'], x),
-  };
+  return _atd_read_array(readContribution)(x, context);
 }
 
 export function writeRuleIdDict(x: RuleIdDict, context: any = x): any {

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -353,10 +353,7 @@ type contribution = Semgrep_output_v1_t.contribution = {
 }
   [@@deriving show]
 
-type contributions = Semgrep_output_v1_t.contributions = {
-  contributions: contribution list
-}
-  [@@deriving show]
+type contributions = Semgrep_output_v1_t.contributions [@@deriving show]
 
 type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   path: fpath;
@@ -11702,101 +11699,15 @@ let read__contribution_list = (
 )
 let _contribution_list_of_string s =
   read__contribution_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write_contributions : _ -> contributions -> _ = (
-  fun ob (x : contributions) ->
-    Buffer.add_char ob '{';
-    let is_first = ref true in
-    if !is_first then
-      is_first := false
-    else
-      Buffer.add_char ob ',';
-      Buffer.add_string ob "\"contributions\":";
-    (
-      write__contribution_list
-    )
-      ob x.contributions;
-    Buffer.add_char ob '}';
+let write_contributions = (
+  write__contribution_list
 )
 let string_of_contributions ?(len = 1024) x =
   let ob = Buffer.create len in
   write_contributions ob x;
   Buffer.contents ob
 let read_contributions = (
-  fun p lb ->
-    Yojson.Safe.read_space p lb;
-    Yojson.Safe.read_lcurl p lb;
-    let field_contributions = ref (None) in
-    try
-      Yojson.Safe.read_space p lb;
-      Yojson.Safe.read_object_end lb;
-      Yojson.Safe.read_space p lb;
-      let f =
-        fun s pos len ->
-          if pos < 0 || len < 0 || pos + len > String.length s then
-            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
-          if len = 13 && String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'i' && String.unsafe_get s (pos+10) = 'o' && String.unsafe_get s (pos+11) = 'n' && String.unsafe_get s (pos+12) = 's' then (
-            0
-          )
-          else (
-            -1
-          )
-      in
-      let i = Yojson.Safe.map_ident p f lb in
-      Atdgen_runtime.Oj_run.read_until_field_value p lb;
-      (
-        match i with
-          | 0 ->
-            field_contributions := (
-              Some (
-                (
-                  read__contribution_list
-                ) p lb
-              )
-            );
-          | _ -> (
-              Yojson.Safe.skip_json p lb
-            )
-      );
-      while true do
-        Yojson.Safe.read_space p lb;
-        Yojson.Safe.read_object_sep p lb;
-        Yojson.Safe.read_space p lb;
-        let f =
-          fun s pos len ->
-            if pos < 0 || len < 0 || pos + len > String.length s then
-              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
-            if len = 13 && String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'o' && String.unsafe_get s (pos+2) = 'n' && String.unsafe_get s (pos+3) = 't' && String.unsafe_get s (pos+4) = 'r' && String.unsafe_get s (pos+5) = 'i' && String.unsafe_get s (pos+6) = 'b' && String.unsafe_get s (pos+7) = 'u' && String.unsafe_get s (pos+8) = 't' && String.unsafe_get s (pos+9) = 'i' && String.unsafe_get s (pos+10) = 'o' && String.unsafe_get s (pos+11) = 'n' && String.unsafe_get s (pos+12) = 's' then (
-              0
-            )
-            else (
-              -1
-            )
-        in
-        let i = Yojson.Safe.map_ident p f lb in
-        Atdgen_runtime.Oj_run.read_until_field_value p lb;
-        (
-          match i with
-            | 0 ->
-              field_contributions := (
-                Some (
-                  (
-                    read__contribution_list
-                  ) p lb
-                )
-              );
-            | _ -> (
-                Yojson.Safe.skip_json p lb
-              )
-        );
-      done;
-      assert false;
-    with Yojson.End_of_object -> (
-        (
-          {
-            contributions = (match !field_contributions with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "contributions");
-          }
-         : contributions)
-      )
+  read__contribution_list
 )
 let contributions_of_string s =
   read_contributions (Yojson.Safe.init_lexer ()) (Lexing.from_string s)

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -353,10 +353,7 @@ type contribution = Semgrep_output_v1_t.contribution = {
 }
   [@@deriving show]
 
-type contributions = Semgrep_output_v1_t.contributions = {
-  contributions: contribution list
-}
-  [@@deriving show]
+type contributions = Semgrep_output_v1_t.contributions [@@deriving show]
 
 type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   path: fpath;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)

## Problem
The contributions type was created as a struct so the output would be in the form of 
```
{
    "contributions": [
        {
            "commit_hash": "9044690c5c36e9228432e1d32b9bff4938338cc8",
            "commit_timestamp": "2023-06-07 22:39:48 -0400",
            "contributor": {
                "commit_author_name": "Zach Yannes",
                "commit_author_email": "zach@semgrep.com"
            }
        },
        {
            "commit_hash": "bb28428c27f34a7ff332f61936c6793be2b8a038",
            "commit_timestamp": "2022-11-08 15:00:56 -0500",
            "contributor": {
                "commit_author_name": "Zach Yannes",
                "commit_author_email": "zach@returntocorp.com"
            }
        },
        {
            "commit_hash": "1d8f8bb1ff3214016f016dc5c439d83c4ffe04c0",
            "commit_timestamp": "2022-09-19 10:42:57 -0400",
            "contributor": {
                "commit_author_name": "Zach Yannes",
                "commit_author_email": "zach@returntocorp.com"
            }
        },
        {
            "commit_hash": "2bd0933b1b3da93ced988ae8580be609dae75233",
            "commit_timestamp": "2023-03-15 14:34:26 +0000",
            "contributor": {
                "commit_author_name": "semgrep.dev on behalf of @zyannes",
                "commit_author_email": "support@r2c.dev"
            }
        }
    ]
}
```

## Solution
Change `contributions` type to a list so it outputs in the form of 
```
[
  {
    "commit_hash": "9044690c5c36e9228432e1d32b9bff4938338cc8",
    "commit_timestamp": "2023-06-07 22:39:48 -0400",
    "contributor": {
      "commit_author_name": "Zach Yannes",
      "commit_author_email": "zach@semgrep.com"
    }
  },
  {
    "commit_hash": "bb28428c27f34a7ff332f61936c6793be2b8a038",
    "commit_timestamp": "2022-11-08 15:00:56 -0500",
    "contributor": {
      "commit_author_name": "Zach Yannes",
      "commit_author_email": "zach@returntocorp.com"
    }
  },
  {
    "commit_hash": "1d8f8bb1ff3214016f016dc5c439d83c4ffe04c0",
    "commit_timestamp": "2022-09-19 10:42:57 -0400",
    "contributor": {
      "commit_author_name": "Zach Yannes",
      "commit_author_email": "zach@returntocorp.com"
    }
  },
  {
    "commit_hash": "2bd0933b1b3da93ced988ae8580be609dae75233",
    "commit_timestamp": "2023-03-15 14:34:26 +0000",
    "contributor": {
      "commit_author_name": "semgrep.dev on behalf of @zyannes",
      "commit_author_email": "support@r2c.dev"
    }
  }
]
```

This way, the `ci_scan_results.contributions` won't include a nested dict `contributions: {"contributions": [...]}`