### PR TITLE
chore: mark rules field as deprecated

### DIFF
--- a/semgrep_metrics.atd
+++ b/semgrep_metrics.atd
@@ -283,7 +283,7 @@ type mcp = {
     ?deployment_name <ocaml mutable>: string option;
     ?session_id <ocaml mutable>: string option;
     ?num_skipped_rules <ocaml mutable>: int option;
-    ?rules <ocaml mutable>: string list option;
+    ?rules <ocaml mutable>: string list option; (* DEPRECATED *)
     ?num_scanned_files <ocaml mutable>: int option;
     ?num_findings <ocaml mutable>: int option;
     ?findings <ocaml mutable>: (string (* rule_id *) * finding) list <json repr="object"> option;


### PR DESCRIPTION
- [x] I ran `make setup && make` to update the generated code after editing a `.atd` file
- [x] I made sure we're still backward compatible with old versions of the CLI.
For example, the Semgrep backend need to still be able to _consume_ data
generated by Semgrep 1.50.0.
See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
Note that the types related to the semgrep-core JSON output or the
semgrep-core RPC do not need to be backward compatible!
- [ ] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged