### PR TITLE
fix python default var and add mypy linting

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -52,6 +52,9 @@ jobs:
   mypy:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout tree
+      uses: actions/checkout@v4
+
     - name: Run mypy on semgrep_output_v1.py
       run: |
         pip install mypy

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,5 +58,6 @@ jobs:
     - name: Run mypy on semgrep_output_v1.py
       run: |
         pip install mypy
+        ls -al
         rm __init__.py # because dir has a - in it
         mypy semgrep_output_v1.py

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -58,6 +58,5 @@ jobs:
     - name: Run mypy on semgrep_output_v1.py
       run: |
         pip install mypy
-        ls -al
         rm __init__.py # because dir has a - in it
         mypy semgrep_output_v1.py

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,3 +48,12 @@ jobs:
       with:
         header: diff-summary
         path: summary-*.txt
+
+  mypy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Run mypy on semgrep_output_v1.py
+      run: |
+        pip install mypy
+        rm __init__.py # because dir has a - in it
+        mypy semgrep_output_v1.py

--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -901,7 +901,7 @@ type dependency_parser_error = {
 (* content of the .semgrepconfig.yml in the repository *)
 type ci_config_from_repo = {
     (* version of the .semgrepconfig.yml format. "V1" right now (useful?) *)
-    ~version <python default="'v1'"> <ts default="'v1'">: version;
+    ~version <python default="Version('v1')"> <ts default="'v1'">: version;
     ?tags: tag list option;
 }
 (* ?? ex? *)

--- a/semgrep_output_v1.py
+++ b/semgrep_output_v1.py
@@ -2206,14 +2206,14 @@ class ProjectMetadata:
 class CiConfigFromRepo:
     """Original type: ci_config_from_repo = { ... }"""
 
-    version: Version = field(default_factory=lambda: 'v1')
+    version: Version = field(default_factory=lambda: Version('v1'))
     tags: Optional[List[Tag]] = None
 
     @classmethod
     def from_json(cls, x: Any) -> 'CiConfigFromRepo':
         if isinstance(x, dict):
             return cls(
-                version=Version.from_json(x['version']) if 'version' in x else 'v1',
+                version=Version.from_json(x['version']) if 'version' in x else Version('v1'),
                 tags=_atd_read_list(Tag.from_json)(x['tags']) if 'tags' in x else None,
             )
         else:


### PR DESCRIPTION
The default var in python land needs the class to wrap the string.
Typescript is fine because everything is a string there anyway.

Also adding mypy to the checks to catch this kind of thing.

- [X] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [X] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades

