### PR TITLE
Add CI workflow to test backwards compatability

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 jobs:
-  build:
+  check-backwards-compatability:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tree
@@ -28,7 +28,7 @@ jobs:
 
       - run: opam install atd
 
-      - name: test
+      - name: atddiff all supported tags
         run: |
             set -e
             eval $(opam env)

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,14 +26,19 @@ jobs:
           opam-depext: false
           dune-cache: true
 
-      - run: opam install atdgen
+      - run: |
+            opam install atdgen
+            opam env >> $GITHUB_ENV
 
       - name: test
         run: |
             set -e
-            git tag -l
+
+            # fetch minimum version and enumerate tags for supported releases
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
             tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
+
+            # check tags
             for tag in $tags; do
                 echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
                 git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,28 +9,28 @@ on:
 permissions: read-all
 
 jobs:
-  compatability:
+  compatibility:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout tree
-        uses: actions/checkout@v4
-        with:
-            fetch-depth: 0
-            fetch-tags: true
+    - name: Checkout tree
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
-      - name: Set-up OCaml
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: 5.1
-          opam-pin: false
-          opam-depext: false
-          dune-cache: true
+    - name: Set-up OCaml
+      uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 5.1
+        opam-pin: false
+        opam-depext: false
+        dune-cache: true
 
-      - name: install atddiff
-        run: opam install atd
+    - name: install atddiff
+      run: opam install atd
 
-      - name: atddiff all supported tags
-        shell: bash
-        run: |
-            eval $(opam env)
-            ./scripts/check-backwards-compatability.sh
+    - name: atddiff all supported tags
+      shell: bash
+      run: |
+        eval $(opam env)
+          ./scripts/check-backwards-compatability.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,11 +14,15 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@v4
+        with:
+            fetch-depth: 0 # get all tags
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: 5.1
+          opam-pin: false
+          opam-depext: false
 
       - run: opam install atdgen
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,7 +38,15 @@ jobs:
             tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
 
             # check tags
+            checked=()
             for tag in $tags; do
+                commit=$(git rev-list -n 1 "$tag")
+                if [[ "${checked[*]}" =~ $commit ]]; then
+                    echo "Skipping $tag because commit $commit has already been checked"
+                    continue
+                fi
+                checked+=($commit)
+
                 echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
                 git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd
             done

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,7 +33,7 @@ jobs:
             set -e
             git tag -l
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
-            tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
+            tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
             for tag in $tags; do
                 echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
                 git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,7 +6,8 @@ on:
     branches:
         - main
 
-permissions: read-all
+permissions:
+  pull-requests: write # for comments
 
 jobs:
   compatibility:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,15 +26,12 @@ jobs:
           opam-depext: false
           dune-cache: true
 
-      - run: |
-            opam install atd
-            opam env >> $GITHUB_ENV
+      - run: opam install atd
 
       - name: test
         run: |
-            # set -e
-            ls -l /home/runner/work/semgrep-interfaces/semgrep-interfaces/_opam/bin
-            which atddiff
+            set -e
+            eval $(opam env)
 
             # fetch minimum version and enumerate tags for supported releases
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,9 @@ jobs:
 
       - name: test
         run: |
-            set -e
+            # set -e
+            ls -l /home/runner/work/semgrep-interfaces/semgrep-interfaces/_opam/bin
+            which atddiff
 
             # fetch minimum version and enumerate tags for supported releases
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,4 +33,4 @@ jobs:
       shell: bash
       run: |
         eval $(opam env)
-          ./scripts/check-backwards-compatability.sh
+        ./scripts/check-backwards-compatability.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,6 +6,10 @@ on:
     branches:
         - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write # for comments
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,11 +26,11 @@ jobs:
           opam-depext: false
           dune-cache: true
 
-      - run: opam install atd
+      - name: install atddiff
+        run: opam install atd
 
       - name: atddiff all supported tags
         run: |
-            set -e
             eval $(opam env)
 
             # fetch minimum version and enumerate tags for supported releases
@@ -39,6 +39,7 @@ jobs:
 
             # check tags
             checked=()
