### PR TITLE
update comment for ci_scan_complete.dependencies

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -1041,7 +1041,7 @@ type ci_scan_dependencies = (string * found_dependency list) list
 type ci_scan_complete = {
   exit_code: int;
   stats: ci_scan_complete_stats;
-  ?dependencies: ci_scan_dependencies option;
+  ?dependencies: ci_scan_dependencies option; (* remove when min version is 1.38.0 *)
   ?dependency_parser_errors: dependency_parser_error list option;
   ?task_id: string option;
   ?final_attempt: bool option; (* always optional *)


### PR DESCRIPTION
- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
