### PR TITLE
Andre/secrets targeting

### DIFF
--- a/semgrep_output_v1.atd
+++ b/semgrep_output_v1.atd
@@ -179,7 +179,7 @@ type rule_id_and_engine_kind <python decorator="dataclass(frozen=True)"> =
 
 (* Need to maintain pairity between this and Inputs_to_core.product. *)
 type product
-  <ocaml attr="deriving show">
+  <ocaml attr="deriving show, eq">
   <python decorator="dataclass(frozen=True)"> = [
   | SAST (* a.k.a. Code *) <json name="sast">
   | SCA <json name="sca">

--- a/semgrep_output_v1_j.ml
+++ b/semgrep_output_v1_j.ml
@@ -157,7 +157,7 @@ type scanned_and_skipped = Semgrep_output_v1_t.scanned_and_skipped = {
   skipped: skipped_target list option
 }
 
-type product = Semgrep_output_v1_t.product [@@deriving show]
+type product = Semgrep_output_v1_t.product [@@deriving show, eq]
 
 type scan_metadata = Semgrep_output_v1_t.scan_metadata = {
   cli_version: version;

--- a/semgrep_output_v1_j.mli
+++ b/semgrep_output_v1_j.mli
@@ -157,7 +157,7 @@ type scanned_and_skipped = Semgrep_output_v1_t.scanned_and_skipped = {
   skipped: skipped_target list option
 }
 
-type product = Semgrep_output_v1_t.product [@@deriving show]
+type product = Semgrep_output_v1_t.product [@@deriving show, eq]
 
 type scan_metadata = Semgrep_output_v1_t.scan_metadata = {
   cli_version: version;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data generated
	  by Semgrep 1.17.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
