### PR TITLE
feat(secrets): add auth object to request

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -23,6 +23,8 @@ $defs:
         type: object
       body:
         type: string
+      auth:
+        type: object
   # EXPERIMENTAL
   response-content:
     properties:


### PR DESCRIPTION
Supports ability to have HTTP request changed to, for instance, add authorization headers which depend on message content and metavariables.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
