### PR TITLE
fix: add `xml` as a valid lang in jsonschema

### DIFF
--- a/rule_schema_v1.yaml
+++ b/rule_schema_v1.yaml
@@ -936,6 +936,7 @@ $defs:
         - typescript
         - vue
         - yaml
+        - xml
 required:
   - rules
 properties:


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file (TODO: have a CI check)
- [x] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
- [x] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged
