### PR TITLE
Semgrep Interface Changes for Path to Transitivity (CLI)

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -804,7 +804,7 @@ type dependency_pattern <ocaml attr="deriving show"> = {
   semver_range: string;
 }
 
-type child <ocaml attr="deriving show"> = {
+type dependency_child <ocaml attr="deriving show"> = {
   package: string;
   version: string;
 }
@@ -820,7 +820,8 @@ type found_dependency <ocaml attr="deriving show"> = {
   ?resolved_url: string option;
   transitivity: transitivity;
   ?line_number: int option;
-  ?children: child list option;
+  (* store child dependency information for calculating path to transitivity*)
+  ?children: dependency_child list option;
 }
 
 (*****************************************************************************)

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -804,6 +804,11 @@ type dependency_pattern <ocaml attr="deriving show"> = {
   semver_range: string;
 }
 
+type child <ocaml attr="deriving show"> = {
+  package: string;
+  version: string;
+}
+
 type found_dependency <ocaml attr="deriving show"> = {
   package: string;
   version: string;
@@ -815,6 +820,7 @@ type found_dependency <ocaml attr="deriving show"> = {
   ?resolved_url: string option;
   transitivity: transitivity;
   ?line_number: int option;
+  ?children: child list option;
 }
 
 (*****************************************************************************)

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -700,7 +700,7 @@
         "semver_range": { "type": "string" }
       }
     },
-    "child": {
+    "dependency_child": {
       "type": "object",
       "required": [ "package", "version" ],
       "properties": {
@@ -729,7 +729,7 @@
         "line_number": { "type": "integer" },
         "children": {
           "type": "array",
-          "items": { "$ref": "#/definitions/child" }
+          "items": { "$ref": "#/definitions/dependency_child" }
         }
       }
     },

--- a/semgrep_output_v1.jsonschema
+++ b/semgrep_output_v1.jsonschema
@@ -700,6 +700,14 @@
         "semver_range": { "type": "string" }
       }
     },
+    "child": {
+      "type": "object",
+      "required": [ "package", "version" ],
+      "properties": {
+        "package": { "type": "string" },
+        "version": { "type": "string" }
+      }
+    },
     "found_dependency": {
       "type": "object",
       "required": [
@@ -718,7 +726,11 @@
         },
         "resolved_url": { "type": "string" },
         "transitivity": { "$ref": "#/definitions/transitivity" },
-        "line_number": { "type": "integer" }
+        "line_number": { "type": "integer" },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/child" }
+        }
       }
     },
     "ci_scan_results": {

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -1867,21 +1867,21 @@ class Ecosystem:
 
 
 @dataclass
-class Child:
-    """Original type: child = { ... }"""
+class DependencyChild:
+    """Original type: dependency_child = { ... }"""
 
     package: str
     version: str
 
     @classmethod
-    def from_json(cls, x: Any) -> 'Child':
+    def from_json(cls, x: Any) -> 'DependencyChild':
         if isinstance(x, dict):
             return cls(
-                package=_atd_read_string(x['package']) if 'package' in x else _atd_missing_json_field('Child', 'package'),
-                version=_atd_read_string(x['version']) if 'version' in x else _atd_missing_json_field('Child', 'version'),
+                package=_atd_read_string(x['package']) if 'package' in x else _atd_missing_json_field('DependencyChild', 'package'),
+                version=_atd_read_string(x['version']) if 'version' in x else _atd_missing_json_field('DependencyChild', 'version'),
             )
         else:
-            _atd_bad_json('Child', x)
+            _atd_bad_json('DependencyChild', x)
 
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
@@ -1890,7 +1890,7 @@ class Child:
         return res
 
     @classmethod
-    def from_json_string(cls, x: str) -> 'Child':
+    def from_json_string(cls, x: str) -> 'DependencyChild':
         return cls.from_json(json.loads(x))
 
     def to_json_string(self, **kw: Any) -> str:
@@ -1908,7 +1908,7 @@ class FoundDependency:
     transitivity: Transitivity
     resolved_url: Optional[str] = None
     line_number: Optional[int] = None
-    children: Optional[List[Child]] = None
+    children: Optional[List[DependencyChild]] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'FoundDependency':
@@ -1921,7 +1921,7 @@ class FoundDependency:
                 transitivity=Transitivity.from_json(x['transitivity']) if 'transitivity' in x else _atd_missing_json_field('FoundDependency', 'transitivity'),
                 resolved_url=_atd_read_string(x['resolved_url']) if 'resolved_url' in x else None,
                 line_number=_atd_read_int(x['line_number']) if 'line_number' in x else None,
-                children=_atd_read_list(Child.from_json)(x['children']) if 'children' in x else None,
+                children=_atd_read_list(DependencyChild.from_json)(x['children']) if 'children' in x else None,
             )
         else:
             _atd_bad_json('FoundDependency', x)

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -1867,6 +1867,37 @@ class Ecosystem:
 
 
 @dataclass
