### PR TITLE
Use string wrap in semgrep_metrics.atd

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -20,33 +20,43 @@
 (* Basic types *)
 (*****************************************************************************)
 
-(* TODO: better type *)
-type uuid = string
+type uuid = string wrap <ocaml module="ATDStringWrap.Uuidm">
 
-(* TODO: better type. Stored as gmtime. *)
-type datetime = string
+type sha256 = string wrap <ocaml module="ATDStringWrap.Sha256">
 
-type sha256 = string
+(* GMT time (in osemgrep at least), in isoformat *)
+type datetime = string wrap <ocaml module="ATDStringWrap.Datetime">
 
-(* TODO: type fpath = string *)
+type lang = string
+
+(* Note that there is no 'fpath' type here. We don't send concrete filenames *)
 
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 
 type payload = {
+    (* required event and timing *)
     event_id <ocaml mutable>: uuid;
     (* as stored in ~/.semgrep/settings.yml *)
     anonymous_user_id <python default="''"> <ocaml mutable>: string;
     started_at <python default="Datetime('')"> <ocaml mutable>: datetime;
     sent_at <python default="Datetime('')"> <ocaml mutable>: datetime;
+
+    (* other fields *)
     environment <ocaml mutable>: environment;
     performance <ocaml mutable>: performance;
     extension <ocaml mutable>: extension;
     errors <ocaml mutable>: errors;
     (* TODO? why called value? *)
     value <ocaml mutable>: misc;
-    ~parse_rate <ocaml mutable>: (string * parse_stat) list <json repr="object">;
+    (* the string is a 'lang' below but we can't use the alias because this
+     * confuses atd which is checking for a 'string' because of the json
+     * repr annotation coming after.
+     * TODO? should we move under performance instead of at the top here?
+     *)
+    ~parse_rate <ocaml mutable>: (string (* lang *) * parse_stat) list
+                                 <json repr="object">;
 }
 
 (*****************************************************************************)
@@ -54,6 +64,7 @@ type payload = {
 (*****************************************************************************)
 
 type environment = {
+    (* semgrep version *)
     version <ocaml mutable>: string;
     projectHash <ocaml mutable>: sha256 nullable;
     configNamesHash <python default="Sha256hash('')"> <ocaml mutable>: sha256;

--- a/semgrep_metrics.py
+++ b/semgrep_metrics.py
@@ -737,3 +737,24 @@ class Payload:
 
     def to_json_string(self, **kw: Any) -> str:
         return json.dumps(self.to_json(), **kw)
+
+
+@dataclass
+class Lang:
+    """Original type: lang"""
+
+    value: str
+
+    @classmethod
+    def from_json(cls, x: Any) -> 'Lang':
+        return cls(_atd_read_string(x))
+
+    def to_json(self) -> Any:
+        return _atd_write_string(self.value)
+
+    @classmethod
+    def from_json_string(cls, x: str) -> 'Lang':
+        return cls.from_json(json.loads(x))
+
+    def to_json_string(self, **kw: Any) -> str:
+        return json.dumps(self.to_json(), **kw)


### PR DESCRIPTION
test plan:
see related PR in semgrep


- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades