### PR TITLE
Revert "remove lots of useless deriving show"

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -50,7 +50,7 @@
  *)
 
 (* escape hatch *)
-type raw_json <ocaml module="Yojson.Basic" t="t"> = abstract
+type raw_json <ocaml module="Yojson.Basic" t="t" attr="deriving show"> = abstract
 
 (*****************************************************************************)
 (* Versioning *)
@@ -82,8 +82,8 @@ type fpath <ocaml attr="deriving show"> = string
 
 (* a.k.a range *)
 type location
-     <ocaml attr="deriving show">
-     <python decorator="dataclass(frozen=True)"> = {
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   path: fpath (* source file *);
   start: position;
   end <ocaml name="end_">: position;
@@ -109,14 +109,18 @@ type rule_id
 (* EXPERIMENTAL: Do not rely on those internal types, they might disappear *)
 
 (* TODO: now only core_match_extra differ, otherwise it's just like cli_match *)
-type core_match <python decorator="dataclass(frozen=True)"> = {
+type core_match
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   check_id: rule_id;
   inherit location;
   extra: core_match_extra;
 }
 
 (* TODO: try to make it as close as possible to 'cli_match_extra' below *)
-type core_match_extra <python decorator="dataclass(frozen=True)"> = {
+type core_match_extra
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   ?message: string option; (* rule.message (?) *)
   metavars: metavars;
   ?dataflow_trace: match_dataflow_trace option;
@@ -140,13 +144,13 @@ type core_match_extra <python decorator="dataclass(frozen=True)"> = {
 (* CLI *)
 (* ----------------------------- *)
 
-type cli_match = {
+type cli_match <ocaml attr="deriving show"> = {
   check_id: rule_id;
   inherit location;
   extra: cli_match_extra;
 }
 
-type cli_match_extra = {
+type cli_match_extra <ocaml attr="deriving show"> = {
   (* TODO: inherit match_extra; but need ?metavars because of dependency_aware code *)
   ?metavars: metavars option;
 
@@ -189,7 +193,7 @@ type cli_match_extra = {
   ?extra_extra: raw_json option;
 }
 
-type fix_regex = {
+type fix_regex <ocaml attr="deriving show"> = {
   regex: string;
   replacement: string;
   ?count: int option;
@@ -213,7 +217,7 @@ type validation_state
  * TODO: semgrep-core always return a metavars, but dependency_aware Python code
  * does not always generate a metavars
 *)
-type metavars = (string * metavar_value) list
+type metavars <ocaml attr="deriving show"> = (string * metavar_value) list
   <json repr="object">
   <python repr="dict">
   <ts repr="map">
@@ -223,7 +227,9 @@ type metavars = (string * metavar_value) list
  * but with deep-semgrep a metavar could also refer to code in another file,
  * so simpler to generalize and 'inherit location'.
  *)
-type metavar_value <python decorator="dataclass(frozen=True)"> = {
+type metavar_value
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   (* for certain metavariable like $...ARGS, 'end' may be equal to 'start'
    * to represent an empty metavariable value. The rest of the Python
    * code (message metavariable substitution and autofix) works
@@ -235,7 +241,9 @@ type metavar_value <python decorator="dataclass(frozen=True)"> = {
   ?propagated_value: svalue_value option;
 }
 
-type svalue_value <python decorator="dataclass(frozen=True)"> = {
+type svalue_value
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   ?svalue_start: position option;
   ?svalue_end: position option;
   svalue_abstract_content: string; (* value? *)
@@ -246,7 +254,9 @@ type svalue_value <python decorator="dataclass(frozen=True)"> = {
 (*****************************************************************************)
 
 (* EXPERIMENTAL *)
-type match_dataflow_trace <python decorator="dataclass(frozen=True)"> = {
+type match_dataflow_trace
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   ?taint_source: match_call_trace option;
   (* Intermediate variables which are involved in the dataflow. For taint, this
    * explains how the taint flows from the source to the sink. *)
@@ -260,14 +270,18 @@ type match_dataflow_trace <python decorator="dataclass(frozen=True)"> = {
 (* the string attached to the location is the actual text from the file
  * TODO: define a location_with_content type that can be reused.
  *)
-type match_call_trace <python decorator="dataclass(frozen=True, order=True)"> = [
+type match_call_trace
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True, order=True)"> = [
   | CliLoc of (location * string)
   | CliCall of ((location * string) * match_intermediate_var list * match_call_trace)
 ] <ocaml repr="classic">
 
 
 (* EXPERIMENTAL *)
-type match_intermediate_var <python decorator="dataclass(frozen=True)"> = {
+type match_intermediate_var
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   location: location;
   (* Unlike abstract_content, this is the actual text read from the
    * corresponding source file *)
@@ -291,7 +305,9 @@ type match_intermediate_var <python decorator="dataclass(frozen=True)"> = {
  * extending cli_error with more fields (but those fields must be optional
  * to remain backward compatible
  *)
-type core_error <python decorator="dataclass(frozen=True)"> = {
+type core_error
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   ?rule_id: rule_id option;
   error_type: core_error_kind;
   severity: core_severity;
@@ -344,8 +360,8 @@ type core_error_kind
 ] <ocaml repr="classic">
 
 type incompatible_rule
-     <ocaml attr="deriving show">
-     <python decorator="dataclass(frozen=True)"> = {
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = {
   rule_id: rule_id;
   this_version: version;
   ?min_version: version option;
@@ -370,7 +386,7 @@ type core_severity
 (* ----------------------------- *)
 (* (called SemgrepError in error.py) *)
 
-type cli_error = {
+type cli_error <ocaml attr="deriving show"> = {
   (* exit code? *)
   code: int;
   (* TODO: use a variant (Warning | Error | ...) *)
@@ -397,7 +413,7 @@ type cli_error = {
   ?help: string option;
 }
 
-type error_span = {
+type error_span <ocaml attr="deriving show"> = {
     (* for InvalidRuleSchemaError *)
     (* LATER: could inherit location; but file: vs path: *)
     (* TODO: source hash should probably also be mandatory? *)
@@ -463,7 +479,7 @@ type skipped_target <ocaml attr="deriving show"> = {
   ?rule_id: rule_id option;
 }
 
-type scanned_and_skipped = {
+type scanned_and_skipped <ocaml attr="deriving show"> = {
     scanned: string list;
     (* really either _comment: (saying "you should use -v to get more info")
      * or skipped:. We should have used a variant.
@@ -475,7 +491,7 @@ type scanned_and_skipped = {
     ?skipped: skipped_target list option;
 }
 
-type skipped_rule = {
+type skipped_rule <ocaml attr="deriving show"> = {
   rule_id: rule_id;
   details: string;
   (* position of the error in the rule file *)
@@ -489,7 +505,7 @@ type skipped_rule = {
 (* ----------------------------- *)
 (* Core *)
 (* ----------------------------- *)
-type core_stats = {
+type core_stats <ocaml attr="deriving show"> = {
   okfiles: int;
   errorfiles: int;
 }
@@ -509,7 +525,7 @@ type core_stats = {
 (* EXPERIMENTAL: Do not rely on those internal types, they might disappear *)
 
 (* TODO: merge with profile below *)
-type core_timing = {
+type core_timing <ocaml attr="deriving show"> = {
   rules: rule_id list;
 
   rules_parse_time: float;
@@ -521,7 +537,7 @@ type core_timing = {
 }
 
 (* TODO: merge with cli_target_times *)
-type target_time = {
+type target_time <ocaml attr="deriving show"> = {
   path: fpath;
   (* parse and match time for each rule on target *)
   rule_times: rule_times list;
@@ -529,7 +545,7 @@ type target_time = {
   run_time: float;
 }
 
-type rule_times = {
+type rule_times <ocaml attr="deriving show"> = {
   rule_id: rule_id;
   (* TODO: time to parse what? *)
   parse_time: float;
@@ -542,7 +558,7 @@ type rule_times = {
 (* coupling: if you change the JSON schema below, you probably need to
  * also modify perf/run-benchmarks. Run locally  $ ./run-benchmarks --dummy --upload
  *)
-type profile = {
+type profile <ocaml attr="deriving show"> = {
     (* List of rules, including the one read but not run on any target.
      * This list is actually more an array which allows other
      * fields to reference rule by number instead of rule_id
@@ -579,7 +595,7 @@ type profile = {
     ?max_memory_bytes : int option;
   }
 
-type cli_target_times = {
+type cli_target_times <ocaml attr="deriving show"> = {
     path: fpath;
     num_bytes: int;
     (* each elt in the list refers to a rule in profile.rules *)
@@ -596,7 +612,7 @@ type cli_target_times = {
 (* coupling: semgrep-core/src/core/Matching_explanation.ml
  * LATER: merge with Matching_explanation.t at some point
  * EXPERIMENTAL *)
-type matching_explanation = {
+type matching_explanation <ocaml attr="deriving show"> = {
     op: matching_operation;
     children: matching_explanation list;
     (* result matches at this node (can be empty when we reach a nomatch) *)
@@ -613,8 +629,6 @@ type matching_explanation = {
  * - Where filters (metavar-comparison, etc)
  * - tainting source/sink/sanitizer
  * - subpattern EllipsisAndStmt, ClassHeaderAndElems
- * Note that this type is used in Matching_explanation.ml hence the need
- * for deriving show below.
  *)
 type matching_operation <ocaml attr="deriving show { with_path = false}"> = [
   | And
@@ -639,18 +653,22 @@ type matching_operation <ocaml attr="deriving show { with_path = false}"> = [
   | ClassHeaderAndElems
 ] <ocaml repr="classic">
 
+
 (*****************************************************************************)
 (* Engine kind  *)
 (*****************************************************************************)
 
 type engine_kind
-     <ocaml attr="deriving show">
-     <python decorator="dataclass(frozen=True)"> = [
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = [
   | OSS
   | PRO
 ]
 
-type rule_id_and_engine_kind <python decorator="dataclass(frozen=True)"> = (rule_id * engine_kind)
+type rule_id_and_engine_kind
+  <ocaml attr="deriving show">
+  <python decorator="dataclass(frozen=True)"> = (rule_id * engine_kind)
+
                      
 (*****************************************************************************)
 (* Final output  *)
@@ -661,7 +679,7 @@ type rule_id_and_engine_kind <python decorator="dataclass(frozen=True)"> = (rule
 (* ----------------------------- *)
 
 (* EXPERIMENTAL: Do not rely on those internal types, they might disappear *)
-type core_output = {
+type core_output <ocaml attr="deriving show"> = {
 
   (* errors are guaranteed to be duplicate free; see also Report.ml *)
   errors: core_error list;
@@ -670,7 +688,7 @@ type core_output = {
   inherit core_output_extra;
 }
 
-type core_output_extra = {  
+type core_output_extra <ocaml attr="deriving show"> = {
   ?skipped_targets <json name="skipped">: skipped_target list option;
   ?time: core_timing option;
   ?explanations: matching_explanation list option;
@@ -686,7 +704,7 @@ type core_output_extra = {
 (* ----------------------------- *)
 
 (* TODO: rename to scan_output at some point *)
-type cli_output = {
+type cli_output <ocaml attr="deriving show"> = {
     (* since: 0.92 *)
     ?version: version option;
 
@@ -699,7 +717,7 @@ type cli_output = {
 (* TODO? used only in TEXT format:
  * ?color_output, per_finding_max_lines_limit, per_line_max_chars_limit
 *)
-type cli_output_extra = {
+type cli_output_extra <ocaml attr="deriving show"> = {
     (* targeting information *)
     paths: scanned_and_skipped;
     (* profiling information *)
@@ -727,14 +745,14 @@ type cli_output_extra = {
 (* Semgrep Supply Chain (SSC, a.k.a., Software Composition Analysis (SCA)) *)
 (*****************************************************************************)
 (* EXPERIMENTAL *)
-type sca_info = {
+type sca_info <ocaml attr="deriving show"> = {
   reachable: bool;
   reachability_rule: bool;
   sca_finding_schema: int;
   dependency_match: dependency_match;
 }
 
-type dependency_match = {
+type dependency_match <ocaml attr="deriving show"> = {
   dependency_pattern: dependency_pattern;
   found_dependency: found_dependency;
   lockfile: string;
@@ -744,7 +762,9 @@ type dependency_match = {
  * classes can be hashed and put in sets (see calls to reachable_deps.add()
  * in semgrep SCA code)
  *)
-type ecosystem <python decorator="dataclass(frozen=True)"> = [
+type ecosystem
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = [
   | Npm <json name="npm">
   | Pypi  <json name="pypi">
   | Gem <json name="gem">
@@ -755,24 +775,26 @@ type ecosystem <python decorator="dataclass(frozen=True)"> = [
   | Nuget <json name="nuget">
 ]
 
-type transitivity <python decorator="dataclass(frozen=True)"> = [
+type transitivity
+    <ocaml attr="deriving show">
+    <python decorator="dataclass(frozen=True)"> = [
   | Direct <json name="direct">
   | Transitive <json name="transitive">
   | Unknown <json name="unknown">
 ]
 
-type dependency_pattern = {
+type dependency_pattern <ocaml attr="deriving show"> = {
   ecosystem: ecosystem;
   package: string;
   semver_range: string;
 }
 
-type dependency_child = {
+type dependency_child <ocaml attr="deriving show"> = {
   package: string;
   version: string;
 }
 
-type found_dependency = {
+type found_dependency <ocaml attr="deriving show"> = {
   package: string;
   version: string;
   ecosystem: ecosystem;
@@ -788,7 +810,7 @@ type found_dependency = {
 }
 
 (* json names are to maintain backwards compatibility with the python enum it is replacing *)
-type sca_parser_name = [
+type sca_parser_name <ocaml attr="deriving show"> = [
   | Gemfile_lock <json name="gemfile_lock">
   | Go_mod <json name="go_mod">
   | Go_sum <json name="go_sum">
@@ -807,13 +829,11 @@ type sca_parser_name = [
   | Composer_lock <json name="composer_lock">
 ]
 
-type dependency_parser_error = {
+type dependency_parser_error <ocaml attr="deriving show"> = {
   path: string;
   parser: sca_parser_name;
   reason: string;
-  (* Not using `position` because this type must be backwards compatible with the python
-   * class it is replacing.
-   *)
+  (* Not using `position` because this type must be backwards compatible with the python class it is replacing *)
   ?line: int option;
   ?col: int option;
   ?text: string option;
@@ -823,19 +843,23 @@ type dependency_parser_error = {
 (* Contributors (App) *)
 (*****************************************************************************)
 
-(* See https://semgrep.dev/docs/usage-limits *)
-type contributor = {
+(* 
+ * https://semgrep.dev/docs/usage-limits
+ *)
+type contributor <ocaml attr="deriving show"> = {
     commit_author_name: string;
     commit_author_email: string;
 }
 
-type contribution = {
+type contribution <ocaml attr="deriving show"> = {
     commit_hash: string;
     commit_timestamp: string;
     contributor: contributor;
 }
 
-type contributions = contribution list
+type contributions
+  <ocaml attr="deriving show"> = contribution list
+
 
 (*****************************************************************************)
 (* Semgrep ci findings for the App *)
@@ -846,7 +870,7 @@ type contributions = contribution list
 *)
 
 (* Sent by the CLI to /findings_and_ignores aka /results *)
-type ci_scan_results = {
+type ci_scan_results <ocaml attr="deriving show"> = {
   (* TODO: ?version: version option; *)
    findings: finding list;
    ignores: finding list;
@@ -861,14 +885,14 @@ type ci_scan_results = {
    ?dependencies: ci_scan_dependencies option;
 }
 
-type parsing_stats = {
+type parsing_stats <ocaml attr="deriving show"> = {
   targets_parsed: int;
   num_targets: int;
   bytes_parsed: int;
   num_bytes: int;
 }
 
-type ci_scan_complete_stats = {
+type ci_scan_complete_stats <ocaml attr="deriving show"> = {
   findings: int;
   errors: cli_error list;
   total_time: float;
@@ -888,13 +912,13 @@ type ci_scan_complete_stats = {
   ?engine_requested: string option;
 }
 
-type ci_scan_dependencies = (string * found_dependency list) list
+type ci_scan_dependencies <ocaml attr="deriving show"> =  (string * found_dependency list) list
     <json repr="object">
     <python repr="dict">
     <ts repr="map">
 
 (* Seny by the CLI to /complete *)
-type ci_scan_complete_response = {
+type ci_scan_complete_response <ocaml attr="deriving show"> = {
   exit_code: int;
   stats: ci_scan_complete_stats;
   ?dependencies: ci_scan_dependencies option;
@@ -902,7 +926,7 @@ type ci_scan_complete_response = {
   ?task_id: string option;
 }
 
-type finding_hashes = {
+type finding_hashes <ocaml attr="deriving show"> = {
   start_line_hash: string;
   end_line_hash: string;
   (* hash of the syntactic_context/code contents from start_line through end_line *)
@@ -912,7 +936,7 @@ type finding_hashes = {
 }
 
 (* TODO: rewrite rule_matches.to_app_finding_format() *)
-type finding = {
+type finding <ocaml attr="deriving show"> = {
   check_id: rule_id;
   path: fpath;
   line: int;
@@ -920,8 +944,7 @@ type finding = {
   end_line: int;
   end_column: int;
   message: string;
-  (* int|string until minimum version exceeds 1.32.0, then string *)
-  severity: abstract;
+  severity: abstract; (* int|string until minimum version exceeds 1.32.0, then string *)
   (* ?? *)
   index: int;
   commit_date: string;
@@ -935,6 +958,6 @@ type finding = {
   ?fixed_lines: string list option;
   ?sca_info: sca_info option;
   ?dataflow_trace: match_dataflow_trace option;
-  (* Added in semgrep 1.39.0 see comments in cli_match_extra. *)
+  (* Added in semgrep 1.39.0 see comments in core_match. *)
   ?validation_state: validation_state option;
 }

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -39,8 +39,9 @@ type match_intermediate_var = Semgrep_output_v1_t.match_intermediate_var = {
   location: location;
   content: string
 }
+  [@@deriving show]
 
-type raw_json = Yojson.Basic.t
+type raw_json = Yojson.Basic.t [@@deriving show]
 
 type rule_id = Semgrep_output_v1_t.rule_id [@@deriving show]
 
@@ -49,6 +50,7 @@ type svalue_value = Semgrep_output_v1_t.svalue_value = {
   svalue_end: position option;
   svalue_abstract_content: string
 }
+  [@@deriving show]
 
 type metavar_value = Semgrep_output_v1_t.metavar_value = {
   start: position;
@@ -56,8 +58,9 @@ type metavar_value = Semgrep_output_v1_t.metavar_value = {
   abstract_content: string;
   propagated_value: svalue_value option
 }
+  [@@deriving show]
 
-type metavars = Semgrep_output_v1_t.metavars
+type metavars = Semgrep_output_v1_t.metavars [@@deriving show]
 
 type validation_state = Semgrep_output_v1_t.validation_state
   [@@deriving show]
@@ -71,12 +74,14 @@ type match_call_trace = Semgrep_output_v1_t.match_call_trace =
         * match_call_trace
       )
 
+  [@@deriving show]
 
 type match_dataflow_trace = Semgrep_output_v1_t.match_dataflow_trace = {
   taint_source: match_call_trace option;
   intermediate_vars: match_intermediate_var list option;
   taint_sink: match_call_trace option
 }
+  [@@deriving show]
 
 type core_match_extra = Semgrep_output_v1_t.core_match_extra = {
   message: string option;
@@ -87,6 +92,7 @@ type core_match_extra = Semgrep_output_v1_t.core_match_extra = {
   validation_state: validation_state option;
   extra_extra: raw_json option
 }
+  [@@deriving show]
 
 type core_match = Semgrep_output_v1_t.core_match = {
   check_id: rule_id;
@@ -95,6 +101,7 @@ type core_match = Semgrep_output_v1_t.core_match = {
   end_ (*atd end *): position;
   extra: core_match_extra
 }
+  [@@deriving show]
 
 type matching_explanation = Semgrep_output_v1_t.matching_explanation = {
   op: matching_operation;
@@ -102,22 +109,25 @@ type matching_explanation = Semgrep_output_v1_t.matching_explanation = {
   matches: core_match list;
   loc: location
 }
+  [@@deriving show]
 
 type version = Semgrep_output_v1_t.version [@@deriving show]
 
-type transitivity = Semgrep_output_v1_t.transitivity
+type transitivity = Semgrep_output_v1_t.transitivity [@@deriving show]
 
 type rule_times = Semgrep_output_v1_t.rule_times = {
   rule_id: rule_id;
   parse_time: float;
   match_time: float
 }
+  [@@deriving show]
 
 type target_time = Semgrep_output_v1_t.target_time = {
   path: fpath;
   rule_times: rule_times list;
   run_time: float
 }
+  [@@deriving show]
 
 type skip_reason = Semgrep_output_v1_t.skip_reason = 
     Always_skipped | Semgrepignore_patterns_match
@@ -141,21 +151,24 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
   details: string;
   position: position
 }
+  [@@deriving show]
 
 type scanned_and_skipped = Semgrep_output_v1_t.scanned_and_skipped = {
   scanned: string list;
   _comment: string option;
   skipped: skipped_target list option
 }
+  [@@deriving show]
 
-type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
+type sca_parser_name = Semgrep_output_v1_t.sca_parser_name [@@deriving show]
 
-type ecosystem = Semgrep_output_v1_t.ecosystem
+type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
 type dependency_child = Semgrep_output_v1_t.dependency_child = {
   package: string;
   version: string
 }
+  [@@deriving show]
 
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
   package: string;
@@ -167,18 +180,21 @@ type found_dependency = Semgrep_output_v1_t.found_dependency = {
   line_number: int option;
   children: dependency_child list option
 }
+  [@@deriving show]
 
 type dependency_pattern = Semgrep_output_v1_t.dependency_pattern = {
   ecosystem: ecosystem;
   package: string;
   semver_range: string
 }
+  [@@deriving show]
 
 type dependency_match = Semgrep_output_v1_t.dependency_match = {
   dependency_pattern: dependency_pattern;
   found_dependency: found_dependency;
   lockfile: string
 }
+  [@@deriving show]
 
 type sca_info = Semgrep_output_v1_t.sca_info = {
   reachable: bool;
@@ -186,8 +202,10 @@ type sca_info = Semgrep_output_v1_t.sca_info = {
   sca_finding_schema: int;
   dependency_match: dependency_match
 }
+  [@@deriving show]
 
 type rule_id_and_engine_kind = Semgrep_output_v1_t.rule_id_and_engine_kind
+  [@@deriving show]
 
 type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   path: fpath;
@@ -196,6 +214,7 @@ type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   parse_times: float list;
   run_time: float
 }
+  [@@deriving show]
 
 type profile = Semgrep_output_v1_t.profile = {
   rules: rule_id list;
@@ -205,6 +224,7 @@ type profile = Semgrep_output_v1_t.profile = {
   total_bytes: int;
   max_memory_bytes: int option
 }
+  [@@deriving show]
 
 type parsing_stats = Semgrep_output_v1_t.parsing_stats = {
   targets_parsed: int;
@@ -212,6 +232,7 @@ type parsing_stats = Semgrep_output_v1_t.parsing_stats = {
   bytes_parsed: int;
   num_bytes: int
 }
+  [@@deriving show]
 
 type incompatible_rule = Semgrep_output_v1_t.incompatible_rule = {
   rule_id: rule_id;
@@ -226,6 +247,7 @@ type fix_regex = Semgrep_output_v1_t.fix_regex = {
   replacement: string;
   count: int option
 }
+  [@@deriving show]
 
 type finding_hashes = Semgrep_output_v1_t.finding_hashes = {
   start_line_hash: string;
@@ -233,6 +255,7 @@ type finding_hashes = Semgrep_output_v1_t.finding_hashes = {
   code_hash: string;
   pattern_hash: string
 }
+  [@@deriving show]
 
 type finding = Semgrep_output_v1_t.finding = {
   check_id: rule_id;
@@ -255,6 +278,7 @@ type finding = Semgrep_output_v1_t.finding = {
   dataflow_trace: match_dataflow_trace option;
   validation_state: validation_state option
 }
+  [@@deriving show]
 
 type error_span = Semgrep_output_v1_t.error_span = {
   file: fpath;
@@ -267,6 +291,7 @@ type error_span = Semgrep_output_v1_t.error_span = {
   context_start: position option option;
   context_end: position option option
 }
+  [@@deriving show]
 
 type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   path: string;
@@ -276,6 +301,7 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   col: int option;
   text: string option
 }
+  [@@deriving show]
 
 type core_timing = Semgrep_output_v1_t.core_timing = {
   rules: rule_id list;
@@ -283,11 +309,13 @@ type core_timing = Semgrep_output_v1_t.core_timing = {
   targets: target_time list;
   max_memory_bytes: int option
 }
+  [@@deriving show]
 
 type core_stats = Semgrep_output_v1_t.core_stats = {
   okfiles: int;
   errorfiles: int
 }
+  [@@deriving show]
 
 type core_severity = Semgrep_output_v1_t.core_severity = 
     Error | Warning | Info
@@ -303,6 +331,7 @@ type core_output_extra = Semgrep_output_v1_t.core_output_extra = {
   skipped_rules: skipped_rule list;
   stats: core_stats
 }
+  [@@deriving show]
 
 type core_error_kind = Semgrep_output_v1_t.core_error_kind = 
     LexicalError
@@ -334,6 +363,7 @@ type core_error = Semgrep_output_v1_t.core_error = {
   message: string;
   details: string option
 }
+  [@@deriving show]
 
 type core_output = Semgrep_output_v1_t.core_output = {
   errors: core_error list;
@@ -346,19 +376,22 @@ type core_output = Semgrep_output_v1_t.core_output = {
   skipped_rules: skipped_rule list;
   stats: core_stats
 }
+  [@@deriving show]
 
 type contributor = Semgrep_output_v1_t.contributor = {
   commit_author_name: string;
   commit_author_email: string
 }
+  [@@deriving show]
 
 type contribution = Semgrep_output_v1_t.contribution = {
   commit_hash: string;
   commit_timestamp: string;
   contributor: contributor
 }
+  [@@deriving show]
 
-type contributions = Semgrep_output_v1_t.contributions
+type contributions = Semgrep_output_v1_t.contributions [@@deriving show]
 
 type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: scanned_and_skipped;
@@ -368,6 +401,7 @@ type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   engine_requested: engine_kind option;
   skipped_rules: skipped_rule list
 }
+  [@@deriving show]
 
 type cli_match_extra = Semgrep_output_v1_t.cli_match_extra = {
   metavars: metavars option;
@@ -386,6 +420,7 @@ type cli_match_extra = Semgrep_output_v1_t.cli_match_extra = {
   validation_state: validation_state option;
   extra_extra: raw_json option
 }
+  [@@deriving show]
 
 type cli_match = Semgrep_output_v1_t.cli_match = {
   check_id: rule_id;
@@ -394,6 +429,7 @@ type cli_match = Semgrep_output_v1_t.cli_match = {
   end_ (*atd end *): position;
   extra: cli_match_extra
 }
+  [@@deriving show]
 
 type cli_error = Semgrep_output_v1_t.cli_error = {
   code: int;
@@ -407,6 +443,7 @@ type cli_error = Semgrep_output_v1_t.cli_error = {
   spans: error_span list option;
   help: string option
 }
+  [@@deriving show]
 
 type cli_output = Semgrep_output_v1_t.cli_output = {
   version: version option;
@@ -419,8 +456,10 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   engine_requested: engine_kind option;
   skipped_rules: skipped_rule list
 }
+  [@@deriving show]
 
 type ci_scan_dependencies = Semgrep_output_v1_t.ci_scan_dependencies
+  [@@deriving show]
 
 type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   findings: finding list;
@@ -432,6 +471,7 @@ type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   contributions: contributions option;
   dependencies: ci_scan_dependencies option
 }
+  [@@deriving show]
 
 type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
   findings: int;
@@ -442,6 +482,7 @@ type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
   parse_rate: (string * parsing_stats) list;
   engine_requested: string option
 }
+  [@@deriving show]
 
 type ci_scan_complete_response =
   Semgrep_output_v1_t.ci_scan_complete_response = {
@@ -451,6 +492,7 @@ type ci_scan_complete_response =
   dependency_parser_errors: dependency_parser_error list option;
   task_id: string option
 }
+  [@@deriving show]
 
 let write__string_option = (
   Atdgen_runtime.Oj_run.write_std_option (
@@ -566,7 +608,7 @@ let read_fpath = (
 let fpath_of_string s =
   read_fpath (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_matching_operation : _ -> matching_operation -> _ = (
-  fun ob x ->
+  fun ob (x : matching_operation) ->
     match x with
       | And -> Buffer.add_string ob "\"And\""
       | Or -> Buffer.add_string ob "\"Or\""
@@ -2143,7 +2185,7 @@ let read__validation_state_option = (
 let _validation_state_option_of_string s =
   read__validation_state_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_match_call_trace : _ -> match_call_trace -> _ = (
-  fun ob x ->
+  fun ob (x : match_call_trace) ->
     match x with
       | CliLoc x ->
         Buffer.add_string ob "[\"CliLoc\",";
@@ -4334,7 +4376,7 @@ let read_target_time = (
 let target_time_of_string s =
   read_target_time (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_skip_reason : _ -> skip_reason -> _ = (
-  fun ob x ->
+  fun ob (x : skip_reason) ->
     match x with
       | Always_skipped -> Buffer.add_string ob "\"always_skipped\""
       | Semgrepignore_patterns_match -> Buffer.add_string ob "\"semgrepignore_patterns_match\""
@@ -11359,7 +11401,7 @@ let read_core_stats = (
 let core_stats_of_string s =
   read_core_stats (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_severity : _ -> core_severity -> _ = (
-  fun ob x ->
+  fun ob (x : core_severity) ->
     match x with
       | Error -> Buffer.add_string ob "\"error\""
       | Warning -> Buffer.add_string ob "\"warning\""
@@ -11958,7 +12000,7 @@ let read__location_list = (
 let _location_list_of_string s =
   read__location_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_error_kind : _ -> core_error_kind -> _ = (
-  fun ob x ->
+  fun ob (x : core_error_kind) ->
     match x with
       | LexicalError -> Buffer.add_string ob "\"Lexical error\""
       | ParseError -> Buffer.add_string ob "\"Syntax error\""

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -39,8 +39,9 @@ type match_intermediate_var = Semgrep_output_v1_t.match_intermediate_var = {
   location: location;
   content: string
 }
+  [@@deriving show]
 
-type raw_json = Yojson.Basic.t
+type raw_json = Yojson.Basic.t [@@deriving show]
 
 type rule_id = Semgrep_output_v1_t.rule_id [@@deriving show]
 
@@ -49,6 +50,7 @@ type svalue_value = Semgrep_output_v1_t.svalue_value = {
   svalue_end: position option;
   svalue_abstract_content: string
 }
+  [@@deriving show]
 
 type metavar_value = Semgrep_output_v1_t.metavar_value = {
   start: position;
@@ -56,8 +58,9 @@ type metavar_value = Semgrep_output_v1_t.metavar_value = {
   abstract_content: string;
   propagated_value: svalue_value option
 }
+  [@@deriving show]
 
-type metavars = Semgrep_output_v1_t.metavars
+type metavars = Semgrep_output_v1_t.metavars [@@deriving show]
 
 type validation_state = Semgrep_output_v1_t.validation_state
   [@@deriving show]
@@ -71,12 +74,14 @@ type match_call_trace = Semgrep_output_v1_t.match_call_trace =
         * match_call_trace
       )
 
+  [@@deriving show]
 
 type match_dataflow_trace = Semgrep_output_v1_t.match_dataflow_trace = {
   taint_source: match_call_trace option;
   intermediate_vars: match_intermediate_var list option;
   taint_sink: match_call_trace option
 }
+  [@@deriving show]
 
 type core_match_extra = Semgrep_output_v1_t.core_match_extra = {
   message: string option;
@@ -87,6 +92,7 @@ type core_match_extra = Semgrep_output_v1_t.core_match_extra = {
   validation_state: validation_state option;
   extra_extra: raw_json option
 }
+  [@@deriving show]
 
 type core_match = Semgrep_output_v1_t.core_match = {
   check_id: rule_id;
@@ -95,6 +101,7 @@ type core_match = Semgrep_output_v1_t.core_match = {
   end_ (*atd end *): position;
   extra: core_match_extra
 }
+  [@@deriving show]
 
 type matching_explanation = Semgrep_output_v1_t.matching_explanation = {
   op: matching_operation;
@@ -102,22 +109,25 @@ type matching_explanation = Semgrep_output_v1_t.matching_explanation = {
   matches: core_match list;
   loc: location
 }
+  [@@deriving show]
 
 type version = Semgrep_output_v1_t.version [@@deriving show]
 
-type transitivity = Semgrep_output_v1_t.transitivity
+type transitivity = Semgrep_output_v1_t.transitivity [@@deriving show]
 
 type rule_times = Semgrep_output_v1_t.rule_times = {
   rule_id: rule_id;
   parse_time: float;
   match_time: float
 }
+  [@@deriving show]
 
 type target_time = Semgrep_output_v1_t.target_time = {
   path: fpath;
   rule_times: rule_times list;
   run_time: float
 }
+  [@@deriving show]
 
 type skip_reason = Semgrep_output_v1_t.skip_reason = 
     Always_skipped | Semgrepignore_patterns_match
@@ -141,21 +151,24 @@ type skipped_rule = Semgrep_output_v1_t.skipped_rule = {
   details: string;
   position: position
 }
+  [@@deriving show]
 
 type scanned_and_skipped = Semgrep_output_v1_t.scanned_and_skipped = {
   scanned: string list;
   _comment: string option;
   skipped: skipped_target list option
 }
+  [@@deriving show]
 
-type sca_parser_name = Semgrep_output_v1_t.sca_parser_name
+type sca_parser_name = Semgrep_output_v1_t.sca_parser_name [@@deriving show]
 
-type ecosystem = Semgrep_output_v1_t.ecosystem
+type ecosystem = Semgrep_output_v1_t.ecosystem [@@deriving show]
 
 type dependency_child = Semgrep_output_v1_t.dependency_child = {
   package: string;
   version: string
 }
+  [@@deriving show]
 
 type found_dependency = Semgrep_output_v1_t.found_dependency = {
   package: string;
@@ -167,18 +180,21 @@ type found_dependency = Semgrep_output_v1_t.found_dependency = {
   line_number: int option;
   children: dependency_child list option
 }
+  [@@deriving show]
 
 type dependency_pattern = Semgrep_output_v1_t.dependency_pattern = {
   ecosystem: ecosystem;
   package: string;
   semver_range: string
 }
+  [@@deriving show]
 
 type dependency_match = Semgrep_output_v1_t.dependency_match = {
   dependency_pattern: dependency_pattern;
   found_dependency: found_dependency;
   lockfile: string
 }
+  [@@deriving show]
 
 type sca_info = Semgrep_output_v1_t.sca_info = {
   reachable: bool;
@@ -186,8 +202,10 @@ type sca_info = Semgrep_output_v1_t.sca_info = {
   sca_finding_schema: int;
   dependency_match: dependency_match
 }
+  [@@deriving show]
 
 type rule_id_and_engine_kind = Semgrep_output_v1_t.rule_id_and_engine_kind
+  [@@deriving show]
 
 type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   path: fpath;
@@ -196,6 +214,7 @@ type cli_target_times = Semgrep_output_v1_t.cli_target_times = {
   parse_times: float list;
   run_time: float
 }
+  [@@deriving show]
 
 type profile = Semgrep_output_v1_t.profile = {
   rules: rule_id list;
@@ -205,6 +224,7 @@ type profile = Semgrep_output_v1_t.profile = {
   total_bytes: int;
   max_memory_bytes: int option
 }
+  [@@deriving show]
 
 type parsing_stats = Semgrep_output_v1_t.parsing_stats = {
   targets_parsed: int;
@@ -212,6 +232,7 @@ type parsing_stats = Semgrep_output_v1_t.parsing_stats = {
   bytes_parsed: int;
   num_bytes: int
 }
+  [@@deriving show]
 
 type incompatible_rule = Semgrep_output_v1_t.incompatible_rule = {
   rule_id: rule_id;
@@ -226,6 +247,7 @@ type fix_regex = Semgrep_output_v1_t.fix_regex = {
   replacement: string;
   count: int option
 }
+  [@@deriving show]
 
 type finding_hashes = Semgrep_output_v1_t.finding_hashes = {
   start_line_hash: string;
@@ -233,6 +255,7 @@ type finding_hashes = Semgrep_output_v1_t.finding_hashes = {
   code_hash: string;
   pattern_hash: string
 }
+  [@@deriving show]
 
 type finding = Semgrep_output_v1_t.finding = {
   check_id: rule_id;
@@ -255,6 +278,7 @@ type finding = Semgrep_output_v1_t.finding = {
   dataflow_trace: match_dataflow_trace option;
   validation_state: validation_state option
 }
+  [@@deriving show]
 
 type error_span = Semgrep_output_v1_t.error_span = {
   file: fpath;
@@ -267,6 +291,7 @@ type error_span = Semgrep_output_v1_t.error_span = {
   context_start: position option option;
   context_end: position option option
 }
+  [@@deriving show]
 
 type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   path: string;
@@ -276,6 +301,7 @@ type dependency_parser_error = Semgrep_output_v1_t.dependency_parser_error = {
   col: int option;
   text: string option
 }
+  [@@deriving show]
 
 type core_timing = Semgrep_output_v1_t.core_timing = {
   rules: rule_id list;
@@ -283,11 +309,13 @@ type core_timing = Semgrep_output_v1_t.core_timing = {
   targets: target_time list;
   max_memory_bytes: int option
 }
+  [@@deriving show]
 
 type core_stats = Semgrep_output_v1_t.core_stats = {
   okfiles: int;
   errorfiles: int
 }
+  [@@deriving show]
 
 type core_severity = Semgrep_output_v1_t.core_severity = 
     Error | Warning | Info
@@ -303,6 +331,7 @@ type core_output_extra = Semgrep_output_v1_t.core_output_extra = {
   skipped_rules: skipped_rule list;
   stats: core_stats
 }
+  [@@deriving show]
 
 type core_error_kind = Semgrep_output_v1_t.core_error_kind = 
     LexicalError
@@ -334,6 +363,7 @@ type core_error = Semgrep_output_v1_t.core_error = {
   message: string;
   details: string option
 }
+  [@@deriving show]
 
 type core_output = Semgrep_output_v1_t.core_output = {
   errors: core_error list;
@@ -346,19 +376,22 @@ type core_output = Semgrep_output_v1_t.core_output = {
   skipped_rules: skipped_rule list;
   stats: core_stats
 }
+  [@@deriving show]
 
 type contributor = Semgrep_output_v1_t.contributor = {
   commit_author_name: string;
   commit_author_email: string
 }
+  [@@deriving show]
 
 type contribution = Semgrep_output_v1_t.contribution = {
   commit_hash: string;
   commit_timestamp: string;
   contributor: contributor
 }
+  [@@deriving show]
 
-type contributions = Semgrep_output_v1_t.contributions
+type contributions = Semgrep_output_v1_t.contributions [@@deriving show]
 
 type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   paths: scanned_and_skipped;
@@ -368,6 +401,7 @@ type cli_output_extra = Semgrep_output_v1_t.cli_output_extra = {
   engine_requested: engine_kind option;
   skipped_rules: skipped_rule list
 }
+  [@@deriving show]
 
 type cli_match_extra = Semgrep_output_v1_t.cli_match_extra = {
   metavars: metavars option;
@@ -386,6 +420,7 @@ type cli_match_extra = Semgrep_output_v1_t.cli_match_extra = {
   validation_state: validation_state option;
   extra_extra: raw_json option
 }
+  [@@deriving show]
 
 type cli_match = Semgrep_output_v1_t.cli_match = {
   check_id: rule_id;
@@ -394,6 +429,7 @@ type cli_match = Semgrep_output_v1_t.cli_match = {
   end_ (*atd end *): position;
   extra: cli_match_extra
 }
+  [@@deriving show]
 
 type cli_error = Semgrep_output_v1_t.cli_error = {
   code: int;
@@ -407,6 +443,7 @@ type cli_error = Semgrep_output_v1_t.cli_error = {
   spans: error_span list option;
   help: string option
 }
+  [@@deriving show]
 
 type cli_output = Semgrep_output_v1_t.cli_output = {
   version: version option;
@@ -419,8 +456,10 @@ type cli_output = Semgrep_output_v1_t.cli_output = {
   engine_requested: engine_kind option;
   skipped_rules: skipped_rule list
 }
+  [@@deriving show]
 
 type ci_scan_dependencies = Semgrep_output_v1_t.ci_scan_dependencies
+  [@@deriving show]
 
 type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   findings: finding list;
@@ -432,6 +471,7 @@ type ci_scan_results = Semgrep_output_v1_t.ci_scan_results = {
   contributions: contributions option;
   dependencies: ci_scan_dependencies option
 }
+  [@@deriving show]
 
 type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
   findings: int;
@@ -442,6 +482,7 @@ type ci_scan_complete_stats = Semgrep_output_v1_t.ci_scan_complete_stats = {
   parse_rate: (string * parsing_stats) list;
   engine_requested: string option
 }
+  [@@deriving show]
 
 type ci_scan_complete_response =
   Semgrep_output_v1_t.ci_scan_complete_response = {
@@ -451,6 +492,7 @@ type ci_scan_complete_response =
   dependency_parser_errors: dependency_parser_error list option;
   task_id: string option
 }
+  [@@deriving show]
 
 val write_engine_kind :
   Buffer.t -> engine_kind -> unit


### PR DESCRIPTION
This reverts commit 1b83490f086c572b239b20960340a5c3e1b93ae4.

Many of the removed deriving shows were needed by code in pro, e.g., https://github.com/returntocorp/semgrep-proprietary/blob/develop/server/cli/Server_CLI.ml.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