+class Child:
+    """Original type: child = { ... }"""
+
+    package: str
+    version: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Child':
+        if isinstance(x, dict):
+            return cls(
+                package=_atd_read_string(x['package']) if 'package' in x else _atd_missing_json_field('Child', 'package'),
+                version=_atd_read_string(x['version']) if 'version' in x else _atd_missing_json_field('Child', 'version'),
+            )
+        else:
+            _atd_bad_json('Child', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        res['package'] = _atd_write_string(self.package)
+        res['version'] = _atd_write_string(self.version)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Child':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class FoundDependency:
     """Original type: found_dependency = { ... }"""
 
@@ -1877,6 +1908,7 @@ class FoundDependency:
     transitivity: Transitivity
     resolved_url: Optional[str] = None
     line_number: Optional[int] = None
+    children: Optional[List[Child]] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'FoundDependency':
@@ -1889,6 +1921,7 @@ class FoundDependency:
                 transitivity=Transitivity.from_json(x['transitivity']) if 'transitivity' in x else _atd_missing_json_field('FoundDependency', 'transitivity'),
                 resolved_url=_atd_read_string(x['resolved_url']) if 'resolved_url' in x else None,
                 line_number=_atd_read_int(x['line_number']) if 'line_number' in x else None,
+                children=_atd_read_list(Child.from_json)(x['children']) if 'children' in x else None,
             )
         else:
             _atd_bad_json('FoundDependency', x)
@@ -1904,6 +1937,8 @@ class FoundDependency:
             res['resolved_url'] = _atd_write_string(self.resolved_url)
         if self.line_number is not None:
             res['line_number'] = _atd_write_int(self.line_number)
+        if self.children is not None:
+            res['children'] = _atd_write_list((lambda x: x.to_json()))(self.children)
         return res
 
     @classmethod

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -385,7 +385,7 @@ export type DependencyPattern = {
   semver_range: string;
 }
 
-export type Child = {
+export type DependencyChild = {
   package_: string;
   version: string;
 }
@@ -398,7 +398,7 @@ export type FoundDependency = {
   resolved_url?: string;
   transitivity: Transitivity;
   line_number?: number /*int*/;
-  children?: Child[];
+  children?: DependencyChild[];
 }
 
 export type CiScanResults = {
@@ -1596,17 +1596,17 @@ export function readDependencyPattern(x: any, context: any = x): DependencyPatte
   };
 }
 
-export function writeChild(x: Child, context: any = x): any {
+export function writeDependencyChild(x: DependencyChild, context: any = x): any {
   return {
-    'package': _atd_write_required_field('Child', 'package', _atd_write_string, x.package_, x),
-    'version': _atd_write_required_field('Child', 'version', _atd_write_string, x.version, x),
+    'package': _atd_write_required_field('DependencyChild', 'package', _atd_write_string, x.package_, x),
+    'version': _atd_write_required_field('DependencyChild', 'version', _atd_write_string, x.version, x),
   };
 }
 
-export function readChild(x: any, context: any = x): Child {
+export function readDependencyChild(x: any, context: any = x): DependencyChild {
   return {
-    package_: _atd_read_required_field('Child', 'package', _atd_read_string, x['package'], x),
-    version: _atd_read_required_field('Child', 'version', _atd_read_string, x['version'], x),
+    package_: _atd_read_required_field('DependencyChild', 'package', _atd_read_string, x['package'], x),
+    version: _atd_read_required_field('DependencyChild', 'version', _atd_read_string, x['version'], x),
   };
 }
 
@@ -1619,7 +1619,7 @@ export function writeFoundDependency(x: FoundDependency, context: any = x): any 
     'resolved_url': _atd_write_optional_field(_atd_write_string, x.resolved_url, x),
     'transitivity': _atd_write_required_field('FoundDependency', 'transitivity', writeTransitivity, x.transitivity, x),
     'line_number': _atd_write_optional_field(_atd_write_int, x.line_number, x),
-    'children': _atd_write_optional_field(_atd_write_array(writeChild), x.children, x),
+    'children': _atd_write_optional_field(_atd_write_array(writeDependencyChild), x.children, x),
   };
 }
 
@@ -1632,7 +1632,7 @@ export function readFoundDependency(x: any, context: any = x): FoundDependency {
     resolved_url: _atd_read_optional_field(_atd_read_string, x['resolved_url'], x),
     transitivity: _atd_read_required_field('FoundDependency', 'transitivity', readTransitivity, x['transitivity'], x),
     line_number: _atd_read_optional_field(_atd_read_int, x['line_number'], x),
-    children: _atd_read_optional_field(_atd_read_array(readChild), x['children'], x),
+    children: _atd_read_optional_field(_atd_read_array(readDependencyChild), x['children'], x),
   };
 }
 

--- a/semgrep_output_v1.ts
+++ b/semgrep_output_v1.ts
@@ -385,6 +385,11 @@ export type DependencyPattern = {
   semver_range: string;
 }
 
+export type Child = {
+  package_: string;
+  version: string;
+}
+
 export type FoundDependency = {
   package_: string;
   version: string;
@@ -393,6 +398,7 @@ export type FoundDependency = {
   resolved_url?: string;
   transitivity: Transitivity;
   line_number?: number /*int*/;
+  children?: Child[];
 }
 
 export type CiScanResults = {
@@ -1590,6 +1596,20 @@ export function readDependencyPattern(x: any, context: any = x): DependencyPatte
   };
 }
 
+export function writeChild(x: Child, context: any = x): any {
+  return {
+    'package': _atd_write_required_field('Child', 'package', _atd_write_string, x.package_, x),
+    'version': _atd_write_required_field('Child', 'version', _atd_write_string, x.version, x),
+  };
+}
+
+export function readChild(x: any, context: any = x): Child {
+  return {
+    package_: _atd_read_required_field('Child', 'package', _atd_read_string, x['package'], x),
+    version: _atd_read_required_field('Child', 'version', _atd_read_string, x['version'], x),
+  };
+}
+
 export function writeFoundDependency(x: FoundDependency, context: any = x): any {
   return {
     'package': _atd_write_required_field('FoundDependency', 'package', _atd_write_string, x.package_, x),
@@ -1599,6 +1619,7 @@ export function writeFoundDependency(x: FoundDependency, context: any = x): any 
     'resolved_url': _atd_write_optional_field(_atd_write_string, x.resolved_url, x),
     'transitivity': _atd_write_required_field('FoundDependency', 'transitivity', writeTransitivity, x.transitivity, x),
     'line_number': _atd_write_optional_field(_atd_write_int, x.line_number, x),
+    'children': _atd_write_optional_field(_atd_write_array(writeChild), x.children, x),
   };
 }
 
@@ -1611,6 +1632,7 @@ export function readFoundDependency(x: any, context: any = x): FoundDependency {
     resolved_url: _atd_read_optional_field(_atd_read_string, x['resolved_url'], x),
     transitivity: _atd_read_required_field('FoundDependency', 'transitivity', readTransitivity, x['transitivity'], x),
     line_number: _atd_read_optional_field(_atd_read_int, x['line_number'], x),
+    children: _atd_read_optional_field(_atd_read_array(readChild), x['children'], x),
   };
 }
 

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -168,6 +168,9 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
+type child = Semgrep_output_v1_t.child = { package: string; version: string }
+  [@@deriving show]
+
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
   package: string;
   version: string;
@@ -175,7 +178,8 @@ type found_dependency = Semgrep_output_v1_t.found_dependency = {
   allowed_hashes: (string * string list) list;
   resolved_url: string option;
   transitivity: transitivity;
-  line_number: int option
+  line_number: int option;
+  children: child list option
 }
   [@@deriving show]
 
