### PR TITLE
feat: add a new rule property for custom entropy values

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -63,20 +63,6 @@ $defs:
             description: "Custom KLD threshold value (required when mode is 'custom')"
         required:
           - kind
-        allOf:
-          - if:
-              properties:
-                mode:
-                  const: custom
-            then:
-              required: [ value ]
-          - if:
-              properties:
-                mode:
-                  enum: [ lax, strict, default ]
-            then:
-              not:
-                required: [ value ]
         additionalProperties: false
       - type: object
         properties:

--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -57,8 +57,26 @@ $defs:
               - const: lax
               - const: strict
               - const: default
+              - const: custom
+          value:
+            type: number
+            description: "Custom KLD threshold value (required when mode is 'custom')"
         required:
           - kind
+        allOf:
+          - if:
+              properties:
+                mode:
+                  const: custom
+            then:
+              required: [ value ]
+          - if:
+              properties:
+                mode:
+                  enum: [ lax, strict, default ]
+            then:
+              not:
+                required: [ value ]
         additionalProperties: false
       - type: object
         properties:


### PR DESCRIPTION
Corresponding PR: https://github.com/semgrep/semgrep-proprietary/pull/4386

- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
- [ ] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged
