### PR TITLE
add linking exn to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,6 +10,21 @@
  as the successor of the GNU Library Public License, version 2, hence
  the version number 2.1.]
 
+-------
+
+As a special exception to the GNU Library General Public License, you may link,
+statically or dynamically, a "work that uses this library" with a publicly
+distributed version of this library to produce an executable file containing
+portions of this library, and distribute that executable file under terms of
+your choice, without any of the additional requirements listed in clause 6 of
+the GNU Library General Public License. By "a publicly distributed version of
+this library", we mean either the unmodified Library as distributed by the
+authors, or a modified version of this library that is distributed under the
+conditions defined in clause 3 of the GNU Library General Public License. This
+exception does not however invalidate any other reasons why the executable file
+might be covered by the GNU Library General Public License.
+
+-------
                             Preamble
 
   The licenses for most software are designed to take away your

--- a/semgrep-interfaces.opam
+++ b/semgrep-interfaces.opam
@@ -7,7 +7,7 @@ homepage: "n/a"
 bug-reports: "n/a"
 synopsis: "Interfaces for Semgrep"
 dev-repo: "git+https://github.com/semgrep/semgrep-interfaces.git"
-license: "LGPL-2.1-only"
+license: "LGPL-2.1-only WITH OCaml-LGPL-linking-exception"
 
 build: []
 install: []


### PR DESCRIPTION
- [ ] I ran `make setup && make` to update the generated code after editing a `.atd` file
- [ ] I made sure we're still backward compatible with old versions of the CLI.
      For example, the Semgrep backend need to still be able to *consume* data
	  generated by Semgrep 1.50.0.
      See https://atd.readthedocs.io/en/latest/atdgen-tutorial.html#smooth-protocol-upgrades
	  Note that the types related to the semgrep-core JSON output or the
	  semgrep-core RPC do not need to be backward compatible!
- [ ] Any accompanying changes in `semgrep-proprietary` are approved and ready to merge once this PR is merged