+            errors=0
             for tag in $tags; do
                 commit=$(git rev-list -n 1 "$tag")
                 if [[ "${checked[*]}" =~ $commit ]]; then
@@ -49,4 +50,13 @@ jobs:
 
                 echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
                 git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd
+
+                if [ $? -ne 0 ]; then
+                    echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
+                    errors=$((errors + 1))
+                fi
             done
+
+            if [ $errors -eq 0 ]; then
+                exit 1
+            fi

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,3 +21,9 @@ jobs:
           ocaml-compiler: 5.1
 
       - run: opam install atdgen
+
+      - name: test
+        run: |
+            minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
+            tags=$(git log --simplify-by-decoration --pretty=format:%D ${minimum}~..main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
+            echo $tags

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 jobs:
-  backwards_compatability:
+  compatability:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tree

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,6 +23,7 @@ jobs:
           ocaml-compiler: 5.1
           opam-pin: false
           opam-depext: false
+          dune-cache: true
 
       - run: opam install atdgen
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout tree
         uses: actions/checkout@v4
         with:
-            fetch-depth: 0 # get all tags
+            fetch-tags: true
 
       - name: Set-up OCaml
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,6 +24,10 @@ jobs:
 
       - name: test
         run: |
+            set -e
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
             tags=$(git log --simplify-by-decoration --pretty=format:%D ${minimum}~..main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
-            echo $tags
+            for tag in $tags; do
+                echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
+                git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd
+            done

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,15 @@ jobs:
       run: opam install atd
 
     - name: atddiff all supported tags
+      id: diff
       shell: bash
       run: |
         eval $(opam env)
-        ./scripts/check-backwards-compatability.sh
+        echo 'Backwards compatability summary:\n```' > summary.txt
+        ./scripts/check-backwards-compatability.sh | tee -a summary.txt
+        echo '```' >> summary.txt
+
+    - uses: marocchino/sticky-pull-request-comment@v2
+      with:
+        header: diff-summary
+        path: summary.txt

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
             set -e
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
-            tags=$(git log --simplify-by-decoration --pretty=format:%D ${minimum}~..main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
+            tags=$(git log --simplify-by-decoration --pretty=format:%D '${minimum}^!' 'main' | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
             for tag in $tags; do
                 echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
                 git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -39,7 +39,7 @@ jobs:
             tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
 
             # check tags
-            set +xo pipefail # take care of error handling ourselves from here
+            set +eo pipefail # take care of error handling ourselves from here
             checked=()
             errors=0
             for tag in $tags; do

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -32,7 +32,7 @@ jobs:
             set -e
             git tag -l
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
-            tags=$(git log --simplify-by-decoration --pretty=format:%D '${minimum}^!' 'main' | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
+            tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
             for tag in $tags; do
                 echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
                 git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,7 @@ jobs:
         run: opam install atd
 
       - name: atddiff all supported tags
+        shell: bash
         run: |
             eval $(opam env)
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
 permissions: read-all
 
 jobs:
-  check-backwards-compatability:
+  backwards_compatability:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout tree

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
           dune-cache: true
 
       - run: |
-            opam install atdgen
+            opam install atd
             opam env >> $GITHUB_ENV
 
       - name: test

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: test
         run: |
             set -e
+            git tag -l
             minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
             tags=$(git log --simplify-by-decoration --pretty=format:%D '${minimum}^!' 'main' | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
             for tag in $tags; do

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,7 @@ jobs:
       - name: Checkout tree
         uses: actions/checkout@v4
         with:
+            checkout-depth: 0
             fetch-tags: true
 
       - name: Set-up OCaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -35,9 +35,9 @@ jobs:
       shell: bash
       run: |
         eval $(opam env)
-        echo 'Backwards compatability summary:\n```' > summary.txt
+        echo -e 'Backwards compatability summary:\n\n```' > summary.txt
         ./scripts/check-backwards-compatability.sh | tee -a summary.txt
-        echo '```' >> summary.txt
+        echo -e '```' >> summary.txt
 
     - uses: marocchino/sticky-pull-request-comment@v2
       with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout tree
         uses: actions/checkout@v4
         with:
-            checkout-depth: 0
+            fetch-depth: 0
             fetch-tags: true
 
       - name: Set-up OCaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -38,6 +38,7 @@ jobs:
             tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
 
             # check tags
+            set +xo pipefail # take care of error handling ourselves from here
             checked=()
             errors=0
             for tag in $tags; do

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,32 +33,4 @@ jobs:
         shell: bash
         run: |
             eval $(opam env)
-
-            # fetch minimum version and enumerate tags for supported releases
-            minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
-            tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
-
-            # check tags
-            set +eo pipefail # take care of error handling ourselves from here
-            checked=()
-            errors=0
-            for tag in $tags; do
-                commit=$(git rev-list -n 1 "$tag")
-                if [[ "${checked[*]}" =~ $commit ]]; then
-                    echo "Skipping $tag because commit $commit has already been checked"
-                    continue
-                fi
-                checked+=($commit)
-
-                echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
-                git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd
-
-                if [ $? -ne 0 ]; then
-                    echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
-                    errors=$((errors + 1))
-                fi
-            done
-
-            if [ $errors -eq 0 ]; then
-                exit 1
-            fi
+            ./scripts/check-backwards-compatability.sh

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,23 @@
+name: Linting
+
+on:
+  pull_request: {}
+  push:
+    branches:
+        - main
+
+permissions: read-all
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 5.1
+
+      - run: opam install atdgen

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# fetch minimum version and enumerate tags for supported releases
+minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
+tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
+
+# check tags
+checked=()
+errors=0
+for tag in $tags; do
+    commit=$(git rev-list -n 1 "$tag")
+    if [[ "${checked[*]}" =~ $commit ]]; then
+        echo "Skipping $tag because commit $commit has already been checked"
+        continue
+    fi
+    checked+=($commit)
+
+    echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
+    git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd
+
+    if [ $? -ne 0 ]; then
+        echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
+        errors=$((errors + 1))
+    fi
+done
+
+if [ $errors -eq 0 ]; then
+    exit 1
+fi

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -16,8 +16,10 @@ for tag in $tags; do
     checked+=($commit)
 
     echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
-    git difftool -x 'atddiff --backward' -y --trust-exit-code "$tag" semgrep_output_v1.atd
+    git difftool -x 'atddiff --backward' -y "$tag" "origin/main" semgrep_output_v1.atd | sed 's|File "/.*/\(.*.atd\)"|File "\1"|g' > before.txt
+    git difftool -x 'atddiff --backward' -y "$tag" "HEAD" semgrep_output_v1.atd | sed 's|File "/.*/\(.*.atd\)"|File "\1"|g' > after.txt
 
+    diff -u before.txt after.txt
     if [ $? -ne 0 ]; then
         echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
         errors=$((errors + 1))

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -16,12 +16,14 @@ for tag in $tags; do
     checked+=($commit)
 
     echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
-    git difftool -x 'atddiff --backward' -y "$tag" "origin/main" semgrep_output_v1.atd | sed 's|File "/.*/\(.*.atd\)"|File "\1"|g' > before.txt
-    git difftool -x 'atddiff --backward' -y "$tag" "HEAD" semgrep_output_v1.atd | sed 's|File "/.*/\(.*.atd\)"|File "\1"|g' > after.txt
+    git difftool -x 'atddiff --backward' -y "$tag" "origin/main" semgrep_output_v1.atd > before.txt
+    git difftool -x 'atddiff --backward' -y "$tag" "HEAD" semgrep_output_v1.atd > after.txt
 
-    diff -u before.txt after.txt
+    expr='s|File "/.*/\(.*.atd\)", line .*$|File "\1", line <removed for diff>|g'
+    diff -u <(sed "$expr" before.txt) <(sed "$expr" after.txt)
     if [ $? -ne 0 ]; then
         echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
+        cat after.txt
         errors=$((errors + 1))
     fi
 done

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -23,7 +23,6 @@ for tag in $tags; do
     diff -u <(sed "$expr" before.txt) <(sed "$expr" after.txt)
     if [ $? -ne 0 ]; then
         echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
-        cat after.txt
         errors=$((errors + 1))
     fi
 done

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-
 # This script is used in CI to ensure that we don't introduce breaking changes to the semgrep_output_v1.atd file.
 # We need this since the backend uses the latest ATD's to validate/parse JSON from all supported client versions.
 # Adding fields as required breaks the backend when an older client doesn't send this field.
@@ -11,6 +10,8 @@
 #    - Diff against origin/main to establish a baseline
 #    - Diff against HEAD
 #    - Diff the two diffs to see if new issues were introduced
+
+set -u # no "-eo pipefail" because we do our own error handling
 
 minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
 tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -24,6 +24,6 @@ for tag in $tags; do
     fi
 done
 
-if [ $errors -eq 0 ]; then
+if [ $errors -ne 0 ]; then
     exit 1
 fi

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -1,24 +1,35 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# fetch minimum version and enumerate tags for supported releases
+# This script is used in CI to ensure that we don't introduce breaking changes to the semgrep_output_v1.atd file.
+# We need this since the backend uses the latest ATD's to validate/parse JSON from all supported client versions.
+# Adding fields as required breaks the backend when an older client doesn't send this field.
+#
+# The rough idea here is:
+#  - Fetch the minimum supported version from the semgrep.dev API
+#  - Enumerate all tags since the minimum version
+#  - For each tag we need to support:
+#    - Diff against origin/main to establish a baseline
+#    - Diff against HEAD
+#    - Diff the two diffs to see if new issues were introduced
+
 minimum="v$(curl -s https://semgrep.dev/api/check-version | jq -r '.versions.minimum')"
 tags=$(git log --simplify-by-decoration --pretty=format:%D "${minimum}^!" origin/main | grep -o 'tag: [^,)]\+' | sed 's/^tag: //' | sort -n)
 
-# check tags
 checked=()
 errors=0
 for tag in $tags; do
     commit=$(git rev-list -n 1 "$tag")
-    if [[ "${checked[*]}" =~ $commit ]]; then
+    if [[ "${checked[*]}" =~ "$commit" ]]; then
         echo "Skipping $tag because commit $commit has already been checked"
         continue
     fi
-    checked+=($commit)
+    checked+=("$commit")
 
     echo "Checking backward compatibility of semgrep_output_v1.atd against past version $tag"
     git difftool -x 'atddiff --backward' -y "$tag" "origin/main" semgrep_output_v1.atd > before.txt
     git difftool -x 'atddiff --backward' -y "$tag" "HEAD" semgrep_output_v1.atd > after.txt
 
+    # neccesary because filenames have temp paths and line numbers can change without causing issues
     expr='s|File "/.*/\(.*.atd\)", line .*$|File "\1", line <removed for diff>|g'
     diff -u <(sed "$expr" before.txt) <(sed "$expr" after.txt)
     if [ $? -ne 0 ]; then

--- a/scripts/check-backwards-compatability.sh
+++ b/scripts/check-backwards-compatability.sh
@@ -33,12 +33,12 @@ for tag in $tags; do
     # neccesary because filenames have temp paths and line numbers can change without causing issues
     expr='s|File "/.*/\(.*.atd\)", line .*$|File "\1", line <removed for diff>|g'
     diff -u <(sed "$expr" before.txt) <(sed "$expr" after.txt)
-    if [ $? -ne 0 ]; then
+    if [ "$?" -ne 0 ]; then
         echo "ERROR: semgrep_output_v1.atd is not backward compatible with $tag"
         errors=$((errors + 1))
     fi
 done
 
-if [ $errors -ne 0 ]; then
+if [ "$errors" -ne 0 ]; then
     exit 1
 fi

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -1015,7 +1015,7 @@ type scan_metadata = {
   cli_version: version;
   unique_id: uuid; (* client generated uuid for the scan *)
   requested_products: product list;
-  }
+}
 
 (* Sent by the CLI to the POST /scans endpoint when a scan is created.
  * See also server/semgrep_app/cloud_platform/scan/models/scan.py in


### PR DESCRIPTION
This adds the very first iteration of a linter that uses atd diff to check backwards compatibility against all supported CLI versions.

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