@@ -5133,6 +5137,169 @@ let read_ecosystem = (
 )
 let ecosystem_of_string s =
   read_ecosystem (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write_child : _ -> child -> _ = (
+  fun ob (x : child) ->
+    Buffer.add_char ob '{';
+    let is_first = ref true in
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"package\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.package;
+    if !is_first then
+      is_first := false
+    else
+      Buffer.add_char ob ',';
+      Buffer.add_string ob "\"version\":";
+    (
+      Yojson.Safe.write_string
+    )
+      ob x.version;
+    Buffer.add_char ob '}';
+)
+let string_of_child ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write_child ob x;
+  Buffer.contents ob
+let read_child = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    Yojson.Safe.read_lcurl p lb;
+    let field_package = ref (None) in
+    let field_version = ref (None) in
+    try
+      Yojson.Safe.read_space p lb;
+      Yojson.Safe.read_object_end lb;
+      Yojson.Safe.read_space p lb;
+      let f =
+        fun s pos len ->
+          if pos < 0 || len < 0 || pos + len > String.length s then
+            invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+          if len = 7 then (
+            match String.unsafe_get s pos with
+              | 'p' -> (
+                  if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'c' && String.unsafe_get s (pos+3) = 'k' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = 'e' then (
+                    0
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | 'v' -> (
+                  if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'o' && String.unsafe_get s (pos+6) = 'n' then (
+                    1
+                  )
+                  else (
+                    -1
+                  )
+                )
+              | _ -> (
+                  -1
+                )
+          )
+          else (
+            -1
+          )
+      in
+      let i = Yojson.Safe.map_ident p f lb in
+      Atdgen_runtime.Oj_run.read_until_field_value p lb;
+      (
+        match i with
+          | 0 ->
+            field_package := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | 1 ->
+            field_version := (
+              Some (
+                (
+                  Atdgen_runtime.Oj_run.read_string
+                ) p lb
+              )
+            );
+          | _ -> (
+              Yojson.Safe.skip_json p lb
+            )
+      );
+      while true do
+        Yojson.Safe.read_space p lb;
+        Yojson.Safe.read_object_sep p lb;
+        Yojson.Safe.read_space p lb;
+        let f =
+          fun s pos len ->
+            if pos < 0 || len < 0 || pos + len > String.length s then
+              invalid_arg (Printf.sprintf "out-of-bounds substring position or length: string = %S, requested position = %i, requested length = %i" s pos len);
+            if len = 7 then (
+              match String.unsafe_get s pos with
+                | 'p' -> (
+                    if String.unsafe_get s (pos+1) = 'a' && String.unsafe_get s (pos+2) = 'c' && String.unsafe_get s (pos+3) = 'k' && String.unsafe_get s (pos+4) = 'a' && String.unsafe_get s (pos+5) = 'g' && String.unsafe_get s (pos+6) = 'e' then (
+                      0
+                    )
+                    else (
+                      -1
+                    )
+                  )
+                | 'v' -> (
+                    if String.unsafe_get s (pos+1) = 'e' && String.unsafe_get s (pos+2) = 'r' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'i' && String.unsafe_get s (pos+5) = 'o' && String.unsafe_get s (pos+6) = 'n' then (
+                      1
+                    )
+                    else (
+                      -1
+                    )
+                  )
+                | _ -> (
+                    -1
+                  )
+            )
+            else (
+              -1
+            )
+        in
+        let i = Yojson.Safe.map_ident p f lb in
+        Atdgen_runtime.Oj_run.read_until_field_value p lb;
+        (
+          match i with
+            | 0 ->
+              field_package := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | 1 ->
+              field_version := (
+                Some (
+                  (
+                    Atdgen_runtime.Oj_run.read_string
+                  ) p lb
+                )
+              );
+            | _ -> (
+                Yojson.Safe.skip_json p lb
+              )
+        );
+      done;
+      assert false;
+    with Yojson.End_of_object -> (
+        (
+          {
+            package = (match !field_package with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "package");
+            version = (match !field_version with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "version");
+          }
+         : child)
+      )
+)
+let child_of_string s =
+  read_child (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__string_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string
@@ -5226,6 +5393,79 @@ let read__int_option = (
 )
 let _int_option_of_string s =
   read__int_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__child_list = (
+  Atdgen_runtime.Oj_run.write_list (
+    write_child
+  )
+)
+let string_of__child_list ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__child_list ob x;
+  Buffer.contents ob
+let read__child_list = (
+  Atdgen_runtime.Oj_run.read_list (
+    read_child
+  )
+)
+let _child_list_of_string s =
+  read__child_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__child_list_option = (
+  Atdgen_runtime.Oj_run.write_std_option (
+    write__child_list
+  )
+)
+let string_of__child_list_option ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__child_list_option ob x;
+  Buffer.contents ob
+let read__child_list_option = (
+  fun p lb ->
+    Yojson.Safe.read_space p lb;
+    match Yojson.Safe.start_any_variant p lb with
+      | `Edgy_bracket -> (
+          match Yojson.Safe.read_ident p lb with
+            | "None" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (None : _ option)
+            | "Some" ->
+              Atdgen_runtime.Oj_run.read_until_field_value p lb;
+              let x = (
+                  read__child_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_gt p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Double_quote -> (
+          match Yojson.Safe.finish_string p lb with
+            | "None" ->
+              (None : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+      | `Square_bracket -> (
+          match Atdgen_runtime.Oj_run.read_string p lb with
+            | "Some" ->
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_comma p lb;
+              Yojson.Safe.read_space p lb;
+              let x = (
+                  read__child_list
+                ) p lb
+              in
+              Yojson.Safe.read_space p lb;
+              Yojson.Safe.read_rbr p lb;
+              (Some x : _ option)
+            | x ->
+              Atdgen_runtime.Oj_run.invalid_variant_tag p x
+        )
+)
+let _child_list_option_of_string s =
+  read__child_list_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_found_dependency : _ -> found_dependency -> _ = (
   fun ob (x : found_dependency) ->
     Buffer.add_char ob '{';
@@ -5297,6 +5537,17 @@ let write_found_dependency : _ -> found_dependency -> _ = (
       )
         ob x;
     );
+    (match x.children with None -> () | Some x ->
+      if !is_first then
+        is_first := false
+      else
+        Buffer.add_char ob ',';
+        Buffer.add_string ob "\"children\":";
+      (
+        write__child_list
+      )
+        ob x;
+    );
     Buffer.add_char ob '}';
 )
 let string_of_found_dependency ?(len = 1024) x =
@@ -5314,6 +5565,7 @@ let read_found_dependency = (
     let field_resolved_url = ref (None) in
     let field_transitivity = ref (None) in
     let field_line_number = ref (None) in
+    let field_children = ref (None) in
     try
       Yojson.Safe.read_space p lb;
       Yojson.Safe.read_object_end lb;
@@ -5344,6 +5596,14 @@ let read_found_dependency = (
                   | _ -> (
                       -1
                     )
+              )
+            | 8 -> (
+                if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'h' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'd' && String.unsafe_get s (pos+5) = 'r' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'n' then (
+                  7
+                )
+                else (
+                  -1
+                )
               )
             | 9 -> (
                 if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'c' && String.unsafe_get s (pos+2) = 'o' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'y' && String.unsafe_get s (pos+5) = 's' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 'm' then (
@@ -5459,6 +5719,16 @@ let read_found_dependency = (
                 )
               );
             )
+          | 7 ->
+            if not (Yojson.Safe.read_null_if_possible p lb) then (
+              field_children := (
+                Some (
+                  (
+                    read__child_list
+                  ) p lb
+                )
+              );
+            )
           | _ -> (
               Yojson.Safe.skip_json p lb
             )
@@ -5493,6 +5763,14 @@ let read_found_dependency = (
                     | _ -> (
                         -1
                       )
+                )
+              | 8 -> (
+                  if String.unsafe_get s pos = 'c' && String.unsafe_get s (pos+1) = 'h' && String.unsafe_get s (pos+2) = 'i' && String.unsafe_get s (pos+3) = 'l' && String.unsafe_get s (pos+4) = 'd' && String.unsafe_get s (pos+5) = 'r' && String.unsafe_get s (pos+6) = 'e' && String.unsafe_get s (pos+7) = 'n' then (
+                    7
+                  )
+                  else (
+                    -1
+                  )
                 )
               | 9 -> (
                   if String.unsafe_get s pos = 'e' && String.unsafe_get s (pos+1) = 'c' && String.unsafe_get s (pos+2) = 'o' && String.unsafe_get s (pos+3) = 's' && String.unsafe_get s (pos+4) = 'y' && String.unsafe_get s (pos+5) = 's' && String.unsafe_get s (pos+6) = 't' && String.unsafe_get s (pos+7) = 'e' && String.unsafe_get s (pos+8) = 'm' then (
@@ -5608,6 +5886,16 @@ let read_found_dependency = (
                   )
                 );
               )
+            | 7 ->
+              if not (Yojson.Safe.read_null_if_possible p lb) then (
+                field_children := (
+                  Some (
+                    (
+                      read__child_list
+                    ) p lb
+                  )
+                );
+              )
             | _ -> (
                 Yojson.Safe.skip_json p lb
               )
@@ -5624,6 +5912,7 @@ let read_found_dependency = (
             resolved_url = !field_resolved_url;
             transitivity = (match !field_transitivity with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "transitivity");
             line_number = !field_line_number;
+            children = !field_children;
           }
          : found_dependency)
       )

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -168,7 +168,10 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
-type child = Semgrep_output_v1_t.child = { package: string; version: string }
+type dependency_child = Semgrep_output_v1_t.dependency_child = {
+  package: string;
+  version: string
+}
   [@@deriving show]
 
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
@@ -179,7 +182,7 @@ type found_dependency = Semgrep_output_v1_t.found_dependency = {
   resolved_url: string option;
   transitivity: transitivity;
   line_number: int option;
-  children: child list option
+  children: dependency_child list option
 }
   [@@deriving show]
 
@@ -5137,8 +5140,8 @@ let read_ecosystem = (
 )
 let ecosystem_of_string s =
   read_ecosystem (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write_child : _ -> child -> _ = (
-  fun ob (x : child) ->
+let write_dependency_child : _ -> dependency_child -> _ = (
+  fun ob (x : dependency_child) ->
     Buffer.add_char ob '{';
     let is_first = ref true in
     if !is_first then
@@ -5161,11 +5164,11 @@ let write_child : _ -> child -> _ = (
       ob x.version;
     Buffer.add_char ob '}';
 )
-let string_of_child ?(len = 1024) x =
+let string_of_dependency_child ?(len = 1024) x =
   let ob = Buffer.create len in
-  write_child ob x;
+  write_dependency_child ob x;
   Buffer.contents ob
-let read_child = (
+let read_dependency_child = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     Yojson.Safe.read_lcurl p lb;
@@ -5295,11 +5298,11 @@ let read_child = (
             package = (match !field_package with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "package");
             version = (match !field_version with Some x -> x | None -> Atdgen_runtime.Oj_run.missing_field p "version");
           }
-         : child)
+         : dependency_child)
       )
 )
-let child_of_string s =
-  read_child (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let dependency_child_of_string s =
+  read_dependency_child (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write__string_list = (
   Atdgen_runtime.Oj_run.write_list (
     Yojson.Safe.write_string
@@ -5393,32 +5396,32 @@ let read__int_option = (
 )
 let _int_option_of_string s =
   read__int_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__child_list = (
+let write__dependency_child_list = (
   Atdgen_runtime.Oj_run.write_list (
-    write_child
+    write_dependency_child
   )
 )
-let string_of__child_list ?(len = 1024) x =
+let string_of__dependency_child_list ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__child_list ob x;
+  write__dependency_child_list ob x;
   Buffer.contents ob
-let read__child_list = (
+let read__dependency_child_list = (
   Atdgen_runtime.Oj_run.read_list (
-    read_child
+    read_dependency_child
   )
 )
-let _child_list_of_string s =
-  read__child_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
-let write__child_list_option = (
+let _dependency_child_list_of_string s =
+  read__dependency_child_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__dependency_child_list_option = (
   Atdgen_runtime.Oj_run.write_std_option (
-    write__child_list
+    write__dependency_child_list
   )
 )
-let string_of__child_list_option ?(len = 1024) x =
+let string_of__dependency_child_list_option ?(len = 1024) x =
   let ob = Buffer.create len in
-  write__child_list_option ob x;
+  write__dependency_child_list_option ob x;
   Buffer.contents ob
-let read__child_list_option = (
+let read__dependency_child_list_option = (
   fun p lb ->
     Yojson.Safe.read_space p lb;
     match Yojson.Safe.start_any_variant p lb with
@@ -5431,7 +5434,7 @@ let read__child_list_option = (
             | "Some" ->
               Atdgen_runtime.Oj_run.read_until_field_value p lb;
               let x = (
-                  read__child_list
+                  read__dependency_child_list
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -5454,7 +5457,7 @@ let read__child_list_option = (
               Yojson.Safe.read_comma p lb;
               Yojson.Safe.read_space p lb;
               let x = (
-                  read__child_list
+                  read__dependency_child_list
                 ) p lb
               in
               Yojson.Safe.read_space p lb;
@@ -5464,8 +5467,8 @@ let read__child_list_option = (
               Atdgen_runtime.Oj_run.invalid_variant_tag p x
         )
 )
-let _child_list_option_of_string s =
-  read__child_list_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let _dependency_child_list_option_of_string s =
+  read__dependency_child_list_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_found_dependency : _ -> found_dependency -> _ = (
   fun ob (x : found_dependency) ->
     Buffer.add_char ob '{';
@@ -5544,7 +5547,7 @@ let write_found_dependency : _ -> found_dependency -> _ = (
         Buffer.add_char ob ',';
         Buffer.add_string ob "\"children\":";
       (
-        write__child_list
+        write__dependency_child_list
       )
         ob x;
     );
@@ -5724,7 +5727,7 @@ let read_found_dependency = (
               field_children := (
                 Some (
                   (
-                    read__child_list
+                    read__dependency_child_list
                   ) p lb
                 )
               );
@@ -5891,7 +5894,7 @@ let read_found_dependency = (
                 field_children := (
                   Some (
                     (
-                      read__child_list
+                      read__dependency_child_list
                     ) p lb
                   )
                 );

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -168,7 +168,10 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
-type child = Semgrep_output_v1_t.child = { package: string; version: string }
+type dependency_child = Semgrep_output_v1_t.dependency_child = {
+  package: string;
+  version: string
+}
   [@@deriving show]
 
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
@@ -179,7 +182,7 @@ type found_dependency = Semgrep_output_v1_t.found_dependency = {
   resolved_url: string option;
   transitivity: transitivity;
   line_number: int option;
-  children: child list option
+  children: dependency_child list option
 }
   [@@deriving show]
 
@@ -990,25 +993,25 @@ val ecosystem_of_string :
   string -> ecosystem
   (** Deserialize JSON data of type {!type:ecosystem}. *)
 
-val write_child :
-  Buffer.t -> child -> unit
-  (** Output a JSON value of type {!type:child}. *)
+val write_dependency_child :
+  Buffer.t -> dependency_child -> unit
+  (** Output a JSON value of type {!type:dependency_child}. *)
 
-val string_of_child :
-  ?len:int -> child -> string
-  (** Serialize a value of type {!type:child}
+val string_of_dependency_child :
+  ?len:int -> dependency_child -> string
+  (** Serialize a value of type {!type:dependency_child}
       into a JSON string.
       @param len specifies the initial length
                  of the buffer used internally.
                  Default: 1024. *)
 
-val read_child :
-  Yojson.Safe.lexer_state -> Lexing.lexbuf -> child
-  (** Input JSON data of type {!type:child}. *)
+val read_dependency_child :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> dependency_child
+  (** Input JSON data of type {!type:dependency_child}. *)
 
-val child_of_string :
-  string -> child
-  (** Deserialize JSON data of type {!type:child}. *)
+val dependency_child_of_string :
+  string -> dependency_child
+  (** Deserialize JSON data of type {!type:dependency_child}. *)
 
 val write_found_dependency :
   Buffer.t -> found_dependency -> unit

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -168,6 +168,9 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
 
 type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
+type child = Semgrep_output_v1_t.child = { package: string; version: string }
+  [@@deriving show]
+
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
   package: string;
   version: string;
@@ -175,7 +178,8 @@ type found_dependency = Semgrep_output_v1_t.found_dependency = {
   allowed_hashes: (string * string list) list;
   resolved_url: string option;
   transitivity: transitivity;
-  line_number: int option
+  line_number: int option;
+  children: child list option
 }
   [@@deriving show]
 
@@ -985,6 +989,26 @@ val read_ecosystem :
 val ecosystem_of_string :
   string -> ecosystem
   (** Deserialize JSON data of type {!type:ecosystem}. *)
+
+val write_child :
+  Buffer.t -> child -> unit
+  (** Output a JSON value of type {!type:child}. *)
+
+val string_of_child :
+  ?len:int -> child -> string
+  (** Serialize a value of type {!type:child}
+      into a JSON string.
+      @param len specifies the initial length
+                 of the buffer used internally.
+                 Default: 1024. *)
+
+val read_child :
+  Yojson.Safe.lexer_state -> Lexing.lexbuf -> child
+  (** Input JSON data of type {!type:child}. *)
+
+val child_of_string :
+  string -> child
+  (** Deserialize JSON data of type {!type:child}. *)
 
 val write_found_dependency :
   Buffer.t -> found_dependency -> unit


### PR DESCRIPTION
Updated the `FoundDependency` class to now store a list of `Child` objects which contain the name and package of the dependencies they rely on. Will be used in the App to construct the adjacency list

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
