### PR TITLE
Use the latest semgrep_studio_v1.proto

### DIFF
--- a/semgrep_studio_v1.proto
+++ b/semgrep_studio_v1.proto
@@ -2,18 +2,35 @@ syntax = "proto3";
 
 package semgrep_studio_v1;
 
-import "semgrep_output_v1.proto";
+option go_package = "semgrep_studio.v1";
+
+import "protos/semgrep_output_v1.proto";
+
+enum RuleFormat {
+  YAML = 0;
+  JSON = 1;
+  JSONNET = 2;
+}
 
 message ScanRequest {
-    string pattern = 1;
-    repeated string repository_names = 2;
+    // the rule raw content
+    string rule = 1;
+    // how to parse the rule content
+    RuleFormat rule_format = 2;
+
+    // list of repos to scan, e.g. ["semgrep", "semgrep-app"]
+    // Note that semgrep-server must be setup with those
+    // same repos and use the same names
+    repeated string repository_names = 3;
 }
 
 message ScanResult {
+    // same as one of the repository_names in the request
     string repository_name = 1;
     semgrep_output_v1.CliMatch cli_match = 2;
 }
 
 service ScanService {
+    // we provide a streaming interface here! to return results as soon as they arrive!
     rpc Scan(ScanRequest) returns (stream ScanResult) {};
 }


### PR DESCRIPTION
This was in a branch but not in main

test plan:
see related PR in semgrep-server


- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades