### PR TITLE
string wrap part4, ruleid

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -13,9 +13,7 @@
  * version of this JSON format. If you need to extend this file, please
  * be careful because you may break consumers of this format (e.g., the
  * Semgrep playground or Semgrep backend or external users of this JSON).
- * See
- *    https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
- *
+ * See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
  * for more information on how to smoothly extend the types in this file.
  *
  * Any backward incompatible changes should require to upgrade the major
@@ -106,7 +104,8 @@ type position
 }
 
 (* File path. less: could convert directly to Path class of pathlib library for Python *)
-type fpath <ocaml attr="deriving show"> = string wrap <ocaml module="ATDStringWrap.Fpath">
+type fpath <ocaml attr="deriving show"> =
+  string wrap <ocaml module="ATDStringWrap.Fpath">
 
 (* a.k.a range *)
 type location
@@ -123,8 +122,9 @@ type location
 
 (* e.g., "javascript.security.do-not-use-eval" *)
 type rule_id
-  <ocaml attr="deriving show">
-  <python decorator="dataclass(frozen=True)"> = string
+     <ocaml attr="deriving show">
+     <python decorator="dataclass(frozen=True)"> =
+  string wrap <ocaml module="ATDStringWrap.Ruleid">
 
 (*
    Error = something wrong that must be fixed

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -566,6 +566,25 @@ let read__x_b7c1b6a = (
 )
 let _x_b7c1b6a_of_string s =
   read__x_b7c1b6a (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
+let write__x_ba914e0 = (
+  fun ob x -> (
+    let x = ( ATDStringWrap.Ruleid.unwrap ) x in (
+      Yojson.Safe.write_string
+    ) ob x)
+)
+let string_of__x_ba914e0 ?(len = 1024) x =
+  let ob = Buffer.create len in
+  write__x_ba914e0 ob x;
+  Buffer.contents ob
+let read__x_ba914e0 = (
+  fun p lb ->
+    let x = (
+      Atdgen_runtime.Oj_run.read_string
+    ) p lb in
+    ( ATDStringWrap.Ruleid.wrap ) x
+)
+let _x_ba914e0_of_string s =
+  read__x_ba914e0 (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_engine_kind = (
   fun ob x ->
     match x with
@@ -1641,14 +1660,14 @@ let read__raw_json_option = (
 let _raw_json_option_of_string s =
   read__raw_json_option (Yojson.Safe.init_lexer ()) (Lexing.from_string s)
 let write_rule_id = (
-  Yojson.Safe.write_string
+  write__x_ba914e0
 )
 let string_of_rule_id ?(len = 1024) x =
   let ob = Buffer.create len in
   write_rule_id ob x;
   Buffer.contents ob
 let read_rule_id = (
-  Atdgen_runtime.Oj_run.read_string
+  read__x_ba914e0
 )
 let rule_id_of_string s =
   read_rule_id (Yojson.Safe.init_lexer ()) (Lexing.from_string s)


### PR DESCRIPTION
test plan:
see related PR in semgrep


- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades