### PR TITLE
chore: bootstrap sync from Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ the interface between different Semgrep components (e.g., between
 the semgrep CLI and the playground). It also includes the schema for Semgrep rules,
 as both Semgrep and Semgrep App rely on this.
 
-This repository is meant to be used as a submodule.
+This repository is meant to be used as a submodule, however it is included in the CLI repos
+and are sync'd via a script.
 
 You may need to install opam and mypy as pre-requisites for contributing to this repository.
 


### PR DESCRIPTION
test plan: https://github.com/semgrep/semgrep-interfaces/pull/454 Seeds the 'synced from Pro' marker so scripts/sync_repos.py can find an anchor on the first run.

synced from Pro bc1a17c6ab21756554ad9c6551f846bac352ee50