### PR TITLE
add diff scan related metrics

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -60,10 +60,10 @@ type environment = {
     ?rulesHash <ocaml mutable>: sha256 option;
     (* TODO: should be just boolean *)
     ci <ocaml mutable>: string nullable;
-    (* SHA-256 hash of the commit ID specified via `--baseline_commit` option.
-       If `baseline_commit` option is set, it implies that the scan is operating
+    (* indicates whether `--baseline-commit` option has been specified. When
+       `baseline_commit` option is set, it implies that the scan is operating
        in differential scan mode. Since semgrep 1.46 *)
-    ?baselineCommitHash <ocaml mutable> : sha256 option;
+    ~isDiffScan <python default="False"> <ocaml mutable> : bool;
     ?integrationName <ocaml mutable>: string option;
     ~isAuthenticated <python default="False"> <ocaml mutable>: bool;
   }
@@ -142,7 +142,7 @@ type pro_features = {
 type misc = {
     (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
     features <ocaml mutable>: string list;
-    proFeatures <ocaml mutable>: pro_features;
+    proFeatures <ocaml mutable>: pro_features option;
     ?numFindings <ocaml mutable>: int option;
     ?numIgnored <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -60,6 +60,9 @@ type environment = {
     ?rulesHash <ocaml mutable>: sha256 option;
     (* TODO: should be just boolean *)
     ci <ocaml mutable>: string nullable;
+    (* SHA-256 hash of the commit ID specified via `--baseline_commit` option.
+       If `baseline_commit` option is set, it implies that the scan is operating
+       in differential scan mode. Since semgrep 1.46 *)
     ?baselineCommitHash <ocaml mutable> : sha256 option;
     ?integrationName <ocaml mutable>: string option;
     ~isAuthenticated <python default="False"> <ocaml mutable>: bool;
@@ -130,12 +133,18 @@ type extension = {
 (* Misc *)
 (*****************************************************************************)
 
+type pro_features = {
+    (* The value is determined by the `--diff-depth` option, and it's utilized
+       for inter-file differential scanning. Since semgrep 1.46 *)
+    ?diffDepth <ocaml mutable>: int option;
+}
+
 type misc = {
     (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
     features <ocaml mutable>: string list;
+    proFeatures <ocaml mutable>: pro_features;
     ?numFindings <ocaml mutable>: int option;
     ?numIgnored <ocaml mutable>: int option;
-    ?diffDepth <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
     (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)
     ~engineRequested <python default="'OSS'"> <ocaml mutable>: string;

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -142,6 +142,7 @@ type pro_features = {
 type misc = {
     (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
     features <ocaml mutable>: string list;
+    (* Since semgrep 1.46 *)
     ?proFeatures <ocaml mutable>: pro_features option;
     ?numFindings <ocaml mutable>: int option;
     ?numIgnored <ocaml mutable>: int option;

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -60,6 +60,7 @@ type environment = {
     ?rulesHash <ocaml mutable>: sha256 option;
     (* TODO: should be just boolean *)
     ci <ocaml mutable>: string nullable;
+    ?baselineCommitHash <ocaml mutable> : sha256 option;
     ?integrationName <ocaml mutable>: string option;
     ~isAuthenticated <python default="False"> <ocaml mutable>: bool;
   }
@@ -134,6 +135,7 @@ type misc = {
     features <ocaml mutable>: string list;
     ?numFindings <ocaml mutable>: int option;
     ?numIgnored <ocaml mutable>: int option;
+    ?diffDepth <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;
     (* TODO: should be OSS | Pro, see semgrep_output_v1.atd engine_kind type *)
     ~engineRequested <python default="'OSS'"> <ocaml mutable>: string;

--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -142,7 +142,7 @@ type pro_features = {
 type misc = {
     (* coupling: features is commented a lot in semgrep/PRIVACY.md *)
     features <ocaml mutable>: string list;
-    proFeatures <ocaml mutable>: pro_features option;
+    ?proFeatures <ocaml mutable>: pro_features option;
     ?numFindings <ocaml mutable>: int option;
     ?numIgnored <ocaml mutable>: int option;
     ?ruleHashesWithFindings <ocaml mutable>: (string * int) list <json repr="object"> option;

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -341,6 +341,35 @@ class RuleStats:
 
 
 @dataclass
+class ProFeatures:
+    """Original type: pro_features = { ... }"""
+
+    diffDepth: Optional[int] = None
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'ProFeatures':
+        if isinstance(x, dict):
+            return cls(
+                diffDepth=_atd_read_int(x['diffDepth']) if 'diffDepth' in x else None,
+            )
+        else:
+            _atd_bad_json('ProFeatures', x)
+
+    def to_json(self) -> Any:
+        res: Dict[str, Any] = {}
+        if self.diffDepth is not None:
+            res['diffDepth'] = _atd_write_int(self.diffDepth)
+        return res
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'ProFeatures':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
 class FileStats:
     """Original type: file_stats = { ... }"""
 
@@ -478,9 +507,9 @@ class Misc:
     """Original type: misc = { ... }"""
 
     features: List[str]
+    proFeatures: ProFeatures
     numFindings: Optional[int] = None
     numIgnored: Optional[int] = None
-    diffDepth: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
     engineRequested: str = field(default_factory=lambda: 'OSS')
 
@@ -489,9 +518,9 @@ class Misc:
         if isinstance(x, dict):
             return cls(
                 features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Misc', 'features'),
+                proFeatures=ProFeatures.from_json(x['proFeatures']) if 'proFeatures' in x else _atd_missing_json_field('Misc', 'proFeatures'),
                 numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
                 numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
-                diffDepth=_atd_read_int(x['diffDepth']) if 'diffDepth' in x else None,
                 ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
                 engineRequested=_atd_read_string(x['engineRequested']) if 'engineRequested' in x else 'OSS',
             )
@@ -501,12 +530,11 @@ class Misc:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['features'] = _atd_write_list(_atd_write_string)(self.features)
+        res['proFeatures'] = (lambda x: x.to_json())(self.proFeatures)
         if self.numFindings is not None:
             res['numFindings'] = _atd_write_int(self.numFindings)
         if self.numIgnored is not None:
             res['numIgnored'] = _atd_write_int(self.numIgnored)
-        if self.diffDepth is not None:
-            res['diffDepth'] = _atd_write_int(self.diffDepth)
         if self.ruleHashesWithFindings is not None:
             res['ruleHashesWithFindings'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.ruleHashesWithFindings)
         res['engineRequested'] = _atd_write_string(self.engineRequested)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -480,6 +480,7 @@ class Misc:
     features: List[str]
     numFindings: Optional[int] = None
     numIgnored: Optional[int] = None
+    diffDepth: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
     engineRequested: str = field(default_factory=lambda: 'OSS')
 
@@ -490,6 +491,7 @@ class Misc:
                 features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Misc', 'features'),
                 numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
                 numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
+                diffDepth=_atd_read_int(x['diffDepth']) if 'diffDepth' in x else None,
                 ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
                 engineRequested=_atd_read_string(x['engineRequested']) if 'engineRequested' in x else 'OSS',
             )
@@ -503,6 +505,8 @@ class Misc:
             res['numFindings'] = _atd_write_int(self.numFindings)
         if self.numIgnored is not None:
             res['numIgnored'] = _atd_write_int(self.numIgnored)
+        if self.diffDepth is not None:
+            res['diffDepth'] = _atd_write_int(self.diffDepth)
         if self.ruleHashesWithFindings is not None:
             res['ruleHashesWithFindings'] = _atd_write_assoc_list_to_object(_atd_write_int)(self.ruleHashesWithFindings)
         res['engineRequested'] = _atd_write_string(self.engineRequested)
@@ -603,6 +607,7 @@ class Environment:
     configNamesHash: Sha256
     ci: Optional[str]
     rulesHash: Optional[Sha256] = None
+    baselineCommitHash: Optional[Sha256] = None
     integrationName: Optional[str] = None
     isAuthenticated: bool = field(default_factory=lambda: False)
 
@@ -615,6 +620,7 @@ class Environment:
                 configNamesHash=Sha256.from_json(x['configNamesHash']) if 'configNamesHash' in x else _atd_missing_json_field('Environment', 'configNamesHash'),
                 ci=_atd_read_nullable(_atd_read_string)(x['ci']) if 'ci' in x else _atd_missing_json_field('Environment', 'ci'),
                 rulesHash=Sha256.from_json(x['rulesHash']) if 'rulesHash' in x else None,
+                baselineCommitHash=Sha256.from_json(x['baselineCommitHash']) if 'baselineCommitHash' in x else None,
                 integrationName=_atd_read_string(x['integrationName']) if 'integrationName' in x else None,
                 isAuthenticated=_atd_read_bool(x['isAuthenticated']) if 'isAuthenticated' in x else False,
             )
@@ -629,6 +635,8 @@ class Environment:
         res['ci'] = _atd_write_nullable(_atd_write_string)(self.ci)
         if self.rulesHash is not None:
             res['rulesHash'] = (lambda x: x.to_json())(self.rulesHash)
+        if self.baselineCommitHash is not None:
+            res['baselineCommitHash'] = (lambda x: x.to_json())(self.baselineCommitHash)
         if self.integrationName is not None:
             res['integrationName'] = _atd_write_string(self.integrationName)
         res['isAuthenticated'] = _atd_write_bool(self.isAuthenticated)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -507,7 +507,7 @@ class Misc:
     """Original type: misc = { ... }"""
 
     features: List[str]
-    proFeatures: ProFeatures
+    proFeatures: Optional[ProFeatures]
     numFindings: Optional[int] = None
     numIgnored: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
@@ -518,7 +518,7 @@ class Misc:
         if isinstance(x, dict):
             return cls(
                 features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Misc', 'features'),
-                proFeatures=ProFeatures.from_json(x['proFeatures']) if 'proFeatures' in x else _atd_missing_json_field('Misc', 'proFeatures'),
+                proFeatures=_atd_read_option(ProFeatures.from_json)(x['proFeatures']) if 'proFeatures' in x else _atd_missing_json_field('Misc', 'proFeatures'),
                 numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
                 numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
                 ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
@@ -530,7 +530,7 @@ class Misc:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['features'] = _atd_write_list(_atd_write_string)(self.features)
-        res['proFeatures'] = (lambda x: x.to_json())(self.proFeatures)
+        res['proFeatures'] = _atd_write_option((lambda x: x.to_json()))(self.proFeatures)
         if self.numFindings is not None:
             res['numFindings'] = _atd_write_int(self.numFindings)
         if self.numIgnored is not None:
@@ -635,7 +635,7 @@ class Environment:
     configNamesHash: Sha256
     ci: Optional[str]
     rulesHash: Optional[Sha256] = None
-    baselineCommitHash: Optional[Sha256] = None
+    isDiffScan: bool = field(default_factory=lambda: False)
     integrationName: Optional[str] = None
     isAuthenticated: bool = field(default_factory=lambda: False)
 
@@ -648,7 +648,7 @@ class Environment:
                 configNamesHash=Sha256.from_json(x['configNamesHash']) if 'configNamesHash' in x else _atd_missing_json_field('Environment', 'configNamesHash'),
                 ci=_atd_read_nullable(_atd_read_string)(x['ci']) if 'ci' in x else _atd_missing_json_field('Environment', 'ci'),
                 rulesHash=Sha256.from_json(x['rulesHash']) if 'rulesHash' in x else None,
-                baselineCommitHash=Sha256.from_json(x['baselineCommitHash']) if 'baselineCommitHash' in x else None,
+                isDiffScan=_atd_read_bool(x['isDiffScan']) if 'isDiffScan' in x else False,
                 integrationName=_atd_read_string(x['integrationName']) if 'integrationName' in x else None,
                 isAuthenticated=_atd_read_bool(x['isAuthenticated']) if 'isAuthenticated' in x else False,
             )
@@ -663,8 +663,7 @@ class Environment:
         res['ci'] = _atd_write_nullable(_atd_write_string)(self.ci)
         if self.rulesHash is not None:
             res['rulesHash'] = (lambda x: x.to_json())(self.rulesHash)
-        if self.baselineCommitHash is not None:
-            res['baselineCommitHash'] = (lambda x: x.to_json())(self.baselineCommitHash)
+        res['isDiffScan'] = _atd_write_bool(self.isDiffScan)
         if self.integrationName is not None:
             res['integrationName'] = _atd_write_string(self.integrationName)
         res['isAuthenticated'] = _atd_write_bool(self.isAuthenticated)

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -507,7 +507,7 @@ class Misc:
     """Original type: misc = { ... }"""
 
     features: List[str]
-    proFeatures: Optional[ProFeatures]
+    proFeatures: Optional[ProFeatures] = None
     numFindings: Optional[int] = None
     numIgnored: Optional[int] = None
     ruleHashesWithFindings: Optional[List[Tuple[str, int]]] = None
@@ -518,7 +518,7 @@ class Misc:
         if isinstance(x, dict):
             return cls(
                 features=_atd_read_list(_atd_read_string)(x['features']) if 'features' in x else _atd_missing_json_field('Misc', 'features'),
-                proFeatures=_atd_read_option(ProFeatures.from_json)(x['proFeatures']) if 'proFeatures' in x else _atd_missing_json_field('Misc', 'proFeatures'),
+                proFeatures=ProFeatures.from_json(x['proFeatures']) if 'proFeatures' in x else None,
                 numFindings=_atd_read_int(x['numFindings']) if 'numFindings' in x else None,
                 numIgnored=_atd_read_int(x['numIgnored']) if 'numIgnored' in x else None,
                 ruleHashesWithFindings=_atd_read_assoc_object_into_list(_atd_read_int)(x['ruleHashesWithFindings']) if 'ruleHashesWithFindings' in x else None,
@@ -530,7 +530,8 @@ class Misc:
     def to_json(self) -> Any:
         res: Dict[str, Any] = {}
         res['features'] = _atd_write_list(_atd_write_string)(self.features)
-        res['proFeatures'] = _atd_write_option((lambda x: x.to_json()))(self.proFeatures)
+        if self.proFeatures is not None:
+            res['proFeatures'] = (lambda x: x.to_json())(self.proFeatures)
         if self.numFindings is not None:
             res['numFindings'] = _atd_write_int(self.numFindings)
         if self.numIgnored is not None:


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
