### PR TITLE
feat!: new syntax for secrets validators/postprocessors

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -10,7 +10,12 @@ $defs:
   validator:
     properties:
       http:
-        type: object # TODO(cooper)
+        properties:
+          request:
+            $ref: "#/$defs/http-request-content"
+          response:
+            $ref: "#/$defs/http-response-content"
+        required: [ request, response ]
     # An individual validator shall be exactly one 'kind' of validator.
     oneOf:
       - required: [ http ]
@@ -54,7 +59,11 @@ $defs:
             name: string
             value: string
       content:
-        type: object # TODO(cooper): fields
+        type: object
+        properties:
+          # TODO(cooper): re-use languages sub-enum?
+          language: string 
+        $ref: "#/$defs/general-pattern-content"
   # EXPERIMENTAL
   new-source-pattern:
     $ref: "#/$defs/new-pattern"

--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -7,13 +7,15 @@ $schema: http://json-schema.org/draft-07/schema#
 #  comment before!!
 $defs:
   # EXPERIMENTAL
-  postprocessor-patterns-content:
-    type: array
-    minItems: 1
-    items:
-      ref: "#/$defs/general-pattern-content"
+  validator:
+    properties:
+      http:
+        type: object # TODO(cooper)
+    # An individual validator shall be exactly one 'kind' of validator.
+    oneOf:
+      - required: [ http ]
   # EXPERIMENTAL
-  request-content:
+  http-request-content:
     properties:
       url:
         type: string
@@ -26,12 +28,33 @@ $defs:
       auth:
         type: object
   # EXPERIMENTAL
-  response-content:
+  http-response-content:
+    type: array
+    items:
+      $ref: "#/$defs/http-response-item"
+  # EXPERIMENTAL
+  http-response-item:
     properties:
-      return_code:
-        type: string
-      pattern-regex:
-        type: string
+      match:
+        $ref: "#/$defs/http-response-match"
+      result:
+        properties:
+          validity:
+            enum: [ valid, invalid ]
+
+  # EXPERIMENTAL
+  http-response-match:
+    properties:
+      status-code:
+        type: int
+      headers:
+        type: array
+        items:
+          properties:
+            name: string
+            value: string
+      content:
+        type: object # TODO(cooper): fields
   # EXPERIMENTAL
   new-source-pattern:
     $ref: "#/$defs/new-pattern"
@@ -778,15 +801,14 @@ properties:
           $ref: "#/$defs/taint-content"
         taint:
           $ref: "#/$defs/new-taint-content"
-        # EXPERIMENTAL
-        postprocessor-patterns:
-          $ref: "#/$defs/postprocessor-patterns-content"
-        request:
-          $ref: "#/$defs/request-content"
-        response:
-          $ref: "#/$defs/response-content"
         join:
           $ref: "#/$defs/join-content"
+        # EXPERIMENTAL
+        validators:
+          type: array
+          minItems: 1
+          items:
+            $ref: "#/$defs/validator"
         fix:
           title: Replacement text to fix matched code. Can use matched metavariables.
           type: string
@@ -1032,32 +1054,3 @@ properties:
               pattern-propagators: false
               pattern-sanitizers: false
               join: false
-        - if:
-            properties:
-              mode:
-                const: semgrep_internal_postprocessor
-            required:
-              - mode
-          then:
-            required:
-              - id
-              - message
-              - severity
-              - postprocessor-patterns
-              - request
-              - response
-            properties:
-              extract: false
-              dest-language: false
-              # EXPERIMENTAL
-              transform: false
-              reduce: false
-              patterns: false
-              pattern: false
-              pattern-either: false
-              pattern-regex: false
-              pattern-sinks: false
-              pattern-sources: false
-              pattern-propagators: false
-              pattern-sanitizers: false
-              match: false

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -566,7 +566,7 @@ let read_fpath = (
 let fpath_of_string s =
   read_fpath (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_matching_operation : _ -> matching_operation -> _ = (
-  fun ob x ->
+  fun ob (x : matching_operation) ->
     match x with
       | And -> Buffer.add_string ob "\"And\""
       | Or -> Buffer.add_string ob "\"Or\""
@@ -2143,7 +2143,7 @@ let read__validation_state_option = (
 let _validation_state_option_of_string s =
   read__validation_state_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let rec write_match_call_trace : _ -> match_call_trace -> _ = (
-  fun ob x ->
+  fun ob (x : match_call_trace) ->
     match x with
       | CliLoc x ->
         Buffer.add_string ob "[\"CliLoc\",";
@@ -4236,7 +4236,7 @@ let read_target_times = (
 let target_times_of_string s =
   read_target_times (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_skip_reason : _ -> skip_reason -> _ = (
-  fun ob x ->
+  fun ob (x : skip_reason) ->
     match x with
       | Always_skipped -> Buffer.add_string ob "\"always_skipped\""
       | Semgrepignore_patterns_match -> Buffer.add_string ob "\"semgrepignore_patterns_match\""
@@ -11879,7 +11879,7 @@ let read_datetime = (
 let datetime_of_string s =
   read_datetime (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_severity : _ -> core_severity -> _ = (
-  fun ob x ->
+  fun ob (x : core_severity) ->
     match x with
       | Error -> Buffer.add_string ob "\"error\""
       | Warning -> Buffer.add_string ob "\"warning\""
@@ -11946,7 +11946,7 @@ let read__location_list = (
 let _location_list_of_string s =
   read__location_list (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_core_error_kind : _ -> core_error_kind -> _ = (
-  fun ob x ->
+  fun ob (x : core_error_kind) ->
     match x with
       | LexicalError -> Buffer.add_string ob "\"Lexical error\""
       | ParseError -> Buffer.add_string ob "\"Syntax error\""


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
