### PR TITLE
chore: fix license metadata

### DIFF
--- a/semgrep-interfaces.opam
+++ b/semgrep-interfaces.opam
@@ -7,7 +7,7 @@ homepage: "n/a"
 bug-reports: "n/a"
 synopsis: "Interfaces for Semgrep"
 dev-repo: "git+https://github.com/semgrep/semgrep-interfaces.git"
-license: "LGPL-2.1-only"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 
 build: []
 install: []


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file
- [x] I made sure we're still backward compatible with old versions of the CLI.
For example, the Semgrep backend need to still be able to _consume_ data
generated by Semgrep 1.50.0.
See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
Note that the types related to the semgrep-core JSON output or the
semgrep-core RPC do not need to be backward compatible!
- [x] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged